### PR TITLE
Add paginated search results section

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -202,7 +202,7 @@ def search_cards_endpoint(
     current_user: models.User = Depends(get_current_user),
 ):
     del current_user  # Only used to enforce authentication via dependency.
-    cleaned_limit = max(1, min(limit, 25))
+    cleaned_limit = max(1, min(limit, 100))
     results = pricing.search_cards(
         name=name,
         number=number,

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -481,149 +481,280 @@ button.danger:hover {
   font-weight: 500;
 }
 
-.card-suggestions {
-  grid-column: 1 / -1;
-  padding: 12px;
+.card-search-results-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card-search-results-header {
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.card-search-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.card-search-sort {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.card-search-sort select {
+  min-width: 180px;
+}
+
+.card-search-summary {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.card-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-search-empty {
+  margin: 0;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(51, 51, 102, 0.06);
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.card-search-empty[data-state='loading'] {
+  color: var(--color-primary);
+}
+
+.card-search-empty[data-state='error'] {
+  color: var(--color-danger);
+  background: rgba(244, 67, 54, 0.08);
+}
+
+.card-search-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
   border-radius: 18px;
   border: 1px solid var(--color-border);
-  background: var(--color-surface-strong);
-  box-shadow: var(--shadow-card);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-height: 360px;
-  overflow-y: auto;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.card-suggestions-empty {
-  margin: 0;
-  padding: 12px 18px;
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
+.card-search-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 45px -28px rgba(17, 22, 63, 0.35);
 }
 
-
-.card-suggestion {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 14px;
-  border-radius: 14px;
-  transition: background 0.2s ease;
+.card-search-item.is-selected {
+  border-color: rgba(51, 51, 102, 0.45);
+  box-shadow: 0 0 0 3px rgba(51, 51, 102, 0.12);
 }
 
-.card-suggestion:hover,
-.card-suggestion:focus-within {
+.card-search-thumb-wrapper {
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  overflow: hidden;
   background: rgba(51, 51, 102, 0.08);
-}
-
-.card-suggestion-link {
-  flex: 1;
-  color: var(--color-primary);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.card-suggestion-link:hover {
-  text-decoration: underline;
-}
-
-.card-suggestion-link:focus-visible {
-  outline: 3px solid rgba(51, 51, 102, 0.35);
-  outline-offset: 2px;
-  border-radius: 10px;
-}
-
-.card-suggestion-add {
-  border: none;
-  border-radius: 50%;
-  background: rgba(51, 51, 102, 0.12);
-  color: var(--color-primary);
-  font-size: 1.1rem;
-  font-weight: 600;
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 12px 28px -20px rgba(17, 22, 63, 0.55);
 }
 
-.card-suggestion-add:hover,
-.card-suggestion-add:focus-visible {
-  background: var(--color-primary);
-  color: #fff;
-  outline: none;
-}
-
-.card-suggestion-add:active {
-  transform: scale(0.95);
-}
-
-.card-suggestion-thumbnail,
-.card-suggestion-placeholder {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+.card-search-thumb {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  box-shadow: 0 10px 20px -16px rgba(17, 22, 63, 0.6);
-  background: rgba(51, 51, 102, 0.08);
+  border-radius: inherit;
 }
 
-.card-suggestion-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.4rem;
-}
-
-.card-suggestion-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.card-suggestion-info strong {
-  font-size: 0.95rem;
+.card-search-thumb.placeholder {
+  font-size: 1.6rem;
   color: var(--color-primary);
 }
 
-.card-suggestion-meta {
+.card-search-info {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  font-size: 0.78rem;
-  color: var(--color-text-muted);
-}
-
-.card-suggestion-set {
-  display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 6px;
 }
 
-.card-suggestion-set-icon {
-  width: 24px;
-  height: 24px;
-  border-radius: 8px;
-  background: #fff;
-  border: 1px solid rgba(51, 51, 102, 0.12);
-  object-fit: contain;
-  padding: 2px;
-  box-shadow: 0 8px 16px -12px rgba(17, 22, 63, 0.5);
+.card-search-title {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-primary);
+  font-weight: 600;
 }
 
-.card-suggestion-rarity {
-  padding: 2px 10px;
+.card-search-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.card-search-title a:hover,
+.card-search-title a:focus-visible {
+  text-decoration: underline;
+}
+
+.card-search-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.card-search-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
   border-radius: 999px;
+  background: rgba(51, 51, 102, 0.08);
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.card-search-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.card-search-detail {
+  font-size: 0.85rem;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.card-search-detail:hover,
+.card-search-detail:focus-visible {
+  text-decoration: underline;
+}
+
+.card-search-select {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--color-primary), #2b2b55);
+  color: #fff;
+  box-shadow: 0 16px 28px -18px rgba(17, 22, 63, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.card-search-select:hover,
+.card-search-select:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px -18px rgba(17, 22, 63, 0.55);
+}
+
+.card-search-select:active {
+  transform: scale(0.96);
+}
+
+.card-search-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.card-search-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 4px;
+}
+
+.card-search-page-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
   background: rgba(51, 51, 102, 0.12);
   color: var(--color-primary);
-  font-size: 0.68rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-search-page-button:hover:not(:disabled),
+.card-search-page-button:focus-visible:not(:disabled) {
+  background: linear-gradient(135deg, var(--color-primary), #2b2b55);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px -22px rgba(17, 22, 63, 0.45);
+}
+
+.card-search-page-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.card-search-page-info {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .card-search-results-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .card-search-controls {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .card-search-sort {
+    width: 100%;
+  }
+
+  .card-search-sort select {
+    width: 100%;
+  }
+
+  .card-search-item {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .card-search-actions {
+    flex-direction: row;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .card-search-select {
+    flex: 1;
+    justify-content: center;
+    text-align: center;
+  }
 }
 
 input,

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -36,7 +36,6 @@
       Kod setu (opcjonalnie)
       <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
     </label>
-    <div id="card-suggestions" class="card-suggestions" hidden></div>
     <label>
       Ilość
       <input type="number" name="quantity" value="1" min="1" />
@@ -60,5 +59,50 @@
       <div class="alert" id="add-card-alert" hidden></div>
     </div>
   </form>
+</section>
+
+<section class="panel card-search-results-panel" id="card-search-results-section" hidden>
+  <div class="panel-header card-search-results-header">
+    <div>
+      <h2>Wyniki wyszukiwania</h2>
+      <p>Wybierz kartę z listy, aby uzupełnić formularz i dodać ją do kolekcji.</p>
+    </div>
+    <div class="card-search-controls">
+      <label class="card-search-sort">
+        Sortuj według
+        <select id="card-search-sort" name="card-search-sort">
+          <option value="relevance">Trafność</option>
+          <option value="name_asc">Nazwa A–Z</option>
+          <option value="name_desc">Nazwa Z–A</option>
+          <option value="number_asc">Numer rosnąco</option>
+          <option value="number_desc">Numer malejąco</option>
+          <option value="set_asc">Set A–Z</option>
+          <option value="set_desc">Set Z–A</option>
+        </select>
+      </label>
+    </div>
+  </div>
+  <p id="card-search-summary" class="card-search-summary" hidden aria-live="polite"></p>
+  <div id="card-search-results" class="card-search-results" role="list"></div>
+  <p id="card-search-empty" class="card-search-empty" hidden aria-live="polite"></p>
+  <div id="card-search-pagination" class="card-search-pagination" hidden>
+    <button
+      type="button"
+      class="card-search-page-button"
+      data-page-action="prev"
+      aria-label="Poprzednia strona wyników"
+    >
+      Poprzednia
+    </button>
+    <span id="card-search-page-info" class="card-search-page-info" aria-live="polite"></span>
+    <button
+      type="button"
+      class="card-search-page-button"
+      data-page-action="next"
+      aria-label="Następna strona wyników"
+    >
+      Następna
+    </button>
+  </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace inline suggestions with a dedicated search results panel on the add card page
- render results with sorting, pagination and selection support from the front-end script
- raise the card search API limit to allow paging through up to 100 items

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ba0c79bc832f8071d207d908313a