### PR TITLE
Fix card detail visuals and add collection button

### DIFF
--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -52,7 +52,7 @@
         </div>
       </dl>
       <div class="card-detail-actions">
-        <a href="/cards/add" class="button primary" id="detail-add-button">Szukaj karty</a>
+        <button type="button" class="button primary" id="detail-add-button">Dodaj do kolekcji</button>
         <a href="https://kartoteka.shop" class="button secondary" id="detail-buy-button" target="_blank" rel="noopener">Kup na kartoteka.shop</a>
       </div>
       <div class="alert" id="card-detail-alert" hidden></div>


### PR DESCRIPTION
## Summary
- ensure the card detail view reliably loads cached art with proper fallbacks
- render rarity symbols and improved PLN formatting in the metadata panel
- replace the search link with a button that adds the card directly to the collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4e4f58c18832fb299cba41e5b208b