### PR TITLE
feat: advanced card search and price tracking

### DIFF
--- a/kartoteka_web/models.py
+++ b/kartoteka_web/models.py
@@ -36,6 +36,7 @@ class Card(SQLModel, table=True):
     rarity: Optional[str] = None
 
     entries: List["CollectionEntry"] = Relationship(back_populates="card")
+    price_history: List["PriceHistory"] = Relationship(back_populates="card")
 
 
 class CollectionEntry(SQLModel, table=True):
@@ -53,3 +54,16 @@ class CollectionEntry(SQLModel, table=True):
 
     owner: Optional["User"] = Relationship(back_populates="collections")
     card: Optional["Card"] = Relationship(back_populates="entries")
+
+
+class PriceHistory(SQLModel, table=True):
+    """Stored snapshots of card prices for chart generation."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    card_id: int = Field(foreign_key="card.id", index=True)
+    price: float = Field(ge=0)
+    recorded_at: dt.datetime = Field(
+        default_factory=lambda: dt.datetime.now(dt.timezone.utc)
+    )
+
+    card: Optional["Card"] = Relationship(back_populates="price_history")

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -44,6 +44,18 @@ class CardRead(CardBase):
     id: int
 
 
+class CardSearchResult(SQLModel):
+    name: str
+    number: str
+    number_display: Optional[str] = None
+    total: Optional[str] = None
+    set_name: str
+    set_code: Optional[str] = None
+    rarity: Optional[str] = None
+    image_small: Optional[str] = None
+    image_large: Optional[str] = None
+
+
 class CollectionEntryBase(SQLModel):
     quantity: int = 1
     purchase_price: Optional[float] = None

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -465,6 +465,100 @@ button.danger:hover {
   font-weight: 500;
 }
 
+.form-grid .with-suggestions {
+  position: relative;
+}
+
+.card-suggestions {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  padding: 8px 0;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 20;
+}
+
+.card-suggestion {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 18px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.card-suggestion:hover,
+.card-suggestion:focus-visible {
+  background: rgba(51, 51, 102, 0.08);
+  outline: none;
+}
+
+.card-suggestion:active {
+  transform: scale(0.995);
+}
+
+.card-suggestion-thumbnail,
+.card-suggestion-placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  object-fit: cover;
+  box-shadow: 0 10px 20px -16px rgba(17, 22, 63, 0.6);
+  background: rgba(51, 51, 102, 0.08);
+}
+
+.card-suggestion-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+}
+
+.card-suggestion-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card-suggestion-info strong {
+  font-size: 0.95rem;
+  color: var(--color-primary);
+}
+
+.card-suggestion-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.card-suggestion-rarity {
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(51, 51, 102, 0.12);
+  color: var(--color-primary);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 input,
 select,
 textarea {

--- a/kartoteka_web/templates/dashboard.html
+++ b/kartoteka_web/templates/dashboard.html
@@ -73,21 +73,22 @@
     </div>
   </div>
   <form id="add-card-form" class="form-grid">
-    <label>
+    <label class="with-suggestions">
       Nazwa karty
-      <input type="text" name="name" required />
+      <input type="text" name="name" id="add-card-name" autocomplete="off" required />
+      <div id="card-suggestions" class="card-suggestions" hidden></div>
     </label>
     <label>
       Numer
-      <input type="text" name="number" required />
+      <input type="text" name="number" id="add-card-number" autocomplete="off" required />
     </label>
     <label>
       Set
-      <input type="text" name="set_name" required />
+      <input type="text" name="set_name" id="add-card-set" autocomplete="off" required />
     </label>
     <label>
       Kod setu (opcjonalnie)
-      <input type="text" name="set_code" />
+      <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
     </label>
     <label>
       Ilość
@@ -105,6 +106,7 @@
       <input type="checkbox" name="is_holo" />
       Holo
     </label>
+    <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">
       <button type="submit" class="primary">Dodaj do kolekcji</button>
       <div class="alert" id="add-card-alert" hidden></div>


### PR DESCRIPTION
## Summary
- add TCGGO-backed search utilities and price normalization helpers
- persist price history snapshots and expose an authenticated card search API
- update dashboard form with live suggestions, nightly price refresh, and API tests

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d38c407e68832f9a9564ea22ad56c9