### PR TITLE
Load API credentials from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ browser.  To start the server locally use uvicorn:
 uvicorn server:app --reload
 ```
 
+### RapidAPI configuration
+
+Price lookups use the same configuration as the desktop app.  Provide a
+RapidAPI host and key either via shell variables (`export RAPIDAPI_HOST=…`,
+`export RAPIDAPI_KEY=…`) or by creating a `.env` file in the project root.
+The repository ships with a `.env.example`; copy it and fill in the desired
+values:
+
+```bash
+cp .env.example .env
+```
+
+Both the Tkinter UI (`python main.py`) and the web server (`uvicorn
+server:app --reload`) load this file automatically on startup, so the
+credentials only need to be set once.
+
 By default the API stores data in `kartoteka.db` (SQLite).  Override the
 location with the `KARTOTEKA_DATABASE_URL` environment variable if you prefer
 a different database path.  Background tasks automatically refresh card prices

--- a/server.py
+++ b/server.py
@@ -9,12 +9,15 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
+
+load_dotenv(Path(__file__).resolve().with_name(".env"))
 
 from kartoteka import pricing
 from kartoteka_web import models


### PR DESCRIPTION
## Summary
- load the FastAPI entrypoint with dotenv so RapidAPI credentials from `.env` are available to the pricing module
- document how to store RapidAPI host/key in a `.env` file for both the desktop app and the API server

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ac3df9e0832fa78c69bffb9d9f8c