### PR TITLE
Adjust global color palette

### DIFF
--- a/app/styles/commonStyles.ts
+++ b/app/styles/commonStyles.ts
@@ -1,18 +1,18 @@
 import { StyleSheet, ViewStyle, TextStyle } from 'react-native';
 
 export const colors = {
-  primary: '#333366',    // Dark blue
-  secondary: '#FFCC00',  // Pokemon yellow
-  accent: '#7DF9FF',     // Electric blue
-  background: '#F5F5F5', // Light gray
-  backgroundAlt: '#FFFFFF', // White
-  text: '#333366',       // Dark blue text
-  textLight: '#666666',  // Light gray text
-  grey: '#E0E0E0',       // Light grey
-  card: '#FFFFFF',       // White card background
-  success: '#4CAF50',    // Green
-  warning: '#FF9800',    // Orange
-  error: '#F44336',      // Red
+  primary: '#007bff',      // Bright blue for primary actions and links
+  secondary: '#0056b3',    // Darker blue for hover and active states
+  accent: '#63e6ff',       // Light accent blue for highlights
+  background: '#f8f9fa',   // Soft light gray page background
+  backgroundAlt: '#ffffff', // White surfaces such as cards and headers
+  text: '#333333',         // Dark gray for main text and headings
+  textLight: '#6c757d',    // Muted gray for secondary text
+  grey: '#e0e0e0',         // Neutral gray for dividers and borders
+  card: '#ffffff',         // Card backgrounds
+  success: '#4CAF50',      // Green
+  warning: '#FF9800',      // Orange
+  error: '#F44336',        // Red
 };
 
 export const buttonStyles = StyleSheet.create({

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1437,8 +1437,8 @@ function updateDetailChart(points) {
             data: values,
             fill: true,
             tension: 0.3,
-            borderColor: "#333366",
-            backgroundColor: "rgba(51, 51, 102, 0.18)",
+            borderColor: "#007bff",
+            backgroundColor: "rgba(0, 123, 255, 0.18)",
             pointRadius: 3,
             pointHoverRadius: 5,
           },
@@ -1450,12 +1450,12 @@ function updateDetailChart(points) {
         plugins: { legend: { display: false } },
         scales: {
           x: {
-            ticks: { color: "rgba(31, 31, 61, 0.6)" },
+            ticks: { color: "rgba(51, 51, 51, 0.6)" },
             grid: { display: false },
           },
           y: {
-            ticks: { color: "rgba(31, 31, 61, 0.6)" },
-            grid: { color: "rgba(51, 51, 102, 0.08)" },
+            ticks: { color: "rgba(51, 51, 51, 0.6)" },
+            grid: { color: "rgba(224, 224, 224, 0.7)" },
           },
         },
       },

--- a/kartoteka_web/static/manifest.json
+++ b/kartoteka_web/static/manifest.json
@@ -7,8 +7,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "background_color": "#f5f5f9",
-  "theme_color": "#333366",
+  "background_color": "#f8f9fa",
+  "theme_color": "#ffffff",
   "icons": [
     {
       "src": "/static/icons/icon-192.png",

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#333366" data-theme-color />
+  <meta name="theme-color" content="#ffffff" data-theme-color />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <title>{% block title %}Kartoteka Web{% endblock %}</title>


### PR DESCRIPTION
## Summary
- align shared app color tokens with the updated blue and gray palette
- refresh the web manifest and meta theme color to keep system chrome white
- retint the price history chart to match the new link and border colors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4e7eca35c832fbf0b7bf34ce06458