### PR TITLE
Normalize card search payload fields

### DIFF
--- a/tests/test_pricing_payload.py
+++ b/tests/test_pricing_payload.py
@@ -1,0 +1,22 @@
+from kartoteka import pricing
+
+
+def test_build_card_payload_normalizes_nested_text_fields():
+    raw = {
+        "name": "Pikachu",
+        "card_number": "25",
+        "total_prints": "102",
+        "episode": {
+            "name": "Base Set",
+            "series": {"id": 1, "name": "Scarlet & Violet", "slug": "scarlet-violet"},
+            "releaseDate": {"label": "1999-01-09"},
+        },
+        "artist": {"id": 414, "name": "kodama", "slug": "kodama"},
+        "images": {"small": "https://example.com/pikachu-small.png"},
+    }
+
+    payload = pricing._build_card_payload(raw)
+    assert payload is not None
+    assert payload["artist"] == "kodama"
+    assert payload["series"] == "Scarlet & Violet"
+    assert payload["release_date"] == "1999-01-09"

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -173,6 +173,8 @@ def test_card_search_endpoint(api_client, monkeypatch):
             "rarity": "Common",
             "image_small": "https://example.com/pikachu-small.png",
             "image_large": "https://example.com/pikachu-large.png",
+            "artist": "kodama",
+            "series": "Scarlet & Violet",
         }
     ]
 


### PR DESCRIPTION
## Summary
- normalize nested artist, series and release date values returned by the external card search API
- add regression coverage for the normalization helper and keep the card search API test aligned with processed payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b209a694832fb105af16b3346a19