### PR TITLE
Revamp card search UI and add details screen

### DIFF
--- a/app/app/card/[id].tsx
+++ b/app/app/card/[id].tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import {
+  ScrollView,
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { commonStyles, colors } from '../../styles/commonStyles';
+import Icon from '../../components/Icon';
+import { mockCards } from '../../data/mockCards';
+
+export default function CardDetailsScreen() {
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const card = mockCards.find((entry) => entry.id.toString() === id);
+
+  return (
+    <SafeAreaView style={commonStyles.container}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: 20,
+          paddingVertical: 16,
+          backgroundColor: colors.backgroundAlt,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.grey,
+        }}
+      >
+        <TouchableOpacity onPress={() => router.back()}>
+          <Icon name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[commonStyles.subtitle, { marginLeft: 16, margin: 0 }]}>Szczegóły karty</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 60 }}>
+        {card ? (
+          <>
+            <View style={styles.heroWrapper}>
+              <Image source={{ uri: card.image }} style={styles.heroImage} resizeMode="cover" />
+            </View>
+
+            <Text style={styles.cardName}>{card.name}</Text>
+            <Text style={styles.cardMeta}>#{card.number} • {card.set}</Text>
+
+            <View style={styles.tagRow}>
+              <View style={styles.tagPill}>
+                <Text style={styles.tagText}>{card.rarity}</Text>
+              </View>
+            </View>
+
+            <View style={styles.priceCard}>
+              <Text style={styles.sectionLabel}>Szacowana wartość</Text>
+              <Text style={styles.priceValue}>${card.price}</Text>
+              <TouchableOpacity
+                style={styles.primaryAction}
+                onPress={() => console.log('Add card to collection:', card.name)}
+              >
+                <Icon name="add" size={20} color={colors.primary} />
+                <Text style={styles.primaryActionText}>Dodaj do kolekcji</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.infoCard}>
+              <Text style={styles.sectionLabel}>Informacje o karcie</Text>
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Nazwa</Text>
+                <Text style={styles.infoValue}>{card.name}</Text>
+              </View>
+              <View style={styles.divider} />
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Numer</Text>
+                <Text style={styles.infoValue}>{card.number}</Text>
+              </View>
+              <View style={styles.divider} />
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Zestaw</Text>
+                <Text style={styles.infoValue}>{card.set}</Text>
+              </View>
+              <View style={styles.divider} />
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Rzadkość</Text>
+                <Text style={styles.infoValue}>{card.rarity}</Text>
+              </View>
+            </View>
+
+            <View style={styles.descriptionCard}>
+              <Text style={styles.sectionLabel}>Opis</Text>
+              <Text style={styles.descriptionText}>
+                Szczegółowe informacje o atakach, zdolnościach oraz historii wydania karty pojawią się tutaj,
+                gdy tylko połączymy ekran z bazą danych. Na ten moment możesz podejrzeć podstawowe dane i dodać kartę do swojej
+                kolekcji.
+              </Text>
+            </View>
+          </>
+        ) : (
+          <View style={{ alignItems: 'center', marginTop: 60 }}>
+            <Text style={[commonStyles.subtitle, { textAlign: 'center' }]}>Nie znaleziono karty</Text>
+            <Text style={[commonStyles.textLight, { textAlign: 'center', marginTop: 8 }]}>
+              Spróbuj wrócić do wyszukiwarki i wybrać inną kartę.
+            </Text>
+            <TouchableOpacity style={styles.primaryAction} onPress={() => router.back()}>
+              <Icon name="arrow-back" size={20} color={colors.primary} />
+              <Text style={styles.primaryActionText}>Wróć</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  heroWrapper: {
+    borderRadius: 20,
+    overflow: 'hidden',
+    backgroundColor: colors.backgroundAlt,
+    padding: 16,
+    alignItems: 'center',
+    shadowColor: '#000000',
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 4,
+  },
+  heroImage: {
+    width: 260,
+    aspectRatio: 63 / 88,
+    borderRadius: 16,
+  },
+  cardName: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: colors.text,
+    marginTop: 24,
+  },
+  cardMeta: {
+    fontSize: 16,
+    color: colors.textLight,
+    marginTop: 8,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  tagPill: {
+    backgroundColor: colors.secondary,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  tagText: {
+    color: colors.primary,
+    fontWeight: '600',
+    fontSize: 12,
+    letterSpacing: 0.6,
+  },
+  priceCard: {
+    marginTop: 28,
+    backgroundColor: colors.backgroundAlt,
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#000000',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  sectionLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textLight,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  priceValue: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.primary,
+    marginTop: 8,
+  },
+  primaryAction: {
+    marginTop: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: colors.secondary,
+    borderRadius: 999,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+  },
+  primaryActionText: {
+    color: colors.primary,
+    fontWeight: '600',
+    fontSize: 14,
+    marginLeft: 8,
+  },
+  infoCard: {
+    marginTop: 28,
+    backgroundColor: colors.backgroundAlt,
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#000000',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  infoLabel: {
+    fontSize: 14,
+    color: colors.textLight,
+  },
+  infoValue: {
+    fontSize: 16,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.grey,
+    opacity: 0.5,
+  },
+  descriptionCard: {
+    marginTop: 28,
+    backgroundColor: colors.backgroundAlt,
+    borderRadius: 16,
+    padding: 20,
+    shadowColor: '#000000',
+    shadowOpacity: 0.05,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  descriptionText: {
+    fontSize: 14,
+    color: colors.textLight,
+    lineHeight: 22,
+    marginTop: 12,
+  },
+});

--- a/app/data/mockCards.ts
+++ b/app/data/mockCards.ts
@@ -1,0 +1,66 @@
+export interface CardSummary {
+  id: number;
+  name: string;
+  number: string;
+  set: string;
+  rarity: string;
+  price: number;
+  image: string;
+}
+
+export const mockCards: CardSummary[] = [
+  {
+    id: 1,
+    name: 'Charizard VMAX',
+    number: '074/073',
+    set: "Champion's Path",
+    price: 450,
+    rarity: 'Secret Rare',
+    image: 'https://images.unsplash.com/photo-1606107557195-0e29a4b5b4aa?w=400&h=560&fit=crop',
+  },
+  {
+    id: 2,
+    name: 'Pikachu VMAX',
+    number: '188/185',
+    set: 'Vivid Voltage',
+    price: 320,
+    rarity: 'Rainbow Rare',
+    image: 'https://images.unsplash.com/photo-1613771404721-1f92d799e49f?w=400&h=560&fit=crop',
+  },
+  {
+    id: 3,
+    name: 'Lugia VSTAR',
+    number: '202/195',
+    set: 'Silver Tempest',
+    price: 280,
+    rarity: 'Ultra Rare',
+    image: 'https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=400&h=560&fit=crop',
+  },
+  {
+    id: 4,
+    name: 'Rayquaza VMAX',
+    number: '218/203',
+    set: 'Evolving Skies',
+    price: 380,
+    rarity: 'Secret Rare',
+    image: 'https://images.unsplash.com/photo-1606107557195-0e29a4b5b4aa?w=400&h=560&fit=crop',
+  },
+  {
+    id: 5,
+    name: 'Mew VMAX',
+    number: '269/264',
+    set: 'Fusion Strike',
+    price: 220,
+    rarity: 'Ultra Rare',
+    image: 'https://images.unsplash.com/photo-1613771404721-1f92d799e49f?w=400&h=560&fit=crop',
+  },
+  {
+    id: 6,
+    name: 'Arceus VSTAR',
+    number: '123/172',
+    set: 'Brilliant Stars',
+    price: 180,
+    rarity: 'Ultra Rare',
+    image: 'https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=400&h=560&fit=crop',
+  },
+];


### PR DESCRIPTION
## Summary
- redesign the search screen results into a grid of larger card previews with filter and sort chips plus a dedicated add-to-collection control
- extract reusable mock card data with card numbers so names, numbers, and sets are clearly listed in the results
- add a card details page with a hero image, metadata, and collection action to complete the navigation flow

## Testing
- npm run lint *(warns about existing missing dependency in BottomSheet useEffect)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c8d39c9c832fa8f561fde2ce6be4