### PR TITLE
Simplify card search results for portfolio additions

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -495,72 +495,32 @@ function setupCardSearch(form) {
       const item = document.createElement("article");
       item.className = "card-suggestion";
 
+      const cardName = card?.name?.trim() || "Nieznana karta";
+      const extraInfo = [];
+      if (card.set_name) {
+        extraInfo.push(card.set_name);
+      }
+      const cardNumber = formatCardNumber(card);
+      if (cardNumber) {
+        extraInfo.push(cardNumber);
+      }
+      const description = [cardName, ...extraInfo].join(" • ");
+
       const link = document.createElement("a");
       link.className = "card-suggestion-link";
       link.href = buildCardDetailUrl(card);
-
-      if (card.image_small) {
-        const img = document.createElement("img");
-        img.src = card.image_small;
-        img.alt = `Podgląd ${card.name}`;
-        img.loading = "lazy";
-        img.className = "card-suggestion-thumbnail";
-        link.appendChild(img);
-      } else {
-        const placeholder = document.createElement("span");
-        placeholder.className = "card-suggestion-placeholder";
-        placeholder.textContent = "🃏";
-        placeholder.setAttribute("aria-hidden", "true");
-        link.appendChild(placeholder);
-      }
-
-      const info = document.createElement("div");
-      info.className = "card-suggestion-info";
-      const title = document.createElement("strong");
-      title.textContent = card.name || "";
-      info.appendChild(title);
-
-      const meta = document.createElement("div");
-      meta.className = "card-suggestion-meta";
-      const numberText = formatCardNumber(card);
-      if (numberText) {
-        const numberSpan = document.createElement("span");
-        numberSpan.textContent = numberText;
-        meta.appendChild(numberSpan);
-      }
-      if (card.set_name) {
-        const setWrapper = document.createElement("span");
-        setWrapper.className = "card-suggestion-set";
-        if (card.set_icon) {
-          const setImg = document.createElement("img");
-          setImg.src = card.set_icon;
-          setImg.alt = `Logo ${card.set_name}`;
-          setImg.loading = "lazy";
-          setImg.className = "card-suggestion-set-icon";
-          setWrapper.appendChild(setImg);
-        }
-        const setLabel = document.createElement("span");
-        setLabel.textContent = card.set_name;
-        setWrapper.appendChild(setLabel);
-        meta.appendChild(setWrapper);
-      }
-      if (meta.childElementCount) {
-        info.appendChild(meta);
-      }
-      if (card.rarity) {
-        const raritySpan = document.createElement("span");
-        raritySpan.className = "card-suggestion-rarity";
-        raritySpan.textContent = card.rarity;
-        info.appendChild(raritySpan);
-      }
-
-      link.appendChild(info);
+      link.textContent = cardName;
+      link.setAttribute("title", description);
+      link.setAttribute("aria-label", description);
       item.appendChild(link);
 
       const addButton = document.createElement("button");
       addButton.type = "button";
       addButton.className = "card-suggestion-add";
-      addButton.textContent = "Wybierz";
+      const buttonLabel = `Dodaj kartę ${description} do portfela`;
+      addButton.setAttribute("aria-label", buttonLabel);
+      addButton.title = buttonLabel;
+      addButton.textContent = "+";
       addButton.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -572,6 +532,7 @@ function setupCardSearch(form) {
     });
     suggestionsBox.appendChild(fragment);
     suggestionsBox.hidden = false;
+    suggestionsBox.scrollTop = 0;
   };
 
   const parseNumberParts = (value) => {

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -481,26 +481,18 @@ button.danger:hover {
   font-weight: 500;
 }
 
-.form-grid .with-suggestions {
-  position: relative;
-}
-
 .card-suggestions {
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  right: 0;
-  padding: 8px 0;
+  grid-column: 1 / -1;
+  padding: 12px;
   border-radius: 18px;
   border: 1px solid var(--color-border);
   background: var(--color-surface-strong);
   box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
-  gap: 0;
-  max-height: 320px;
+  gap: 8px;
+  max-height: 360px;
   overflow-y: auto;
-  z-index: 20;
 }
 
 .card-suggestions-empty {
@@ -514,10 +506,11 @@ button.danger:hover {
 .card-suggestion {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 10px 18px;
-  border-radius: 18px;
-  transition: background 0.2s ease, transform 0.2s ease;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  transition: background 0.2s ease;
 }
 
 .card-suggestion:hover,
@@ -526,29 +519,34 @@ button.danger:hover {
 }
 
 .card-suggestion-link {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 14px;
   flex: 1;
-  color: inherit;
+  color: var(--color-primary);
+  font-weight: 600;
   text-decoration: none;
+}
+
+.card-suggestion-link:hover {
+  text-decoration: underline;
 }
 
 .card-suggestion-link:focus-visible {
   outline: 3px solid rgba(51, 51, 102, 0.35);
-  outline-offset: 4px;
-  border-radius: 16px;
+  outline-offset: 2px;
+  border-radius: 10px;
 }
 
 .card-suggestion-add {
   border: none;
-  border-radius: 999px;
+  border-radius: 50%;
   background: rgba(51, 51, 102, 0.12);
   color: var(--color-primary);
-  font-size: 0.78rem;
+  font-size: 1.1rem;
   font-weight: 600;
-  padding: 6px 14px;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
@@ -561,7 +559,7 @@ button.danger:hover {
 }
 
 .card-suggestion-add:active {
-  transform: scale(0.96);
+  transform: scale(0.95);
 }
 
 .card-suggestion-thumbnail,

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -20,10 +20,9 @@
     </div>
   </div>
   <form id="add-card-form" class="form-grid" autocomplete="off">
-    <label class="with-suggestions">
+    <label>
       Nazwa karty
       <input type="text" name="name" id="add-card-name" autocomplete="off" required />
-      <div id="card-suggestions" class="card-suggestions" hidden></div>
     </label>
     <label>
       Numer (opcjonalnie)
@@ -37,6 +36,7 @@
       Kod setu (opcjonalnie)
       <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
     </label>
+    <div id="card-suggestions" class="card-suggestions" hidden></div>
     <label>
       Ilość
       <input type="number" name="quantity" value="1" min="1" />


### PR DESCRIPTION
## Summary
- move the card search results container below the search fields so the list displays in its own area
- restyle the suggestions to render as a minimal list with a circular plus icon for adding cards
- update the search renderer to output only the card name, keep detail links, and provide accessible labels for the add action

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b6bcc7c4832fbfc85b780f96324a