### PR TITLE
Add card search workflow before adding to collection

### DIFF
--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -375,7 +375,7 @@ def fetch_card_price(
 
 def search_cards(
     name: str,
-    number: str,
+    number: str | None = None,
     *,
     set_name: Optional[str] = None,
     total: Optional[str] = None,
@@ -391,18 +391,21 @@ def search_cards(
     form without persisting any information yet.
     """
 
-    if not name or not number:
+    if not name:
         return []
 
     http = session or requests
     rapidapi_key = rapidapi_key if rapidapi_key is not None else RAPIDAPI_KEY
     rapidapi_host = rapidapi_host if rapidapi_host is not None else RAPIDAPI_HOST
 
-    number_part, number_total = _split_number_total(str(number))
+    number_part = ""
+    number_total = ""
+    if number:
+        number_part, number_total = _split_number_total(str(number))
     if total:
         _, forced_total = _split_number_total(str(total))
         number_total = forced_total or number_total
-    number_clean = sanitize_number(number_part)
+    number_clean = sanitize_number(number_part) if number_part else ""
     total_clean = sanitize_number(number_total) if number_total else ""
 
     name_api = normalize(name, keep_spaces=True)
@@ -470,6 +473,8 @@ def search_cards(
             score += 1
         if number_clean and card_number_clean == number_clean:
             score += 3
+        elif not number_clean and card_number_clean:
+            score += 1
         if total_norm and card_total_clean == total_norm:
             score += 1
         if set_norm and set_norm in card_set_norm:

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -164,7 +164,7 @@ def _serialize_entries(entries: Iterable[models.CollectionEntry]) -> list[schema
 @router.get("/search", response_model=list[schemas.CardSearchResult])
 def search_cards_endpoint(
     name: str,
-    number: str,
+    number: str | None = None,
     total: str | None = None,
     set_name: str | None = None,
     limit: int = 10,

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -341,6 +341,22 @@ button.danger:hover {
   gap: 24px;
 }
 
+.add-card-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.add-card-cta p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.add-card-cta .button {
+  align-self: flex-start;
+}
+
 .panel-header {
   display: flex;
   flex-wrap: wrap;
@@ -485,6 +501,13 @@ button.danger:hover {
   max-height: 320px;
   overflow-y: auto;
   z-index: 20;
+}
+
+.card-suggestions-empty {
+  margin: 0;
+  padding: 12px 18px;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
 }
 
 

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block title %}Dodaj kartę - Kartoteka{% endblock %}
+{% block content %}
+<section class="page-hero">
+  <div>
+    <p class="eyebrow">Rozszerz swoją kolekcję</p>
+    <h1>Wyszukaj kartę w bazie</h1>
+    <p>
+      Aby dodać nowy wpis do kolekcji najpierw wyszukaj kartę po nazwie, numerze lub
+      zestawie, a następnie potwierdź dodanie do zbioru.
+    </p>
+  </div>
+</section>
+
+<section class="panel" id="add-card-page">
+  <div class="panel-header">
+    <div>
+      <h2>Znajdź kartę i dodaj do kolekcji</h2>
+      <p>Podaj szczegóły karty – wymagane jest co najmniej pole nazwy.</p>
+    </div>
+  </div>
+  <form id="add-card-form" class="form-grid" autocomplete="off">
+    <label class="with-suggestions">
+      Nazwa karty
+      <input type="text" name="name" id="add-card-name" autocomplete="off" required />
+      <div id="card-suggestions" class="card-suggestions" hidden></div>
+    </label>
+    <label>
+      Numer (opcjonalnie)
+      <input type="text" name="number" id="add-card-number" autocomplete="off" />
+    </label>
+    <label>
+      Set (opcjonalnie)
+      <input type="text" name="set_name" id="add-card-set" autocomplete="off" />
+    </label>
+    <label>
+      Kod setu (opcjonalnie)
+      <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
+    </label>
+    <label>
+      Ilość
+      <input type="number" name="quantity" value="1" min="1" />
+    </label>
+    <label>
+      Cena zakupu
+      <input type="number" name="purchase_price" step="0.01" />
+    </label>
+    <label class="form-checkbox">
+      <input type="checkbox" name="is_reverse" />
+      Reverse
+    </label>
+    <label class="form-checkbox">
+      <input type="checkbox" name="is_holo" />
+      Holo
+    </label>
+    <input type="hidden" name="rarity" id="add-card-rarity" />
+    <div class="form-footer">
+      <button type="button" class="secondary" id="card-search-trigger">Szukaj</button>
+      <button type="submit" class="primary" id="card-add-button" disabled>Dodaj do kolekcji</button>
+      <div class="alert" id="add-card-alert" hidden></div>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -47,7 +47,7 @@
         </div>
       </dl>
       <div class="card-detail-actions">
-        <a href="/dashboard" class="button primary" id="detail-add-button">Dodaj do kolekcji</a>
+        <a href="/cards/add" class="button primary" id="detail-add-button">Szukaj karty</a>
         <a href="https://kartoteka.shop" class="button secondary" id="detail-buy-button" target="_blank" rel="noopener">Kup na kartoteka.shop</a>
       </div>
       <div class="alert" id="card-detail-alert" hidden></div>

--- a/kartoteka_web/templates/dashboard.html
+++ b/kartoteka_web/templates/dashboard.html
@@ -7,7 +7,7 @@
     <h1>Witaj, {{ username or 'Trenerze' }}!</h1>
     <p>Z poziomu kokpitu błyskawicznie sprawdzisz stan swojej kolekcji, dodasz nowe karty i odświeżysz ich wycenę.</p>
     <div class="hero-actions">
-      <a class="button primary" href="#add-card-form">Dodaj nową kartę</a>
+      <a class="button primary" href="/cards/add">Wyszukaj kartę</a>
       <a class="button secondary" href="#collection-section">Przeglądaj kolekcję</a>
     </div>
   </div>
@@ -47,7 +47,7 @@
     </div>
   </div>
   <div class="quick-actions">
-    <a class="action-card" href="#add-card-form">
+    <a class="action-card" href="/cards/add">
       <span class="action-emoji">➕</span>
       <strong>Dodaj kartę</strong>
       <span>Rozszerz swoją kolekcję o nowy wpis.</span>
@@ -69,49 +69,16 @@
   <div class="panel-header">
     <div>
       <h2>Dodaj kartę</h2>
-      <p>Uzupełnij szczegóły karty, aby znalazła się w Twojej kolekcji.</p>
+      <p>Skorzystaj z wyszukiwarki, aby odnaleźć kartę przed dodaniem jej do kolekcji.</p>
     </div>
   </div>
-  <form id="add-card-form" class="form-grid">
-    <label class="with-suggestions">
-      Nazwa karty
-      <input type="text" name="name" id="add-card-name" autocomplete="off" required />
-      <div id="card-suggestions" class="card-suggestions" hidden></div>
-    </label>
-    <label>
-      Numer
-      <input type="text" name="number" id="add-card-number" autocomplete="off" required />
-    </label>
-    <label>
-      Set
-      <input type="text" name="set_name" id="add-card-set" autocomplete="off" required />
-    </label>
-    <label>
-      Kod setu (opcjonalnie)
-      <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
-    </label>
-    <label>
-      Ilość
-      <input type="number" name="quantity" value="1" min="1" />
-    </label>
-    <label>
-      Cena zakupu
-      <input type="number" name="purchase_price" step="0.01" />
-    </label>
-    <label class="form-checkbox">
-      <input type="checkbox" name="is_reverse" />
-      Reverse
-    </label>
-    <label class="form-checkbox">
-      <input type="checkbox" name="is_holo" />
-      Holo
-    </label>
-    <input type="hidden" name="rarity" id="add-card-rarity" />
-    <div class="form-footer">
-      <button type="submit" class="primary">Dodaj do kolekcji</button>
-      <div class="alert" id="add-card-alert" hidden></div>
-    </div>
-  </form>
+  <div class="add-card-cta">
+    <p>
+      Nowe wpisy dodasz na dedykowanej stronie wyszukiwania kart. Wprowadź nazwę, opcjonalnie
+      numer lub zestaw, wybierz odpowiednią kartę i potwierdź dodanie do kolekcji.
+    </p>
+    <a class="button primary" href="/cards/add">Szukaj kart</a>
+  </div>
 </section>
 
 <section class="panel" id="collection-section">

--- a/server.py
+++ b/server.py
@@ -156,6 +156,19 @@ async def dashboard_page(request: Request) -> HTMLResponse:
     )
 
 
+@app.get("/cards/add", response_class=HTMLResponse)
+async def add_card_page(request: Request) -> HTMLResponse:
+    username, invalid_credentials = await _resolve_request_username(request)
+    if invalid_credentials:
+        return templates.TemplateResponse(
+            "login.html", {"request": request, "username": ""}
+        )
+    return templates.TemplateResponse(
+        "add_card.html",
+        {"request": request, "username": username},
+    )
+
+
 @app.get("/portfolio", response_class=HTMLResponse)
 async def portfolio_page(request: Request) -> HTMLResponse:
     username, invalid_credentials = await _resolve_request_username(request)


### PR DESCRIPTION
## Summary
- create a dedicated add-card page with a manual search form that requires selecting a result before adding to the collection
- update dashboard and card detail buttons to direct users to the new search-first flow and tidy supporting styles
- adjust backend search endpoint and pricing helper to allow name-only searches used by the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a004ca40832f9fc41a8cd1358afb