### PR TITLE
Add card detail experience and search improvements

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Iterable
+from pathlib import Path
+from typing import Any, Iterable
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import selectinload
@@ -12,9 +13,111 @@ from sqlmodel import Session, select
 from .. import models, schemas
 from ..auth import get_current_user
 from ..database import get_session
+from ..utils import sets as set_utils
 from kartoteka import pricing
 
 router = APIRouter(prefix="/cards", tags=["cards"])
+
+SET_LOGO_DIR = Path("set_logos")
+
+
+def _resolve_set_icon(set_code: str | None, set_name: str | None) -> str | None:
+    code = set_utils.clean_code(set_code)
+    if not code and set_name:
+        code = set_utils.guess_set_code(set_name)
+    if not code:
+        return None
+    candidate = SET_LOGO_DIR / f"{code}.png"
+    if candidate.exists():
+        return f"/set-logos/{candidate.name}"
+    return None
+
+
+def _enrich_card_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    data = dict(payload)
+    info = set_utils.get_set_info(
+        set_code=data.get("set_code"),
+        set_name=data.get("set_name"),
+    )
+    if info:
+        if info.get("era") and not data.get("series"):
+            data["series"] = info.get("era")
+        if info.get("total") and not data.get("total"):
+            data["total"] = str(info.get("total"))
+        if info.get("code") and not data.get("set_code"):
+            data["set_code"] = info.get("code")
+    local_icon = _resolve_set_icon(data.get("set_code"), data.get("set_name"))
+    if not data.get("set_icon") and local_icon:
+        data["set_icon"] = local_icon
+    return data
+
+
+def _select_best_result(
+    results: list[dict[str, Any]],
+    *,
+    set_code: str | None = None,
+    set_name: str | None = None,
+) -> dict[str, Any] | None:
+    code_clean = set_utils.clean_code(set_code)
+    if code_clean:
+        for item in results:
+            if set_utils.clean_code(item.get("set_code")) == code_clean:
+                return item
+    name_norm = pricing.normalize(set_name or "") if set_name else ""
+    if name_norm:
+        for item in results:
+            if pricing.normalize(item.get("set_name")) == name_norm:
+                return item
+    return results[0] if results else None
+
+
+def _find_card_record(
+    session: Session,
+    *,
+    name: str,
+    number: str,
+    set_name: str | None = None,
+    set_code: str | None = None,
+) -> models.Card | None:
+    name_value = name.strip()
+    number_value = number.strip()
+    set_name_value = (set_name or "").strip()
+    set_code_value = (set_code or "").strip()
+
+    stmt = select(models.Card).where(
+        (models.Card.name == name_value) & (models.Card.number == number_value)
+    )
+    if set_name_value:
+        stmt = stmt.where(models.Card.set_name == set_name_value)
+    card = session.exec(stmt).first()
+    if card:
+        return card
+
+    if set_code_value:
+        card = session.exec(
+            select(models.Card).where(
+                (models.Card.number == number_value)
+                & (models.Card.set_code == set_code_value)
+            )
+        ).first()
+        if card:
+            return card
+
+    return session.exec(
+        select(models.Card).where(
+            (models.Card.name == name_value) & (models.Card.number == number_value)
+        )
+    ).first()
+
+
+def _load_price_history(session: Session, card: models.Card | None) -> list[models.PriceHistory]:
+    if not card or card.id is None:
+        return []
+    return session.exec(
+        select(models.PriceHistory)
+        .where(models.PriceHistory.card_id == card.id)
+        .order_by(models.PriceHistory.recorded_at)
+    ).all()
 
 
 def _apply_variant_multiplier(price: float | None, entry: models.CollectionEntry) -> float | None:
@@ -76,9 +179,148 @@ def search_cards_endpoint(
         set_name=set_name,
         limit=cleaned_limit,
     )
+    enriched = [_enrich_card_payload(result) for result in results]
     return [
-        schemas.CardSearchResult.model_validate(result) for result in results
+        schemas.CardSearchResult.model_validate(result) for result in enriched
     ]
