### PR TITLE
Add account settings, security policies, and improve card detail view

### DIFF
--- a/kartoteka_web/models.py
+++ b/kartoteka_web/models.py
@@ -13,6 +13,7 @@ class User(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     username: str = Field(index=True, unique=True)
     email: Optional[str] = Field(default=None, index=True)
+    avatar_url: Optional[str] = Field(default=None)
     hashed_password: str
     created_at: dt.datetime = Field(
         default_factory=lambda: dt.datetime.now(dt.timezone.utc)

--- a/kartoteka_web/routes/users.py
+++ b/kartoteka_web/routes/users.py
@@ -11,6 +11,7 @@ from ..auth import (
     create_access_token,
     get_current_user,
     get_password_hash,
+    verify_password,
 )
 from ..database import get_session
 
@@ -26,6 +27,7 @@ def register_user(user_in: schemas.UserCreate, session: Session = Depends(get_se
     user = models.User(
         username=user_in.username,
         email=user_in.email,
+        avatar_url=user_in.avatar_url,
         hashed_password=get_password_hash(user_in.password),
     )
     session.add(user)
@@ -45,4 +47,48 @@ def login(user_in: schemas.UserLogin, session: Session = Depends(get_session)):
 
 @router.get("/me", response_model=schemas.UserRead)
 async def read_current_user(current_user: models.User = Depends(get_current_user)):
+    return current_user
+
+
+@router.patch("/me", response_model=schemas.UserRead)
+def update_current_user(
+    payload: schemas.UserUpdate,
+    current_user: models.User = Depends(get_current_user),
+    session: Session = Depends(get_session),
+):
+    updated = False
+
+    if payload.email is not None:
+        email_value = payload.email.strip() or None
+        if current_user.email != email_value:
+            current_user.email = email_value
+            updated = True
+
+    if payload.avatar_url is not None:
+        avatar_value = payload.avatar_url.strip() or None
+        if current_user.avatar_url != avatar_value:
+            current_user.avatar_url = avatar_value
+            updated = True
+
+    if payload.new_password:
+        if len(payload.new_password) < 8:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Hasło musi zawierać co najmniej 8 znaków.",
+            )
+        if not payload.current_password or not verify_password(
+            payload.current_password, current_user.hashed_password
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Niepoprawne bieżące hasło.",
+            )
+        current_user.hashed_password = get_password_hash(payload.new_password)
+        updated = True
+
+    if updated:
+        session.add(current_user)
+        session.commit()
+        session.refresh(current_user)
+
     return current_user

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -16,6 +16,7 @@ class Token(SQLModel):
 class UserBase(SQLModel):
     username: str
     email: Optional[str] = None
+    avatar_url: Optional[str] = None
 
 
 class UserCreate(UserBase):
@@ -30,6 +31,13 @@ class UserLogin(SQLModel):
 class UserRead(UserBase):
     id: int
     created_at: dt.datetime
+
+
+class UserUpdate(SQLModel):
+    email: Optional[str] = None
+    avatar_url: Optional[str] = None
+    current_password: Optional[str] = None
+    new_password: Optional[str] = None
 
 
 class CardBase(SQLModel):

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -255,6 +255,9 @@ img {
   height: 36px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--color-primary), rgba(var(--color-primary-rgb), 0.5));
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
   color: #fff;
   display: inline-flex;
   align-items: center;
@@ -262,6 +265,7 @@ img {
   font-weight: 700;
   letter-spacing: 0.02em;
   box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.6);
+  overflow: hidden;
 }
 
 body[data-theme="dark"] .user-avatar {
@@ -2096,3 +2100,129 @@ body[data-theme="dark"] .portfolio-card-update {
     padding: 18px 16px;
   }
 }
+
+.settings-panel {
+  gap: 32px;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.settings-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.settings-form input {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  background: var(--color-background-alt);
+  color: var(--color-text);
+}
+
+.settings-form input:focus {
+  outline: 2px solid rgba(var(--color-primary-rgb), 0.35);
+  border-color: rgba(var(--color-primary-rgb), 0.45);
+}
+
+.settings-form .alert {
+  margin-top: 4px;
+}
+
+.legal-panel {
+  gap: 24px;
+}
+
+.legal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  line-height: 1.6;
+}
+
+.legal-content h2 {
+  font-size: 1.25rem;
+  color: var(--color-primary);
+}
+
+.legal-content ul {
+  list-style: disc;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.footer-links {
+  margin-top: 12px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.footer-links a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  border-bottom-color: currentColor;
+}
+
+.home-legal {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.home-legal article {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.home-legal a {
+  align-self: flex-start;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+@media (max-width: 960px) {
+  .settings-grid,
+  .home-legal {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -14,7 +14,7 @@
   <script defer src="{{ url_for('static', path='/js/app.js') }}"></script>
   {% block head_extra %}{% endblock %}
 </head>
-<body data-username="{{ username | default('') }}">
+<body data-username="{{ username | default('') }}" data-avatar="{{ avatar_url | default('') }}">
   {% set current_path = request.url.path %}
   <header class="app-header">
     <div class="brand">
@@ -33,7 +33,8 @@
       <a href="/" class="{{ 'active' if current_path == '/' else '' }}">Strona główna</a>
       <a href="/dashboard" class="{{ 'active' if current_path.startswith('/dashboard') else '' }}">Konto</a>
       <a href="/portfolio" class="{{ 'active' if current_path.startswith('/portfolio') else '' }}">Portfel</a>
-    </nav>
+      <a href="/settings" class="{{ 'active' if current_path.startswith('/settings') else '' }}">Ustawienia</a>
+  </nav>
     <div class="header-actions">
       <button type="button" class="theme-toggle" data-theme-toggle aria-label="Przełącz motyw">
         <span aria-hidden="true">🌙</span>
@@ -49,6 +50,11 @@
   </main>
   <footer class="app-footer">
     <p>&copy; Kartoteka – zarządzaj swoją kolekcją Pokemon TCG gdziekolwiek jesteś.</p>
+    <nav class="footer-links" aria-label="Informacje prawne">
+      <a href="/terms">Regulamin</a>
+      <a href="/privacy">Polityka prywatności</a>
+      <a href="/cookies">Polityka cookies</a>
+    </nav>
   </footer>
 </body>
 </html>

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -16,22 +16,27 @@
   <div class="card-detail-main">
     <div class="card-detail-media">
       <div class="card-detail-image" id="card-image-container">
-        <img id="card-detail-image" alt="Podgląd karty" loading="lazy" hidden />
+        <img
+          id="card-detail-image"
+          alt="Podgląd karty {{ card_name or '' }}"
+          loading="lazy"
+          hidden
+        />
         <div class="card-detail-placeholder" id="card-detail-placeholder">🃏</div>
       </div>
     </div>
     <div class="card-detail-info">
       <p class="card-detail-era" id="card-detail-era" hidden></p>
-      <h1 id="card-detail-title">Szczegóły karty</h1>
+      <h1 id="card-detail-title">{{ card_name or 'Szczegóły karty' }}</h1>
       <div class="card-detail-set">
         <img id="card-detail-set-icon" alt="Logo dodatku" hidden />
-        <span id="card-detail-set-name"></span>
+        <span id="card-detail-set-name">{{ card_set_name or '' }}</span>
       </div>
       <p class="card-detail-artist" id="card-detail-artist"></p>
       <dl class="card-detail-meta">
         <div>
           <dt>Numer</dt>
-          <dd id="card-detail-number"></dd>
+          <dd id="card-detail-number">{{ card_number or '' }}</dd>
         </div>
         <div>
           <dt>Rzadkość</dt>

--- a/kartoteka_web/templates/cookies.html
+++ b/kartoteka_web/templates/cookies.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Polityka cookies - Kartoteka{% endblock %}
+{% block content %}
+<section class="panel legal-panel">
+  <div class="panel-header">
+    <div>
+      <h1>Polityka plików cookies</h1>
+      <p>Wyjaśniamy, w jaki sposób wykorzystujemy pliki cookies i podobne technologie.</p>
+    </div>
+  </div>
+  <div class="legal-content">
+    <h2>Rodzaje stosowanych cookies</h2>
+    <p>Korzystamy z plików cookies niezbędnych do działania serwisu oraz analitycznych służących do tworzenia anonimowych statystyk.</p>
+    <h2>Zarządzanie zgodą</h2>
+    <p>Użytkownik może w każdej chwili zmienić ustawienia cookies w przeglądarce lub skontaktować się z nami w celu usunięcia danych analitycznych.</p>
+    <h2>Okres przechowywania</h2>
+    <p>Cookies techniczne są przechowywane przez 12 miesięcy. Dane statystyczne są anonimizowane i nie pozwalają na identyfikację użytkownika.</p>
+    <h2>Więcej informacji</h2>
+    <p>W przypadku pytań dotyczących cookies prosimy o wiadomość na adres <a href="mailto:privacy@kartoteka.app">privacy@kartoteka.app</a>.</p>
+  </div>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/home.html
+++ b/kartoteka_web/templates/home.html
@@ -132,4 +132,30 @@
     </div>
   </div>
 </section>
+
+<section class="panel home-panel">
+  <div class="panel-header">
+    <div>
+      <h2>Transparentność i bezpieczeństwo</h2>
+      <p>Poznaj nasze zasady działania, ochronę danych osobowych oraz sposób korzystania z plików cookies.</p>
+    </div>
+  </div>
+  <div class="home-legal">
+    <article>
+      <h3>Regulamin serwisu</h3>
+      <p>Dowiedz się, jakie obowiązki mają użytkownicy i jakie wsparcie zapewnia zespół Kartoteki.</p>
+      <a href="/terms" class="button secondary">Przeczytaj regulamin</a>
+    </article>
+    <article>
+      <h3>Polityka prywatności</h3>
+      <p>Sprawdź, jakie dane gromadzimy oraz w jaki sposób możesz nimi zarządzać zgodnie z RODO.</p>
+      <a href="/privacy" class="button secondary">Polityka prywatności</a>
+    </article>
+    <article>
+      <h3>Polityka cookies</h3>
+      <p>Poznaj rodzaje wykorzystywanych plików cookies i dowiedz się, jak wycofać zgodę.</p>
+      <a href="/cookies" class="button secondary">Zarządzaj cookies</a>
+    </article>
+  </div>
+</section>
 {% endblock %}

--- a/kartoteka_web/templates/privacy.html
+++ b/kartoteka_web/templates/privacy.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Polityka prywatności - Kartoteka{% endblock %}
+{% block content %}
+<section class="panel legal-panel">
+  <div class="panel-header">
+    <div>
+      <h1>Polityka prywatności</h1>
+      <p>Dowiedz się, jakie dane przetwarzamy i w jakim celu, zgodnie z RODO.</p>
+    </div>
+  </div>
+  <div class="legal-content">
+    <h2>Administrator danych</h2>
+    <p>Administratorem danych osobowych jest Kartoteka sp. z o.o. z siedzibą w Warszawie.</p>
+    <h2>Zakres przetwarzanych danych</h2>
+    <p>Przetwarzamy dane identyfikacyjne (login), kontaktowe (e-mail) oraz dane niezbędne do świadczenia usługi (historia kart i wyceny).</p>
+    <h2>Podstawa prawna</h2>
+    <p>Dane są przetwarzane na podstawie art. 6 ust. 1 lit. b RODO, w celu realizacji umowy świadczenia usługi.</p>
+    <h2>Prawa użytkownika</h2>
+    <ul>
+      <li>dostęp do danych i możliwość ich sprostowania,</li>
+      <li>prawo do usunięcia konta i danych,</li>
+      <li>prawo do przenoszenia danych w formacie elektronicznym.</li>
+    </ul>
+    <h2>Kontakt w sprawie prywatności</h2>
+    <p>Skontaktuj się z naszym Inspektorem Ochrony Danych pod adresem <a href="mailto:iod@kartoteka.app">iod@kartoteka.app</a>.</p>
+  </div>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/settings.html
+++ b/kartoteka_web/templates/settings.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Ustawienia konta - Kartoteka{% endblock %}
+{% block content %}
+<section class="panel settings-panel" id="settings-page">
+  <div class="panel-header">
+    <div>
+      <h1>Ustawienia konta</h1>
+      <p>Zarządzaj danymi logowania, adresem e-mail i wizerunkiem profilu.</p>
+    </div>
+  </div>
+  <div class="settings-grid">
+    <article class="settings-card">
+      <h2>Dane profilu</h2>
+      <p>Aktualizuj e-mail do powiadomień oraz adres URL awatara wyświetlanego w panelu.</p>
+      <form id="settings-profile-form" class="settings-form" novalidate>
+        <label>
+          <span>E-mail</span>
+          <input type="email" name="email" autocomplete="email" placeholder="np. trener@pokemon.tcg" />
+        </label>
+        <label>
+          <span>Adres awatara</span>
+          <input type="url" name="avatar_url" autocomplete="url" placeholder="https://…" />
+        </label>
+        <div class="alert" role="status" aria-live="polite" hidden></div>
+        <button type="submit" class="button primary">Zapisz profil</button>
+      </form>
+    </article>
+    <article class="settings-card">
+      <h2>Zmień hasło</h2>
+      <p>Użyj silnego, unikalnego hasła. Minimalna długość to 8 znaków.</p>
+      <form id="settings-password-form" class="settings-form" novalidate>
+        <label>
+          <span>Obecne hasło</span>
+          <input type="password" name="current_password" autocomplete="current-password" required />
+        </label>
+        <label>
+          <span>Nowe hasło</span>
+          <input type="password" name="new_password" autocomplete="new-password" minlength="8" required />
+        </label>
+        <div class="alert" role="status" aria-live="polite" hidden></div>
+        <button type="submit" class="button secondary">Aktualizuj hasło</button>
+      </form>
+    </article>
+  </div>
+</section>
+{% endblock %}

--- a/kartoteka_web/templates/terms.html
+++ b/kartoteka_web/templates/terms.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Regulamin - Kartoteka{% endblock %}
+{% block content %}
+<section class="panel legal-panel">
+  <div class="panel-header">
+    <div>
+      <h1>Regulamin serwisu Kartoteka</h1>
+      <p>Obowiązuje od 1 marca 2025 r. i określa zasady korzystania z aplikacji.</p>
+    </div>
+  </div>
+  <div class="legal-content">
+    <h2>Postanowienia ogólne</h2>
+    <p>Kartoteka jest usługą cyfrową umożliwiającą zarządzanie prywatną kolekcją kart Pokemon TCG.</p>
+    <p>Użytkownik zobowiązuje się do korzystania z serwisu zgodnie z prawem Unii Europejskiej oraz przepisami lokalnymi.</p>
+    <h2>Rejestracja i konto</h2>
+    <p>Założenie konta wymaga podania unikalnej nazwy użytkownika oraz hasła spełniającego minimalne wymagania bezpieczeństwa.</p>
+    <p>Użytkownik ma obowiązek aktualizować swoje dane kontaktowe, w tym adres e-mail wykorzystywany do powiadomień.</p>
+    <h2>Płatności i odpowiedzialność</h2>
+    <p>Serwis nie prowadzi sprzedaży kart i nie odpowiada za wartość rynkową prezentowanych danych.</p>
+    <p>Administrator dokłada starań, aby dane cenowe były aktualne, ale nie gwarantuje pełnej dokładności.</p>
+    <h2>Kontakt</h2>
+    <p>W sprawach formalnych prosimy o kontakt pod adresem <a href="mailto:support@kartoteka.app">support@kartoteka.app</a>.</p>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add avatar support and profile update API with a web settings panel for email, avatar, and password management
- improve the card detail experience by persisting price history snapshots, formatting prices, and showing metadata immediately
- introduce legal policy pages, footer navigation, and security headers middleware to strengthen compliance and transparency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4de3dffcc832fb61bdecbca4950be