### PR TITLE
Cache card images and render them in portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ card_prices.csv
 ceny_kart_*.xlsx
 name
 last_location.txt
+card_images/

--- a/kartoteka_web/models.py
+++ b/kartoteka_web/models.py
@@ -34,6 +34,8 @@ class Card(SQLModel, table=True):
     set_name: str = Field(index=True)
     set_code: Optional[str] = Field(default=None, index=True)
     rarity: Optional[str] = None
+    image_small: Optional[str] = Field(default=None)
+    image_large: Optional[str] = Field(default=None)
 
     entries: List["CollectionEntry"] = Relationship(back_populates="card")
     price_history: List["PriceHistory"] = Relationship(back_populates="card")

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -38,6 +38,8 @@ class CardBase(SQLModel):
     set_name: str
     set_code: Optional[str] = None
     rarity: Optional[str] = None
+    image_small: Optional[str] = None
+    image_large: Optional[str] = None
 
 
 class CardRead(CardBase):

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -746,6 +746,113 @@ tbody tr:hover {
   flex-wrap: wrap;
 }
 
+.portfolio-grid {
+  display: grid;
+  gap: 24px;
+  margin-top: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.portfolio-empty {
+  margin-top: 16px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.portfolio-card {
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.portfolio-card:hover,
+.portfolio-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 56px -32px rgba(17, 22, 63, 0.5);
+}
+
+.portfolio-card-link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.portfolio-card-media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  background: rgba(51, 51, 102, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.portfolio-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.portfolio-card-placeholder {
+  font-size: 2.8rem;
+  color: rgba(51, 51, 102, 0.28);
+}
+
+.portfolio-card-body {
+  padding: 16px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.portfolio-card-set {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.portfolio-card-set img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid rgba(51, 51, 102, 0.12);
+  object-fit: contain;
+  padding: 3px;
+}
+
+.portfolio-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.portfolio-card-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.portfolio-card-value {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-primary);
+}
+
+.portfolio-card-update {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(31, 31, 61, 0.6);
+}
+
 .table-responsive a.table-link {
   color: var(--color-primary);
   font-weight: 600;

--- a/kartoteka_web/templates/portfolio.html
+++ b/kartoteka_web/templates/portfolio.html
@@ -39,4 +39,15 @@
   </div>
   <div class="alert" id="portfolio-alert" hidden></div>
 </section>
+
+<section class="panel">
+  <div class="panel-header">
+    <div>
+      <h2>Karty w portfelu</h2>
+      <p>Przeglądaj zapisane karty wraz z ich aktualną wyceną i szczegółami.</p>
+    </div>
+  </div>
+  <div class="portfolio-grid" id="portfolio-cards"></div>
+  <p class="portfolio-empty" id="portfolio-empty" hidden>Brak kart w portfelu. Dodaj pozycje do kolekcji, aby pojawiły się w tym miejscu.</p>
+</section>
 {% endblock %}

--- a/kartoteka_web/utils/__init__.py
+++ b/kartoteka_web/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for the Kartoteka web application."""
 
-from . import sets
+from . import images, sets
 
-__all__ = ["sets"]
+__all__ = ["images", "sets"]

--- a/kartoteka_web/utils/images.py
+++ b/kartoteka_web/utils/images.py
@@ -1,0 +1,161 @@
+"""Helpers for caching card artwork locally."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+CARD_IMAGE_DIR = Path(os.getenv("CARD_IMAGE_DIR", "card_images"))
+CARD_IMAGE_URL_PREFIX = os.getenv("CARD_IMAGE_URL_PREFIX", "/card-images")
+
+_VALID_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+def ensure_directory() -> Path:
+    """Ensure the cache directory exists and return it."""
+
+    try:
+        CARD_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - logged for visibility
+        LOGGER.warning("Failed to create card image directory %s: %s", CARD_IMAGE_DIR, exc)
+    return CARD_IMAGE_DIR
+
+
+def _normalise_suffix(suffix: str) -> str:
+    suffix = suffix.lower()
+    if suffix == ".jpe":
+        return ".jpg"
+    return suffix if suffix in _VALID_SUFFIXES else ""
+
+
+def _guess_extension(url: str, content_type: str | None) -> str:
+    candidate = _normalise_suffix(Path(url.split("?", 1)[0]).suffix)
+    if candidate:
+        return candidate
+    if content_type:
+        ext = mimetypes.guess_extension(content_type.split(";", 1)[0].strip())
+        if ext:
+            candidate = _normalise_suffix(ext)
+            if candidate:
+                return candidate
+    return ".jpg"
+
+
+def _candidate_filename(url: str, variant: str) -> tuple[str, Optional[Path]]:
+    digest = hashlib.sha1(url.encode("utf-8")).hexdigest()
+    suffix = _normalise_suffix(Path(url.split("?", 1)[0]).suffix)
+    if suffix:
+        filename = f"{digest}-{variant}{suffix}"
+        return filename, CARD_IMAGE_DIR / filename
+    return f"{digest}-{variant}", None
+
+
+def _local_path(filename: str) -> str:
+    prefix = CARD_IMAGE_URL_PREFIX.rstrip("/")
+    return f"{prefix}/{filename}"
+
+
+def cache_card_image(
+    url: str,
+    *,
+    variant: str = "image",
+    session: Optional[requests.sessions.Session] = None,
+    timeout: float = 10.0,
+) -> Optional[str]:
+    """Download ``url`` into the cache directory and return a local path."""
+
+    if not url:
+        return None
+    value = url.strip()
+    if not value:
+        return None
+    if value.startswith(CARD_IMAGE_URL_PREFIX):
+        return value
+
+    ensure_directory()
+
+    filename, existing_path = _candidate_filename(value, variant)
+    if existing_path and existing_path.exists():
+        return _local_path(existing_path.name)
+
+    http = session or requests
+    try:
+        response = http.get(value, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - logged in production
+        LOGGER.warning("Failed to download card image %s: %s", value, exc)
+        return None
+
+    if response.status_code != 200 or not response.content:
+        LOGGER.warning(
+            "Failed to download card image %s (status %s)", value, response.status_code
+        )
+        return None
+
+    extension = _guess_extension(value, response.headers.get("Content-Type"))
+    filename = f"{hashlib.sha1(value.encode('utf-8')).hexdigest()}-{variant}{extension}"
+    path = CARD_IMAGE_DIR / filename
+    if not path.exists():
+        try:
+            path.write_bytes(response.content)
+        except OSError as exc:  # pragma: no cover - logged for visibility
+            LOGGER.warning("Failed to write card image %s: %s", path, exc)
+            return None
+
+    return _local_path(filename)
+
+
+def ensure_local_path(
+    value: Optional[str],
+    *,
+    variant: str = "image",
+    session: Optional[requests.sessions.Session] = None,
+    timeout: float = 10.0,
+) -> Optional[str]:
+    """Return a cached local path for ``value`` if possible."""
+
+    if not value:
+        return None
+    trimmed = value.strip()
+    if not trimmed:
+        return None
+    if trimmed.startswith(CARD_IMAGE_URL_PREFIX):
+        return trimmed
+    return cache_card_image(trimmed, variant=variant, session=session, timeout=timeout)
+
+
+def cache_card_images(
+    payload: dict[str, Any],
+    *,
+    session: Optional[requests.sessions.Session] = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Return a copy of ``payload`` with local image paths when available."""
+
+    data = dict(payload)
+    small = ensure_local_path(
+        payload.get("image_small"), variant="small", session=session, timeout=timeout
+    )
+    large = ensure_local_path(
+        payload.get("image_large"), variant="large", session=session, timeout=timeout
+    )
+
+    small_value = small or payload.get("image_small")
+    large_value = large or payload.get("image_large")
+
+    if not small_value and large_value:
+        small_value = large_value
+    if not large_value and small_value:
+        large_value = small_value
+
+    data["image_small"] = small_value
+    data["image_large"] = large_value
+    return data
+

--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ from kartoteka_web import models
 from kartoteka_web.auth import get_current_user, oauth2_scheme
 from kartoteka_web.database import init_db, session_scope
 from kartoteka_web.routes import cards, users
+from kartoteka_web.utils import images as image_utils
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,16 @@ app.include_router(cards.router)
 app.mount("/static", StaticFiles(directory="kartoteka_web/static"), name="static")
 if Path("set_logos").exists():
     app.mount("/set-logos", StaticFiles(directory="set_logos"), name="set-logos")
+
+image_utils.ensure_directory()
+card_image_mount = image_utils.CARD_IMAGE_URL_PREFIX
+if not card_image_mount.startswith("/"):
+    card_image_mount = f"/{card_image_mount}"
+app.mount(
+    card_image_mount,
+    StaticFiles(directory=str(image_utils.CARD_IMAGE_DIR)),
+    name="card-images",
+)
 
 templates = Jinja2Templates(directory="kartoteka_web/templates")
 

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -43,6 +43,8 @@ def api_client(db_path, monkeypatch):
     monkeypatch.setattr("kartoteka.pricing.fetch_card_price", fake_price)
     monkeypatch.setattr("kartoteka.pricing.search_cards", lambda *a, **k: [])
     monkeypatch.setattr("kartoteka.pricing.list_set_cards", lambda *a, **k: [])
+    monkeypatch.setattr("kartoteka_web.utils.images.cache_card_images", lambda payload, **_: payload)
+    monkeypatch.setattr("kartoteka_web.utils.images.ensure_local_path", lambda value, **_: value)
 
     with TestClient(server.app) as client:
         yield client, prices, server
@@ -188,6 +190,7 @@ def test_card_search_endpoint(api_client, monkeypatch):
     assert results[0]["set_name"] == "Base Set"
     assert results[0]["number"] == "25"
     assert "set_icon" in results[0]
+    assert results[0]["image_small"] == sample[0]["image_small"]
 
 
 def test_card_info_endpoint(api_client, monkeypatch):


### PR DESCRIPTION
## Summary
- add a caching helper for card images and expose the files under a new `/card-images` static mount
- persist cached image paths on card records and return local paths from search/detail endpoints
- extend the portfolio page to render a grid of cards with thumbnails and value information

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a6b2d3ec832fae784bed7b3b3534