+
+
+@router.get("/info", response_model=schemas.CardDetailResponse)
+def card_info(
+    name: str,
+    number: str,
+    total: str | None = None,
+    set_code: str | None = None,
+    set_name: str | None = None,
+    related_limit: int = 6,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    del current_user
+    search_results = pricing.search_cards(
+        name=name,
+        number=number,
+        total=total,
+        set_name=set_name,
+        limit=20,
+    )
+    if not search_results:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Nie znaleziono karty.")
+
+    selected = _select_best_result(
+        search_results,
+        set_code=set_code,
+        set_name=set_name,
+    )
+    if not selected:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Nie znaleziono karty.")
+
+    detail_data = _enrich_card_payload(selected)
+    if total and not detail_data.get("total"):
+        total_value = pricing.sanitize_number(str(total))
+        if total_value:
+            detail_data["total"] = total_value
+    if not detail_data.get("name"):
+        detail_data["name"] = name
+
+    number_value = detail_data.get("number") or pricing.sanitize_number(str(number))
+    detail_data["number"] = number_value
+    if not detail_data.get("number_display"):
+        detail_data["number_display"] = number
+
+    resolved_set_name = detail_data.get("set_name") or set_name or ""
+    resolved_set_code = detail_data.get("set_code") or set_code or ""
+
+    card = _find_card_record(
+        session,
+        name=detail_data.get("name") or name,
+        number=number_value,
+        set_name=resolved_set_name,
+        set_code=set_utils.clean_code(resolved_set_code) or resolved_set_code,
+    )
+
+    history_rows = _load_price_history(session, card)
+    history = [
+        schemas.PricePoint(price=row.price, recorded_at=row.recorded_at)
+        for row in history_rows
+    ]
+
+    price_value: float | None = history_rows[-1].price if history_rows else None
+    last_update = history_rows[-1].recorded_at if history_rows else None
+
+    if card and card.id is not None:
+        entries = session.exec(
+            select(models.CollectionEntry).where(
+                models.CollectionEntry.card_id == card.id
+            )
+        ).all()
+        for entry in entries:
+            if entry.current_price is None:
+                continue
+            if entry.last_price_update and (
+                not last_update or entry.last_price_update > last_update
+            ):
+                price_value = entry.current_price
+                last_update = entry.last_price_update
+            elif price_value is None:
+                price_value = entry.current_price
+
+    if price_value is None:
+        price_value = pricing.fetch_card_price(
+            name=detail_data.get("name") or name,
+            number=number_value,
+            set_name=resolved_set_name,
+            set_code=resolved_set_code,
+        )
+
+    detail_data["price_pln"] = price_value
+    detail_data["last_price_update"] = last_update
+
+    limit_value = max(0, min(related_limit, 24))
+    related_items: list[schemas.CardSearchResult] = []
+    if limit_value:
+        lookup_code = set_utils.clean_code(resolved_set_code)
+        lookup_code = lookup_code or set_utils.clean_code(detail_data.get("set_code"))
+        lookup_code = lookup_code or set_utils.guess_set_code(resolved_set_name)
+
+        candidate_cards: list[dict[str, Any]] = []
+        if lookup_code:
+            candidate_cards = pricing.list_set_cards(lookup_code, limit=limit_value + 1)
+        elif resolved_set_name:
+            guessed = set_utils.guess_set_code(resolved_set_name)
+            if guessed:
+                candidate_cards = pricing.list_set_cards(guessed, limit=limit_value + 1)
+
+        def is_same_card(candidate: dict[str, Any]) -> bool:
+            same_number = (candidate.get("number") or "") == number_value
+            if not same_number:
+                return False
+            candidate_code = set_utils.clean_code(candidate.get("set_code"))
+            detail_code = set_utils.clean_code(detail_data.get("set_code"))
+            if candidate_code and detail_code:
+                return candidate_code == detail_code
+            candidate_name = pricing.normalize(candidate.get("set_name"))
+            detail_name = pricing.normalize(detail_data.get("set_name"))
+            if candidate_name and detail_name:
+                return candidate_name == detail_name
+            return False
+
+        for item in candidate_cards:
+            if is_same_card(item):
+                continue
+            enriched = _enrich_card_payload(item)
+            related_items.append(
+                schemas.CardSearchResult.model_validate(enriched)
+            )
+            if len(related_items) >= limit_value:
+                break
+
+    detail = schemas.CardDetail.model_validate(detail_data)
+    return schemas.CardDetailResponse(
+        card=detail,
+        history=history,
+        related=related_items,
+    )
 
 
 @router.get("/", response_model=list[schemas.CollectionEntryRead])

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Optional
+from typing import List, Optional
 
 from sqlmodel import SQLModel
 
@@ -54,6 +54,39 @@ class CardSearchResult(SQLModel):
     rarity: Optional[str] = None
     image_small: Optional[str] = None
     image_large: Optional[str] = None
+    set_icon: Optional[str] = None
+    artist: Optional[str] = None
+    series: Optional[str] = None
+    release_date: Optional[str] = None
+
+
+class PricePoint(SQLModel):
+    price: float
+    recorded_at: dt.datetime
+
+
+class CardDetail(SQLModel):
+    name: str
+    number: str
+    number_display: Optional[str] = None
+    total: Optional[str] = None
+    set_name: str
+    set_code: Optional[str] = None
+    set_icon: Optional[str] = None
+    image_small: Optional[str] = None
+    image_large: Optional[str] = None
+    rarity: Optional[str] = None
+    artist: Optional[str] = None
+    series: Optional[str] = None
+    release_date: Optional[str] = None
+    price_pln: Optional[float] = None
+    last_price_update: Optional[dt.datetime] = None
+
+
+class CardDetailResponse(SQLModel):
+    card: CardDetail
+    history: List[PricePoint] = []
+    related: List[CardSearchResult] = []
 
 
 class CollectionEntryBase(SQLModel):

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -487,29 +487,58 @@ button.danger:hover {
   z-index: 20;
 }
 
+
 .card-suggestion {
-  display: grid;
-  grid-template-columns: auto 1fr;
+  display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 16px;
   padding: 10px 18px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-  color: inherit;
+  border-radius: 18px;
   transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .card-suggestion:hover,
-.card-suggestion:focus-visible {
+.card-suggestion:focus-within {
   background: rgba(51, 51, 102, 0.08);
+}
+
+.card-suggestion-link {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 14px;
+  flex: 1;
+  color: inherit;
+  text-decoration: none;
+}
+
+.card-suggestion-link:focus-visible {
+  outline: 3px solid rgba(51, 51, 102, 0.35);
+  outline-offset: 4px;
+  border-radius: 16px;
+}
+
+.card-suggestion-add {
+  border: none;
+  border-radius: 999px;
+  background: rgba(51, 51, 102, 0.12);
+  color: var(--color-primary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.card-suggestion-add:hover,
+.card-suggestion-add:focus-visible {
+  background: var(--color-primary);
+  color: #fff;
   outline: none;
 }
 
-.card-suggestion:active {
-  transform: scale(0.995);
+.card-suggestion-add:active {
+  transform: scale(0.96);
 }
 
 .card-suggestion-thumbnail,
@@ -546,6 +575,23 @@ button.danger:hover {
   gap: 8px;
   font-size: 0.78rem;
   color: var(--color-text-muted);
+}
+
+.card-suggestion-set {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.card-suggestion-set-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: #fff;
+  border: 1px solid rgba(51, 51, 102, 0.12);
+  object-fit: contain;
+  padding: 2px;
+  box-shadow: 0 8px 16px -12px rgba(17, 22, 63, 0.5);
 }
 
 .card-suggestion-rarity {
@@ -677,6 +723,17 @@ tbody tr:hover {
   flex-wrap: wrap;
 }
 
+.table-responsive a.table-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.table-responsive a.table-link:hover,
+.table-responsive a.table-link:focus-visible {
+  text-decoration: underline;
+}
+
 .table-empty {
   text-align: center;
   padding: 32px 16px;
@@ -786,6 +843,256 @@ tbody tr:hover {
   color: var(--color-text-muted);
 }
 
+.card-detail-hero,
+.card-detail-chart-panel,
+.card-detail-related {
+  padding: clamp(24px, 4vw, 36px);
+}
+
+.card-detail-main {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: clamp(24px, 5vw, 48px);
+  align-items: center;
+}
+
+.card-detail-media {
+  display: flex;
+  justify-content: center;
+}
+
+.card-detail-image {
+  position: relative;
+  width: min(100%, 320px);
+  aspect-ratio: 3 / 4;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(51, 51, 102, 0.14), rgba(255, 204, 0, 0.18));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.card-detail-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 20px;
+  box-shadow: 0 28px 40px -32px rgba(17, 22, 63, 0.65);
+}
+
+.card-detail-placeholder {
+  font-size: clamp(3rem, 8vw, 4.5rem);
+  color: rgba(51, 51, 102, 0.3);
+}
+
+.card-detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-detail-era {
+  align-self: flex-start;
+  background: rgba(51, 51, 102, 0.12);
+  color: var(--color-primary);
+  padding: 4px 14px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.card-detail-set {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+}
+
+#card-detail-set-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(51, 51, 102, 0.12);
+  background: #fff;
+  object-fit: contain;
+  padding: 4px;
+  box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.65);
+}
+
+.card-detail-artist {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+.card-detail-meta {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 16px 0 12px;
+}
+
+.card-detail-meta div {
+  background: rgba(51, 51, 102, 0.05);
+  border-radius: 16px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card-detail-meta dt {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.card-detail-meta dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.card-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.card-detail-chart-panel .panel-header {
+  align-items: center;
+}
+
+.chart-range {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.chart-range .secondary {
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+}
+
+.chart-range .secondary.active {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.6);
+}
+
+.card-chart-wrapper {
+  margin-top: 24px;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 24px;
+  border: 1px solid rgba(51, 51, 102, 0.08);
+  padding: clamp(18px, 4vw, 28px);
+  box-shadow: var(--shadow-soft);
+}
+
+.chart-empty {
+  text-align: center;
+  margin: 16px 0 0;
+  color: var(--color-text-muted);
+}
+
+.related-grid {
+  display: grid;
+  gap: 18px;
+  margin-top: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.related-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.related-card:hover,
+.related-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 48px -32px rgba(17, 22, 63, 0.45);
+}
+
+.related-card a {
+  display: flex;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+  height: 100%;
+}
+
+.related-card-image {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+}
+
+.related-card-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.4rem;
+  color: rgba(51, 51, 102, 0.28);
+  background: rgba(51, 51, 102, 0.08);
+}
+
+.related-card-body {
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.related-card-set {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+}
+
+.related-card-set img {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid rgba(51, 51, 102, 0.12);
+  object-fit: contain;
+  padding: 3px;
+}
+
+.related-card-title {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.related-card-meta {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.related-empty {
+  margin-top: 12px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
 @media (max-width: 920px) {
   .app-header {
     grid-template-columns: auto auto;
@@ -799,6 +1106,23 @@ tbody tr:hover {
 
   .header-actions {
     justify-content: flex-start;
+  }
+
+  .card-detail-main {
+    grid-template-columns: 1fr;
+  }
+
+  .card-detail-info {
+    align-items: center;
+    text-align: center;
+  }
+
+  .card-detail-set {
+    justify-content: center;
+  }
+
+  .card-detail-meta {
+    justify-items: center;
   }
 }
 
@@ -861,6 +1185,16 @@ tbody tr:hover {
   .page-hero {
     padding: 28px 24px;
   }
+
+  .card-detail-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chart-range {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 520px) {
@@ -922,5 +1256,9 @@ tbody tr:hover {
 
   .table-empty::before {
     display: none;
+  }
+
+  .card-chart-wrapper {
+    padding: 18px 16px;
   }
 }

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -12,6 +12,7 @@
   <link rel="manifest" href="{{ url_for('static', path='/manifest.json') }}" />
   <link rel="stylesheet" href="{{ url_for('static', path='/style.css') }}" />
   <script defer src="{{ url_for('static', path='/js/app.js') }}"></script>
+  {% block head_extra %}{% endblock %}
 </head>
 <body data-username="{{ username | default('') }}">
   {% set current_path = request.url.path %}

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block title %}{{ card_name or 'Szczegóły karty' }} - Kartoteka{% endblock %}
+{% block head_extra %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" integrity="sha384-eDqHtkobaN6D+PfYZ7RUTpujISiFDUFxIr05oig3NbS1Ry6j3TDIrS9KuX3sI5OG" crossorigin="anonymous" defer></script>
+{% endblock %}
+{% block content %}
+<section
+  class="panel card-detail-hero"
+  id="card-detail-page"
+  data-name="{{ card_name | default('') }}"
+  data-number="{{ card_number | default('') }}"
+  data-set-code="{{ card_set_code | default('') }}"
+  data-set-name="{{ card_set_name | default('') }}"
+  data-total="{{ card_total | default('') }}"
+>
+  <div class="card-detail-main">
+    <div class="card-detail-media">
+      <div class="card-detail-image" id="card-image-container">
+        <img id="card-detail-image" alt="Podgląd karty" loading="lazy" hidden />
+        <div class="card-detail-placeholder" id="card-detail-placeholder">🃏</div>
+      </div>
+    </div>
+    <div class="card-detail-info">
+      <p class="card-detail-era" id="card-detail-era" hidden></p>
+      <h1 id="card-detail-title">Szczegóły karty</h1>
+      <div class="card-detail-set">
+        <img id="card-detail-set-icon" alt="Logo dodatku" hidden />
+        <span id="card-detail-set-name"></span>
+      </div>
+      <p class="card-detail-artist" id="card-detail-artist"></p>
+      <dl class="card-detail-meta">
+        <div>
+          <dt>Numer</dt>
+          <dd id="card-detail-number"></dd>
+        </div>
+        <div>
+          <dt>Rzadkość</dt>
+          <dd id="card-detail-rarity"></dd>
+        </div>
+        <div>
+          <dt>Cena [PLN]</dt>
+          <dd id="card-detail-price"></dd>
+        </div>
+        <div>
+          <dt>Ostatnia aktualizacja</dt>
+          <dd id="card-detail-updated"></dd>
+        </div>
+      </dl>
+      <div class="card-detail-actions">
+        <a href="/dashboard" class="button primary" id="detail-add-button">Dodaj do kolekcji</a>
+        <a href="https://kartoteka.shop" class="button secondary" id="detail-buy-button" target="_blank" rel="noopener">Kup na kartoteka.shop</a>
+      </div>
+      <div class="alert" id="card-detail-alert" hidden></div>
+    </div>
+  </div>
+</section>
+
+<section class="panel card-detail-chart-panel">
+  <div class="panel-header">
+    <div>
+      <h2>Historia cen</h2>
+      <p>Śledź, jak zmieniała się wartość tej karty w czasie.</p>
+    </div>
+    <div class="chart-range" role="group" aria-label="Zakres czasowy">
+      <button type="button" class="secondary" data-range="1d">1 dzień</button>
+      <button type="button" class="secondary" data-range="1w">1 tydzień</button>
+      <button type="button" class="secondary active" data-range="1m">1 miesiąc</button>
+    </div>
+  </div>
+  <div class="card-chart-wrapper">
+    <canvas id="card-price-chart" height="220"></canvas>
+    <p class="chart-empty" id="card-chart-empty" hidden>Brak danych historycznych. Dodaj kartę do kolekcji, aby zapełnić wykres.</p>
+  </div>
+</section>
+
+<section class="panel card-detail-related">
+  <div class="panel-header">
+    <div>
+      <h2>Inne karty z tego setu</h2>
+      <p>Poznaj dodatkowe karty z wybranego dodatku.</p>
+    </div>
+  </div>
+  <div class="related-grid" id="related-cards-list"></div>
+  <p class="related-empty" id="related-empty" hidden>Nie znaleziono innych kart z tego dodatku.</p>
+</section>
+{% endblock %}

--- a/kartoteka_web/utils/__init__.py
+++ b/kartoteka_web/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the Kartoteka web application."""
+
+from . import sets
+
+__all__ = ["sets"]

--- a/kartoteka_web/utils/sets.py
+++ b/kartoteka_web/utils/sets.py
@@ -1,0 +1,101 @@
+"""Set metadata helpers for the web UI."""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from kartoteka import pricing
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+SET_FILES = ("tcg_sets.json", "tcg_sets_jp.json")
+
+
+def clean_code(code: Optional[str]) -> Optional[str]:
+    """Return a filesystem-friendly version of ``code``."""
+
+    if not code:
+        return None
+    cleaned = re.sub(r"[^a-z0-9-]", "", str(code).lower())
+    return cleaned or None
+
+
+def normalise_name(name: Optional[str]) -> Optional[str]:
+    """Return a normalised key for ``name`` using the pricing helper."""
+
+    if not name:
+        return None
+    value = pricing.normalize(name, keep_spaces=False)
+    return value or None
+
+
+@lru_cache(maxsize=1)
+def _load_indices() -> tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    """Return lookup tables indexed by set code and set name."""
+
+    by_code: Dict[str, Dict[str, Any]] = {}
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for filename in SET_FILES:
+        path = BASE_DIR / filename
+        if not path.exists():
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (json.JSONDecodeError, OSError):  # pragma: no cover - defensive
+            continue
+        for era, sets in (payload or {}).items():
+            for item in sets or []:
+                entry = {
+                    "code": item.get("code"),
+                    "name": item.get("name"),
+                    "abbr": item.get("abbr"),
+                    "total": item.get("total"),
+                    "era": era,
+                }
+                code_key = clean_code(entry.get("code"))
+                name_key = normalise_name(entry.get("name"))
+                if code_key:
+                    by_code[code_key] = entry
+                if name_key and name_key not in by_name:
+                    by_name[name_key] = entry
+    return by_code, by_name
+
+
+def get_set_info(*, set_code: Optional[str] = None, set_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Return metadata for the given set or ``None`` when unknown."""
+
+    index_code, index_name = _load_indices()
+    code_key = clean_code(set_code)
+    if code_key and code_key in index_code:
+        return index_code[code_key]
+    name_key = normalise_name(set_name)
+    if name_key and name_key in index_name:
+        return index_name[name_key]
+    return None
+
+
+def guess_set_code(set_name: Optional[str]) -> Optional[str]:
+    """Return the known code for ``set_name`` when possible."""
+
+    info = get_set_info(set_name=set_name)
+    if not info:
+        return None
+    code = clean_code(info.get("code"))
+    return code
+
+
+def slugify_set_identifier(*, set_code: Optional[str] = None, set_name: Optional[str] = None) -> str:
+    """Return a URL-friendly identifier for routing card detail pages."""
+
+    code = clean_code(set_code)
+    if code:
+        return code
+    name = pricing.normalize(set_name or "", keep_spaces=True)
+    if not name:
+        return "unknown"
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "unknown"


### PR DESCRIPTION
## Summary
- enrich card search payloads with set metadata and add helpers for resolving icons
- expose a card detail API and FastAPI page with pricing history and related cards
- update the dashboard UI with new suggestion styling, detail page rendering, and supporting assets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d393621828832fbf44e8a644aa47c5