### PR TITLE
Prevent SQLModel relationship warnings when creating collection entries

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -963,9 +963,17 @@ def add_card(
         if updated:
             session.add(card)
 
+    owner_id = current_user.id
+    if owner_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    if card.id is None:
+        session.add(card)
+        session.flush()
+
     entry = models.CollectionEntry(
-        owner=current_user,
-        card=card,
+        user_id=owner_id,
+        card_id=card.id,
         quantity=payload.quantity,
         purchase_price=payload.purchase_price,
         is_reverse=payload.is_reverse,


### PR DESCRIPTION
## Summary
- avoid assigning detached relationship objects when creating collection entries by persisting user and card identifiers instead
- ensure new cards are flushed so relationship identifiers are available before inserting entries

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e59c8dc4832f84ab6bcf25a73958