### PR TITLE
Use timezone-aware datetimes in web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ With dependencies installed, launch the interface:
 python main.py
 ```
 
+## Web API and dashboard
+
+Kartoteka now exposes a FastAPI service with JWT authentication, REST
+endpoints and a lightweight dashboard for browsing the collection in a web
+browser.  To start the server locally use uvicorn:
+
+```bash
+uvicorn server:app --reload
+```
+
+By default the API stores data in `kartoteka.db` (SQLite).  Override the
+location with the `KARTOTEKA_DATABASE_URL` environment variable if you prefer
+a different database path.  Background tasks automatically refresh card prices
+at regular intervals using the shared pricing module.
+
+The web UI is available at `http://localhost:8000/` and provides pages for
+logging in, registering new users, managing the collection and monitoring the
+portfolio value.  JavaScript widgets communicate with the REST API to perform
+CRUD operations on stored cards.
+
 ## Set validation
 
 OpenAI responses normally validate set and era names against a built-in list.

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -7,6 +7,8 @@ from tkinter import filedialog, messagebox, TclError
 
 import logging
 
+from .pricing import normalize
+
 logger = logging.getLogger(__name__)
 
 INVENTORY_CSV = os.getenv(
@@ -157,8 +159,6 @@ def find_duplicates(
     list[dict[str, str]]
         List of matching rows including warehouse codes.
     """
-
-    from .ui import normalize  # local import to avoid circular dependency
 
     matches = []
     number = _sanitize_number(str(number))

--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -1,0 +1,201 @@
+"""Utilities for card price retrieval shared between the UI and web API."""
+
+from __future__ import annotations
+
+import logging
+import os
+import unicodedata
+from typing import Callable, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Default configuration mirrors the desktop application so that both the UI and
+# web API share the same behaviour without duplicating constants.
+PRICE_MULTIPLIER = float(os.getenv("PRICE_MULTIPLIER", "1.23"))
+HOLO_REVERSE_MULTIPLIER = float(os.getenv("HOLO_REVERSE_MULTIPLIER", "3.5"))
+RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
+RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
+DEFAULT_EXCHANGE_RATE = float(os.getenv("DEFAULT_EUR_PLN", "4.265"))
+
+
+def normalize(text: str, keep_spaces: bool = False) -> str:
+    """Normalise ``text`` for API queries and lookups."""
+
+    if not text:
+        return ""
+    value = unicodedata.normalize("NFKD", text)
+    value = "".join(char for char in value if not unicodedata.combining(char))
+    value = value.lower()
+    for suffix in (" shiny", " promo"):
+        value = value.replace(suffix, "")
+    value = value.replace("-", "")
+    if not keep_spaces:
+        value = value.replace(" ", "")
+    return value.strip()
+
+
+def extract_cardmarket_price(card: dict | None) -> Optional[float]:
+    """Return the most representative price from TCG data."""
+
+    prices = (card or {}).get("prices") or {}
+    cardmarket = prices.get("cardmarket") or {}
+
+    def _float_value(key: str) -> float:
+        try:
+            return float(cardmarket.get(key, 0) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    avg_30d = _float_value("30d_average")
+    trend = _float_value("trendPrice") or _float_value("trend_price")
+    values = [value for value in (avg_30d, trend) if value > 0]
+    if len(values) == 2:
+        return sum(values) / 2
+    if len(values) == 1:
+        return values[0]
+
+    lowest = _float_value("lowest_near_mint")
+    if lowest > 0:
+        return lowest
+    return None
+
+
+def get_exchange_rate(session: Optional[requests.sessions.Session] = None) -> float:
+    """Fetch the EUR/PLN exchange rate using the public NBP API."""
+
+    http = session or requests
+    try:
+        response = http.get(
+            "https://api.nbp.pl/api/exchangerates/rates/A/EUR/?format=json",
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return float(data["rates"][0]["mid"])
+    except requests.Timeout:
+        logger.warning("Exchange rate request timed out")
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        logger.warning("Failed to fetch exchange rate: %s", exc)
+    return DEFAULT_EXCHANGE_RATE
+
+
+def fetch_card_price(
+    name: str,
+    number: str,
+    set_name: str,
+    *,
+    set_code: Optional[str] = None,
+    is_reverse: bool = False,
+    is_holo: bool = False,
+    price_multiplier: float | None = None,
+    rapidapi_key: Optional[str] = None,
+    rapidapi_host: Optional[str] = None,
+    get_rate: Optional[Callable[[], float]] = None,
+    session: Optional[requests.sessions.Session] = None,
+    timeout: float = 10.0,
+) -> Optional[float]:
+    """Return the current PLN price for a card.
+
+    The function mirrors the behaviour of :class:`kartoteka.ui.CardEditorApp`
+    while remaining independent from Tkinter specifics.  It uses the
+    TCGGO/RapidAPI endpoint and converts the result to PLN using the provided
+    exchange rate callback.
+    """
+
+    if price_multiplier is None:
+        price_multiplier = PRICE_MULTIPLIER
+    rapidapi_key = rapidapi_key if rapidapi_key is not None else RAPIDAPI_KEY
+    rapidapi_host = rapidapi_host if rapidapi_host is not None else RAPIDAPI_HOST
+    http = session or requests
+
+    name_api = normalize(name, keep_spaces=True)
+    name_input = normalize(name)
+    number_input = (number or "").strip().lower()
+    set_input = (set_name or "").strip().lower()
+    set_code = (set_code or set_name or "").strip().lower()
+
+    try:
+        headers: dict[str, str] = {}
+        if rapidapi_key and rapidapi_host:
+            url = f"https://{rapidapi_host}/cards/search"
+            params = {"search": name_api}
+            headers = {
+                "X-RapidAPI-Key": rapidapi_key,
+                "X-RapidAPI-Host": rapidapi_host,
+            }
+        else:
+            url = "https://www.tcggo.com/api/cards/"
+            params = {
+                "name": name_api,
+                "number": number_input,
+                "set": set_code,
+            }
+
+        response = http.get(url, params=params, headers=headers, timeout=timeout)
+        if response.status_code != 200:
+            logger.warning("API error: %s", response.status_code)
+            return None
+
+        cards = response.json()
+        if isinstance(cards, dict):
+            if "cards" in cards:
+                cards = cards["cards"]
+            elif "data" in cards:
+                cards = cards["data"]
+            else:
+                cards = []
+
+        candidates = []
+        for card in cards:
+            card_name = normalize(card.get("name", ""))
+            card_number = str(card.get("card_number", "")).lower()
+            episode = card.get("episode") or {}
+            card_set = str(episode.get("name", "")).lower()
+
+            name_match = name_input in card_name
+            number_match = number_input == card_number
+            set_match = not set_input or set_input in card_set or card_set.startswith(set_input)
+
+            if name_match and number_match and set_match:
+                candidates.append(card)
+
+        if candidates:
+            best = candidates[0]
+            price_eur = extract_cardmarket_price(best)
+            if price_eur is not None:
+                rate_func = get_rate or get_exchange_rate
+                eur_pln = rate_func()
+                price_pln = round(float(price_eur) * eur_pln * price_multiplier, 2)
+                logger.info(
+                    "Cena %s (%s, %s) = %s PLN",
+                    best.get("name"),
+                    number_input,
+                    set_input,
+                    price_pln,
+                )
+                return price_pln
+
+        logger.debug("Nie znaleziono dokładnej karty. Zbliżone:")
+        for card in cards:
+            episode = card.get("episode") or {}
+            card_number = str(card.get("card_number", "")).lower()
+            card_set = str(episode.get("name", "")).lower()
+            if number_input == card_number and (not set_input or set_input in card_set):
+                logger.debug(
+                    "%s | %s | %s",
+                    card.get("name"),
+                    card_number,
+                    episode.get("name"),
+                )
+
+    except requests.Timeout:
+        logger.warning("Request timed out")
+    except requests.RequestException as exc:
+        logger.warning("Fetching price from TCGGO failed: %s", exc)
+    except ValueError as exc:
+        logger.warning("Invalid JSON from TCGGO: %s", exc)
+
+    return None
+

--- a/kartoteka_web/__init__.py
+++ b/kartoteka_web/__init__.py
@@ -1,0 +1,7 @@
+"""FastAPI powered web interface for Kartoteka."""
+
+__all__ = [
+    "database",
+    "models",
+    "schemas",
+]

--- a/kartoteka_web/auth.py
+++ b/kartoteka_web/auth.py
@@ -1,0 +1,75 @@
+"""Authentication utilities for the web API."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import Session, select
+
+from .database import get_session
+from .models import User
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+SECRET_KEY = os.getenv("KARTOTEKA_SECRET_KEY", os.getenv("SECRET_KEY", "change-me"))
+ALGORITHM = os.getenv("KARTOTEKA_JWT_ALGORITHM", "HS256")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("KARTOTEKA_ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+)
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/users/login")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def authenticate_user(session: Session, username: str, password: str) -> Optional[User]:
+    user = session.exec(select(User).where(User.username == username)).first()
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Optional[dt.timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = dt.datetime.now(dt.timezone.utc) + (
+        expires_delta or dt.timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+async def get_current_user(
+    session: Session = Depends(get_session), token: str = Depends(oauth2_scheme)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        subject = payload.get("sub")
+        if subject is None:
+            raise credentials_exception
+        user_id = int(subject)
+    except (JWTError, ValueError, TypeError) as exc:
+        raise credentials_exception from exc
+
+    user = session.exec(select(User).where(User.id == user_id)).first()
+    if user is None:
+        raise credentials_exception
+    return user

--- a/kartoteka_web/database.py
+++ b/kartoteka_web/database.py
@@ -1,0 +1,43 @@
+"""Database utilities for the Kartoteka web API."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+DATABASE_URL = os.getenv("KARTOTEKA_DATABASE_URL", "sqlite:///./kartoteka.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, echo=False, connect_args=connect_args)
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    with Session(engine) as session:
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+
+
+def init_db() -> None:
+    """Initialise database tables."""
+
+    # Import models lazily to avoid circular imports during module initialisation.
+    from . import models  # noqa: F401  # pylint: disable=unused-import
+
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Iterator[Session]:
+    """FastAPI dependency returning a new SQLModel session."""
+
+    with Session(engine) as session:
+        yield session

--- a/kartoteka_web/routes/__init__.py
+++ b/kartoteka_web/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for the Kartoteka web service."""
+
+from . import users, cards  # noqa: F401
+
+__all__ = ["users", "cards"]

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -1,0 +1,210 @@
+"""Card and collection management API routes."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from .. import models, schemas
+from ..auth import get_current_user
+from ..database import get_session
+from kartoteka.pricing import HOLO_REVERSE_MULTIPLIER, fetch_card_price
+
+router = APIRouter(prefix="/cards", tags=["cards"])
+
+
+def _apply_variant_multiplier(price: float | None, entry: models.CollectionEntry) -> float | None:
+    if price is None:
+        return None
+    multiplier = 1.0
+    if entry.is_reverse or entry.is_holo:
+        multiplier *= HOLO_REVERSE_MULTIPLIER
+    try:
+        return round(float(price) * multiplier, 2)
+    except (TypeError, ValueError):
+        return price
+
+
+def _serialize_entries(entries: Iterable[models.CollectionEntry]) -> list[schemas.CollectionEntryRead]:
+    return [
+        schemas.CollectionEntryRead.model_validate(entry, from_attributes=True)
+        for entry in entries
+    ]
+
+
+@router.get("/", response_model=list[schemas.CollectionEntryRead])
+def list_collection(
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    entries = session.exec(
+        select(models.CollectionEntry)
+        .where(models.CollectionEntry.user_id == current_user.id)
+        .options(selectinload(models.CollectionEntry.card))
+    ).all()
+    return _serialize_entries(entries)
+
+
+@router.get("/summary", response_model=schemas.PortfolioSummary)
+def portfolio_summary(
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    entries = session.exec(
+        select(models.CollectionEntry)
+        .where(models.CollectionEntry.user_id == current_user.id)
+        .options(selectinload(models.CollectionEntry.card))
+    ).all()
+    total_quantity = sum(entry.quantity for entry in entries)
+    estimated_value = sum((entry.current_price or 0) * entry.quantity for entry in entries)
+    return schemas.PortfolioSummary(
+        total_cards=len(entries),
+        total_quantity=total_quantity,
+        estimated_value=round(estimated_value, 2),
+    )
+
+
+@router.post("/", response_model=schemas.CollectionEntryRead, status_code=status.HTTP_201_CREATED)
+def add_card(
+    payload: schemas.CollectionEntryCreate,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    card_data = payload.card
+    card = session.exec(
+        select(models.Card)
+        .where(
+            (models.Card.name == card_data.name)
+            & (models.Card.number == card_data.number)
+            & (models.Card.set_name == card_data.set_name)
+        )
+    ).first()
+    if not card:
+        card = models.Card(
+            name=card_data.name,
+            number=card_data.number,
+            set_name=card_data.set_name,
+            set_code=card_data.set_code,
+            rarity=card_data.rarity,
+        )
+        session.add(card)
+        session.commit()
+        session.refresh(card)
+
+    entry = models.CollectionEntry(
+        owner=current_user,
+        card=card,
+        quantity=payload.quantity,
+        purchase_price=payload.purchase_price,
+        is_reverse=payload.is_reverse,
+        is_holo=payload.is_holo,
+    )
+
+    base_price = fetch_card_price(
+        name=card.name,
+        number=card.number,
+        set_name=card.set_name,
+        set_code=card.set_code,
+    )
+    entry.current_price = _apply_variant_multiplier(base_price, entry)
+    if entry.current_price is not None:
+        entry.last_price_update = dt.datetime.now(dt.timezone.utc)
+
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    session.refresh(card)
+    return schemas.CollectionEntryRead.model_validate(entry, from_attributes=True)
+
+
+@router.patch("/{entry_id}", response_model=schemas.CollectionEntryRead)
+def update_entry(
+    entry_id: int,
+    payload: schemas.CollectionEntryUpdate,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    entry = session.exec(
+        select(models.CollectionEntry)
+        .where(
+            (models.CollectionEntry.id == entry_id)
+            & (models.CollectionEntry.user_id == current_user.id)
+        )
+        .options(selectinload(models.CollectionEntry.card))
+    ).first()
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    if payload.quantity is not None:
+        entry.quantity = payload.quantity
+    if payload.purchase_price is not None:
+        entry.purchase_price = payload.purchase_price
+    if payload.is_reverse is not None:
+        entry.is_reverse = payload.is_reverse
+    if payload.is_holo is not None:
+        entry.is_holo = payload.is_holo
+
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    return schemas.CollectionEntryRead.model_validate(entry, from_attributes=True)
+
+
+@router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_entry(
+    entry_id: int,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    entry = session.exec(
+        select(models.CollectionEntry)
+        .where(
+            (models.CollectionEntry.id == entry_id)
+            & (models.CollectionEntry.user_id == current_user.id)
+        )
+    ).first()
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    session.delete(entry)
+    session.commit()
+    return None
+
+
+@router.post("/{entry_id}/refresh", response_model=schemas.CollectionEntryRead)
+def refresh_entry_price(
+    entry_id: int,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    entry = session.exec(
+        select(models.CollectionEntry)
+        .where(
+            (models.CollectionEntry.id == entry_id)
+            & (models.CollectionEntry.user_id == current_user.id)
+        )
+        .options(selectinload(models.CollectionEntry.card))
+    ).first()
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+    card = entry.card
+    if card is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Entry has no card")
+
+    base_price = fetch_card_price(
+        name=card.name,
+        number=card.number,
+        set_name=card.set_name,
+        set_code=card.set_code,
+    )
+    entry.current_price = _apply_variant_multiplier(base_price, entry)
+    entry.last_price_update = dt.datetime.now(dt.timezone.utc)
+    session.add(entry)
+    session.commit()
+    session.refresh(entry)
+    return schemas.CollectionEntryRead.model_validate(entry, from_attributes=True)

--- a/kartoteka_web/routes/users.py
+++ b/kartoteka_web/routes/users.py
@@ -1,0 +1,48 @@
+"""User related API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from .. import models, schemas
+from ..auth import (
+    authenticate_user,
+    create_access_token,
+    get_current_user,
+    get_password_hash,
+)
+from ..database import get_session
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/register", response_model=schemas.UserRead, status_code=status.HTTP_201_CREATED)
+def register_user(user_in: schemas.UserCreate, session: Session = Depends(get_session)):
+    existing = session.exec(select(models.User).where(models.User.username == user_in.username)).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already registered")
+
+    user = models.User(
+        username=user_in.username,
+        email=user_in.email,
+        hashed_password=get_password_hash(user_in.password),
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@router.post("/login", response_model=schemas.Token)
+def login(user_in: schemas.UserLogin, session: Session = Depends(get_session)):
+    user = authenticate_user(session, user_in.username, user_in.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect username or password")
+    token = create_access_token({"sub": str(user.id)})
+    return schemas.Token(access_token=token)
+
+
+@router.get("/me", response_model=schemas.UserRead)
+async def read_current_user(current_user: models.User = Depends(get_current_user)):
+    return current_user

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -1,0 +1,75 @@
+"""Pydantic/SQLModel schemas for the web API."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Optional
+
+from sqlmodel import SQLModel
+
+
+class Token(SQLModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserBase(SQLModel):
+    username: str
+    email: Optional[str] = None
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserLogin(SQLModel):
+    username: str
+    password: str
+
+
+class UserRead(UserBase):
+    id: int
+    created_at: dt.datetime
+
+
+class CardBase(SQLModel):
+    name: str
+    number: str
+    set_name: str
+    set_code: Optional[str] = None
+    rarity: Optional[str] = None
+
+
+class CardRead(CardBase):
+    id: int
+
+
+class CollectionEntryBase(SQLModel):
+    quantity: int = 1
+    purchase_price: Optional[float] = None
+    is_reverse: bool = False
+    is_holo: bool = False
+
+
+class CollectionEntryCreate(CollectionEntryBase):
+    card: CardBase
+
+
+class CollectionEntryUpdate(SQLModel):
+    quantity: Optional[int] = None
+    purchase_price: Optional[float] = None
+    is_reverse: Optional[bool] = None
+    is_holo: Optional[bool] = None
+
+
+class CollectionEntryRead(CollectionEntryBase):
+    id: int
+    current_price: Optional[float] = None
+    last_price_update: Optional[dt.datetime] = None
+    card: CardRead
+
+
+class PortfolioSummary(SQLModel):
+    total_cards: int
+    total_quantity: int
+    estimated_value: float

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1,0 +1,260 @@
+const TOKEN_KEY = "kartoteka_token";
+
+const getToken = () => window.localStorage.getItem(TOKEN_KEY);
+const setToken = (token) => window.localStorage.setItem(TOKEN_KEY, token);
+const clearToken = () => window.localStorage.removeItem(TOKEN_KEY);
+
+async function apiFetch(path, options = {}) {
+  const headers = options.headers ? { ...options.headers } : {};
+  if (!headers["Content-Type"] && options.body) {
+    headers["Content-Type"] = "application/json";
+  }
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const response = await fetch(path, { ...options, headers });
+  if (response.status === 204) {
+    return null;
+  }
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const message = data.detail || "Wystąpił błąd.";
+    throw new Error(message);
+  }
+  return data;
+}
+
+function showAlert(element, message) {
+  if (!element) return;
+  element.textContent = message;
+  element.hidden = !message;
+}
+
+function formToJSON(form) {
+  const data = new FormData(form);
+  const result = {};
+  for (const [key, value] of data.entries()) {
+    if (value === "on") {
+      result[key] = true;
+    } else if (value === "") {
+      result[key] = undefined;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+async function handleLogin(form) {
+  const alertBox = document.getElementById("login-alert");
+  showAlert(alertBox, "");
+  try {
+    const payload = formToJSON(form);
+    const data = await apiFetch("/users/login", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    setToken(data.access_token);
+    window.location.href = "/dashboard";
+  } catch (error) {
+    showAlert(alertBox, error.message);
+  }
+}
+
+async function handleRegister(form) {
+  const alertBox = document.getElementById("register-alert");
+  showAlert(alertBox, "");
+  try {
+    const payload = formToJSON(form);
+    await apiFetch("/users/register", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    showAlert(alertBox, "Konto utworzone. Możesz się zalogować.");
+    form.reset();
+  } catch (error) {
+    showAlert(alertBox, error.message);
+  }
+}
+
+function renderCollection(entries) {
+  const body = document.getElementById("collection-table");
+  if (!body) return;
+  body.innerHTML = "";
+  for (const entry of entries) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${entry.card.name}</td>
+      <td>${entry.card.number}</td>
+      <td>${entry.card.set_name}</td>
+      <td>${entry.quantity}</td>
+      <td>${entry.current_price ?? "-"}</td>
+      <td>
+        <button class="primary" data-action="refresh" data-id="${entry.id}">Cena</button>
+        <button data-action="delete" data-id="${entry.id}">Usuń</button>
+      </td>
+    `;
+    body.appendChild(tr);
+  }
+}
+
+function updateSummary(summary) {
+  const count = document.getElementById("summary-count");
+  const quantity = document.getElementById("summary-quantity");
+  const value = document.getElementById("summary-value");
+  if (count) count.textContent = summary.total_cards;
+  if (quantity) quantity.textContent = summary.total_quantity;
+  if (value) value.textContent = summary.estimated_value.toFixed(2);
+
+  const pCount = document.getElementById("portfolio-count");
+  const pQuantity = document.getElementById("portfolio-quantity");
+  const pValue = document.getElementById("portfolio-value");
+  if (pCount) pCount.textContent = summary.total_cards;
+  if (pQuantity) pQuantity.textContent = summary.total_quantity;
+  if (pValue) pValue.textContent = summary.estimated_value.toFixed(2);
+}
+
+async function loadCollection() {
+  try {
+    const entries = await apiFetch("/cards/");
+    renderCollection(entries);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function loadSummary(targetAlert) {
+  try {
+    const summary = await apiFetch("/cards/summary");
+    updateSummary(summary);
+    showAlert(targetAlert, "");
+  } catch (error) {
+    if (targetAlert) {
+      showAlert(targetAlert, error.message);
+    }
+  }
+}
+
+async function addCard(form) {
+  const alertBox = document.getElementById("add-card-alert");
+  showAlert(alertBox, "");
+  const data = formToJSON(form);
+  const payload = {
+    quantity: Number(data.quantity) || 1,
+    purchase_price: data.purchase_price ? Number(data.purchase_price) : undefined,
+    is_reverse: Boolean(data.is_reverse),
+    is_holo: Boolean(data.is_holo),
+    card: {
+      name: data.name,
+      number: data.number,
+      set_name: data.set_name,
+      set_code: data.set_code || null,
+    },
+  };
+  try {
+    await apiFetch("/cards/", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    form.reset();
+    await Promise.all([loadCollection(), loadSummary(alertBox)]);
+  } catch (error) {
+    showAlert(alertBox, error.message);
+  }
+}
+
+async function refreshEntry(id) {
+  await apiFetch(`/cards/${id}/refresh`, { method: "POST" });
+  await Promise.all([loadCollection(), loadSummary()]);
+}
+
+async function deleteEntry(id) {
+  await apiFetch(`/cards/${id}`, { method: "DELETE" });
+  await Promise.all([loadCollection(), loadSummary()]);
+}
+
+function bindDashboard() {
+  const addForm = document.getElementById("add-card-form");
+  if (addForm) {
+    addForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      addCard(addForm);
+    });
+  }
+  const refreshBtn = document.getElementById("refresh-collection");
+  if (refreshBtn) {
+    refreshBtn.addEventListener("click", () => {
+      loadCollection();
+      loadSummary();
+    });
+  }
+  const table = document.getElementById("collection-table");
+  if (table) {
+    table.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const action = target.dataset.action;
+      const id = target.dataset.id;
+      if (!action || !id) return;
+      if (action === "refresh") {
+        refreshEntry(id);
+      } else if (action === "delete") {
+        deleteEntry(id);
+      }
+    });
+  }
+  loadCollection();
+  loadSummary();
+}
+
+function bindPortfolio() {
+  const alertBox = document.getElementById("portfolio-alert");
+  const refreshBtn = document.getElementById("refresh-portfolio");
+  if (refreshBtn) {
+    refreshBtn.addEventListener("click", () => loadSummary(alertBox));
+  }
+  loadSummary(alertBox);
+}
+
+function ensureAuthenticated() {
+  const token = getToken();
+  if (!token) {
+    const alertBox = document.querySelector(".alert");
+    if (alertBox) {
+      showAlert(alertBox, "Wymagane logowanie.");
+    }
+    return false;
+  }
+  return true;
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  const loginForm = document.getElementById("login-form");
+  if (loginForm) {
+    loginForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      handleLogin(loginForm);
+    });
+  }
+
+  const registerForm = document.getElementById("register-form");
+  if (registerForm) {
+    registerForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      handleRegister(registerForm);
+    });
+  }
+
+  if (document.getElementById("collection-table")) {
+    if (ensureAuthenticated()) {
+      bindDashboard();
+    }
+  }
+
+  if (document.getElementById("portfolio-overview")) {
+    if (ensureAuthenticated()) {
+      bindPortfolio();
+    }
+  }
+});

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1,0 +1,104 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f5f5f5;
+  color: #222;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+nav {
+  background: #212121;
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+main {
+  flex: 1;
+  padding: 2rem;
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+}
+
+form input,
+form button {
+  padding: 0.75rem;
+  font-size: 1rem;
+}
+
+.table-wrapper {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+thead {
+  background: #3f51b5;
+  color: #fff;
+}
+
+td,
+th {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+button.primary {
+  background: #3f51b5;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.alert {
+  margin: 1rem auto;
+  max-width: 480px;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  background: #ffebee;
+  color: #b71c1c;
+}

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{% block title %}Kartoteka Web{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', path='/style.css') }}" />
+  <script defer src="{{ url_for('static', path='/js/app.js') }}"></script>
+</head>
+<body data-username="{{ username | default('') }}">
+  <nav>
+    <div class="brand">Kartoteka Web</div>
+    <div class="links">
+      <a href="/">Logowanie</a>
+      <a href="/register">Rejestracja</a>
+      <a href="/dashboard">Kolekcja</a>
+      <a href="/portfolio">Portfel</a>
+    </div>
+  </nav>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/kartoteka_web/templates/dashboard.html
+++ b/kartoteka_web/templates/dashboard.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% block title %}Kolekcja - Kartoteka{% endblock %}
+{% block content %}
+<h2>Twoja kolekcja</h2>
+<section class="summary-grid" id="portfolio-summary">
+  <article class="summary-card">
+    <h3>Liczba wpisów</h3>
+    <p id="summary-count">0</p>
+  </article>
+  <article class="summary-card">
+    <h3>Liczba kart</h3>
+    <p id="summary-quantity">0</p>
+  </article>
+  <article class="summary-card">
+    <h3>Wartość [PLN]</h3>
+    <p id="summary-value">0.00</p>
+  </article>
+</section>
+
+<section class="table-wrapper">
+  <header>
+    <h3>Dodaj kartę</h3>
+  </header>
+  <form id="add-card-form">
+    <label>
+      Nazwa karty
+      <input type="text" name="name" required />
+    </label>
+    <label>
+      Numer
+      <input type="text" name="number" required />
+    </label>
+    <label>
+      Set
+      <input type="text" name="set_name" required />
+    </label>
+    <label>
+      Kod setu (opcjonalnie)
+      <input type="text" name="set_code" />
+    </label>
+    <label>
+      Ilość
+      <input type="number" name="quantity" value="1" min="1" />
+    </label>
+    <label>
+      Cena zakupu
+      <input type="number" name="purchase_price" step="0.01" />
+    </label>
+    <label>
+      Reverse?
+      <input type="checkbox" name="is_reverse" />
+    </label>
+    <label>
+      Holo?
+      <input type="checkbox" name="is_holo" />
+    </label>
+    <button type="submit" class="primary">Dodaj do kolekcji</button>
+    <div class="alert" id="add-card-alert" hidden></div>
+  </form>
+</section>
+
+<section class="table-wrapper">
+  <header>
+    <h3>Aktualna kolekcja</h3>
+    <button id="refresh-collection" class="primary" type="button">Odśwież</button>
+  </header>
+  <table>
+    <thead>
+      <tr>
+        <th>Nazwa</th>
+        <th>Numer</th>
+        <th>Set</th>
+        <th>Ilość</th>
+        <th>Wartość</th>
+        <th>Akcje</th>
+      </tr>
+    </thead>
+    <tbody id="collection-table"></tbody>
+  </table>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/login.html
+++ b/kartoteka_web/templates/login.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Logowanie - Kartoteka{% endblock %}
+{% block content %}
+<section>
+  <form id="login-form">
+    <h2>Zaloguj się</h2>
+    <div class="alert" id="login-alert" hidden></div>
+    <label>
+      Nazwa użytkownika
+      <input type="text" name="username" required />
+    </label>
+    <label>
+      Hasło
+      <input type="password" name="password" required />
+    </label>
+    <button type="submit" class="primary">Zaloguj</button>
+  </form>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/portfolio.html
+++ b/kartoteka_web/templates/portfolio.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Portfel - Kartoteka{% endblock %}
+{% block content %}
+<section class="summary-grid" id="portfolio-overview">
+  <article class="summary-card">
+    <h3>Wpisy w kolekcji</h3>
+    <p id="portfolio-count">0</p>
+  </article>
+  <article class="summary-card">
+    <h3>Łączna ilość kart</h3>
+    <p id="portfolio-quantity">0</p>
+  </article>
+  <article class="summary-card">
+    <h3>Szacowana wartość [PLN]</h3>
+    <p id="portfolio-value">0.00</p>
+  </article>
+</section>
+<div class="alert" id="portfolio-alert" hidden></div>
+<button id="refresh-portfolio" class="primary" type="button">Odśwież wartość</button>
+{% endblock %}

--- a/kartoteka_web/templates/register.html
+++ b/kartoteka_web/templates/register.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Rejestracja - Kartoteka{% endblock %}
+{% block content %}
+<section>
+  <form id="register-form">
+    <h2>Załóż konto</h2>
+    <div class="alert" id="register-alert" hidden></div>
+    <label>
+      Nazwa użytkownika
+      <input type="text" name="username" required />
+    </label>
+    <label>
+      Adres e-mail (opcjonalnie)
+      <input type="email" name="email" />
+    </label>
+    <label>
+      Hasło
+      <input type="password" name="password" required minlength="6" />
+    </label>
+    <button type="submit" class="primary">Zarejestruj</button>
+  </form>
+</section>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,11 @@ httpx==0.27.2
 pytesseract==0.3.10
 numpy>=2.0,<2.3
 opencv-python-headless==4.12.0.88
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+sqlmodel==0.0.16
+SQLAlchemy>=1.4.51
+passlib[bcrypt]==1.7.4
+python-jose[cryptography]==3.3.0
+aiofiles==23.2.1
+jinja2==3.1.4

--- a/server.py
+++ b/server.py
@@ -1,0 +1,134 @@
+"""FastAPI entry point for the Kartoteka web API and interface."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as dt
+import logging
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from kartoteka import pricing
+from kartoteka_web import models
+from kartoteka_web.auth import get_current_user
+from kartoteka_web.database import init_db, session_scope
+from kartoteka_web.routes import cards, users
+
+logger = logging.getLogger(__name__)
+
+def _apply_variant_multiplier(entry: models.CollectionEntry, base_price: Optional[float]) -> Optional[float]:
+    if base_price is None:
+        return None
+    multiplier = 1.0
+    if entry.is_reverse or entry.is_holo:
+        multiplier *= pricing.HOLO_REVERSE_MULTIPLIER
+    try:
+        return round(float(base_price) * multiplier, 2)
+    except (TypeError, ValueError):
+        return base_price
+
+
+def _refresh_prices() -> int:
+    """Synchronously refresh prices for all collection entries."""
+
+    updated = 0
+    with session_scope() as session:
+        entries = session.exec(
+            select(models.CollectionEntry).options(selectinload(models.CollectionEntry.card))
+        ).all()
+        for entry in entries:
+            card = entry.card
+            if not card:
+                continue
+            price = pricing.fetch_card_price(
+                name=card.name,
+                number=card.number,
+                set_name=card.set_name,
+                set_code=card.set_code,
+            )
+            new_price = _apply_variant_multiplier(entry, price)
+            if new_price is not None:
+                entry.current_price = new_price
+                entry.last_price_update = dt.datetime.now(dt.timezone.utc)
+                updated += 1
+        session.flush()
+    return updated
+
+
+async def _price_update_loop(interval: int = 3600) -> None:
+    while True:
+        updated = await asyncio.to_thread(_refresh_prices)
+        if updated:
+            logger.info("Background price refresh updated %s entries", updated)
+        await asyncio.sleep(interval)
+
+
+@contextlib.asynccontextmanager
+async def lifespan(app: FastAPI):
+    init_db()
+    task = asyncio.create_task(_price_update_loop())
+    app.state.price_task = task
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+app = FastAPI(title="Kartoteka Web", version="1.0.0", lifespan=lifespan)
+app.include_router(users.router)
+app.include_router(cards.router)
+
+app.mount("/static", StaticFiles(directory="kartoteka_web/static"), name="static")
+
+templates = Jinja2Templates(directory="kartoteka_web/templates")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def login_page(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.get("/register", response_class=HTMLResponse)
+async def register_page(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("register.html", {"request": request})
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard_page(
+    request: Request, current_user: models.User = Depends(get_current_user)
+) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {"request": request, "username": current_user.username},
+    )
+
+
+@app.get("/portfolio", response_class=HTMLResponse)
+async def portfolio_page(
+    request: Request, current_user: models.User = Depends(get_current_user)
+) -> HTMLResponse:
+    return templates.TemplateResponse(
+        "portfolio.html",
+        {"request": request, "username": current_user.username},
+    )
+
+
+def run() -> None:
+    """Helper to run the development server."""
+
+    import uvicorn
+
+    uvicorn.run("server:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -1,0 +1,139 @@
+import sys
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(scope="session")
+def db_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("web") / "api.db"
+
+
+@pytest.fixture
+def api_client(db_path, monkeypatch):
+    db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("KARTOTEKA_DATABASE_URL", db_url)
+
+    from kartoteka_web import database
+
+    with suppress(Exception):
+        database.engine.dispose()
+    if db_path.exists():
+        db_path.unlink()
+    connect_args = {"check_same_thread": False}
+    database.engine = create_engine(db_url, echo=False, connect_args=connect_args)
+
+    SQLModel.metadata.create_all(database.engine)
+
+    import server
+
+    prices = {"value": 12.5}
+
+    def fake_price(*_args, **_kwargs):
+        return prices["value"]
+
+    monkeypatch.setattr("kartoteka.pricing.fetch_card_price", fake_price)
+    monkeypatch.setattr("kartoteka_web.routes.cards.fetch_card_price", fake_price)
+
+    with TestClient(server.app) as client:
+        yield client, prices, server
+
+
+def register_and_login(client: TestClient, username: str = "ash", password: str = "pikachu") -> str:
+    res = client.post(
+        "/users/register",
+        json={"username": username, "password": password},
+    )
+    assert res.status_code == 201
+
+    res = client.post(
+        "/users/login",
+        json={"username": username, "password": password},
+    )
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    assert token
+    return token
+
+
+def test_collection_crud_and_summary(api_client):
+    client, prices, server = api_client
+    token = register_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    payload = {
+        "quantity": 2,
+        "purchase_price": 9.99,
+        "is_reverse": False,
+        "is_holo": False,
+        "card": {"name": "Pikachu", "number": "25", "set_name": "Base Set", "set_code": "base"},
+    }
+
+    prices["value"] = 15.0
+    res = client.post("/cards/", json=payload, headers=headers)
+    assert res.status_code == 201, res.text
+    entry = res.json()
+    assert entry["current_price"] == 15.0
+    entry_id = entry["id"]
+
+    res = client.get("/cards/", headers=headers)
+    assert res.status_code == 200
+    cards = res.json()
+    assert len(cards) == 1
+    assert cards[0]["card"]["name"] == "Pikachu"
+
+    res = client.patch(f"/cards/{entry_id}", json={"quantity": 3}, headers=headers)
+    assert res.status_code == 200
+    assert res.json()["quantity"] == 3
+
+    res = client.get("/cards/summary", headers=headers)
+    assert res.status_code == 200
+    summary = res.json()
+    assert summary["total_cards"] == 1
+    assert summary["total_quantity"] == 3
+
+    prices["value"] = 20.0
+    res = client.post(f"/cards/{entry_id}/refresh", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["current_price"] == 20.0
+
+    prices["value"] = 25.0
+    updated = server._refresh_prices()
+    assert updated >= 1
+    res = client.get("/cards/", headers=headers)
+    assert res.json()[0]["current_price"] == 25.0
+
+    res = client.delete(f"/cards/{entry_id}", headers=headers)
+    assert res.status_code == 204
+    res = client.get("/cards/", headers=headers)
+    assert res.json() == []
+
+
+def test_requires_authentication(api_client):
+    client, _, _ = api_client
+    res = client.get("/cards/")
+    assert res.status_code == 401
+
+    token = register_and_login(client, username="misty", password="starmie")
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.post(
+        "/cards/",
+        json={
+            "quantity": 1,
+            "card": {"name": "Squirtle", "number": "7", "set_name": "Base Set"},
+        },
+        headers=headers,
+    )
+    assert res.status_code == 201
+    entry_id = res.json()["id"]
+
+    res = client.delete(f"/cards/{entry_id}")
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- replace datetime.utcnow() with timezone-aware datetime.now(datetime.UTC) usages across the web API
- switch the FastAPI application to lifespan startup/shutdown management and keep price refresh scheduling intact

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d2839151b0832f972ee4e123cac31d