### PR TITLE
Adjust search UI and pagination

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -2,9 +2,9 @@
 
 :root {
   color-scheme: light;
-  --color-primary: #f06595;
-  --color-primary-dark: #d9487b;
-  --color-primary-rgb: 240, 101, 149;
+  --color-primary: #d1d5db;
+  --color-primary-dark: #9ca3af;
+  --color-primary-rgb: 209, 213, 219;
   --color-secondary: #ffd166;
   --color-accent: #ff922b;
   --color-background: #f8f9fa;
@@ -32,17 +32,17 @@
 
 body[data-theme="dark"] {
   color-scheme: dark;
-  --color-primary: #ff87b7;
-  --color-primary-dark: #ff5c99;
-  --color-primary-rgb: 255, 135, 183;
+  --color-primary: #cbd2d9;
+  --color-primary-dark: #9aa5b1;
+  --color-primary-rgb: 203, 210, 217;
   --color-secondary: #f7c948;
   --color-accent: #ff9770;
   --color-background: #090c15;
   --color-background-alt: rgba(21, 25, 39, 0.92);
   --color-surface: rgba(17, 20, 32, 0.92);
   --color-surface-strong: rgba(21, 25, 39, 0.96);
-  --color-border: rgba(255, 135, 183, 0.18);
-  --color-border-strong: rgba(255, 151, 112, 0.32);
+  --color-border: rgba(203, 210, 217, 0.24);
+  --color-border-strong: rgba(154, 165, 177, 0.42);
   --color-text: #f6f7fb;
   --color-text-muted: rgba(222, 223, 231, 0.72);
   --shadow-soft: 0 24px 48px -28px rgba(0, 0, 0, 0.82);
@@ -50,8 +50,8 @@ body[data-theme="dark"] {
   --gradient-start: #090c15;
   --gradient-mid: #111626;
   --gradient-end: #171d30;
-  --glow-primary: rgba(255, 135, 183, 0.28);
-  --glow-secondary: rgba(255, 151, 112, 0.2);
+  --glow-primary: rgba(var(--color-primary-rgb), 0.28);
+  --glow-secondary: rgba(154, 165, 177, 0.2);
 }
 
 *, *::before, *::after {
@@ -950,7 +950,6 @@ body[data-theme="dark"] .home-trends-column li {
 }
 
 .card-search-item {
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -970,42 +969,6 @@ body[data-theme="dark"] .home-trends-column li {
 .card-search-item.is-selected {
   border-color: rgba(var(--color-primary-rgb), 0.45);
   box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.12);
-}
-
-.card-search-add {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  font-size: 1.4rem;
-  cursor: pointer;
-  box-shadow: 0 16px 32px -18px rgba(17, 22, 63, 0.5);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-}
-
-.card-search-add:hover,
-.card-search-add:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 20px 40px -18px rgba(17, 22, 63, 0.55);
-}
-
-.card-search-add:active {
-  transform: scale(0.95);
-}
-
-.card-search-add:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
 }
 
 .card-search-link {
@@ -1147,11 +1110,6 @@ body[data-theme="dark"] .home-trends-column li {
 
   .card-search-item {
     padding: 16px;
-  }
-
-  .card-search-add {
-    top: 10px;
-    right: 10px;
   }
 
   .card-search-thumb-wrapper {

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -6,8 +6,8 @@
     <p class="eyebrow">Rozszerz swoją kolekcję</p>
     <h1>Wyszukaj kartę w bazie</h1>
     <p>
-      Aby dodać nowy wpis do kolekcji najpierw wyszukaj kartę po nazwie, numerze lub
-      zestawie, a następnie potwierdź dodanie do zbioru.
+      Aby wyszukać kartę w bazie podaj jej nazwę, numer lub zestaw, a następnie wybierz
+      interesujący Cię wynik z listy.
     </p>
   </div>
 </section>
@@ -15,7 +15,7 @@
 <section class="panel" id="add-card-page">
   <div class="panel-header">
     <div>
-      <h2>Znajdź kartę i dodaj do kolekcji</h2>
+      <h2>Znajdź kartę w bazie</h2>
       <p>Podaj szczegóły karty – wymagane jest co najmniej pole nazwy.</p>
     </div>
   </div>
@@ -32,30 +32,9 @@
       Set (opcjonalnie)
       <input type="text" name="set_name" id="add-card-set" autocomplete="off" />
     </label>
-    <label>
-      Kod setu (opcjonalnie)
-      <input type="text" name="set_code" id="add-card-set-code" autocomplete="off" />
-    </label>
-    <label>
-      Ilość
-      <input type="number" name="quantity" value="1" min="1" />
-    </label>
-    <label>
-      Cena zakupu
-      <input type="number" name="purchase_price" step="0.01" />
-    </label>
-    <label class="form-checkbox">
-      <input type="checkbox" name="is_reverse" />
-      Reverse
-    </label>
-    <label class="form-checkbox">
-      <input type="checkbox" name="is_holo" />
-      Holo
-    </label>
     <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">
       <button type="button" class="secondary" id="card-search-trigger">Szukaj</button>
-      <button type="submit" class="primary" id="card-add-button" disabled>Dodaj do kolekcji</button>
       <div class="alert" id="add-card-alert" hidden></div>
     </div>
   </form>
@@ -63,10 +42,10 @@
 
 <section class="panel card-search-results-panel" id="card-search-results-section" hidden>
   <div class="panel-header card-search-results-header">
-    <div>
-      <h2>Wyniki wyszukiwania</h2>
-      <p>Wybierz kartę z listy, aby uzupełnić formularz i dodać ją do kolekcji.</p>
-    </div>
+      <div>
+        <h2>Wyniki wyszukiwania</h2>
+        <p>Otwórz kartę z listy, aby zobaczyć jej szczegóły.</p>
+      </div>
     <div class="card-search-controls">
       <label class="card-search-sort">
         Sortuj według


### PR DESCRIPTION
## Summary
- switch application theme highlight color from pink to light gray for both light and dark modes
- simplify the card search form by removing collection-specific fields and the add-to-collection button
- fix card search pagination so the controls update the displayed results reliably without the inline add button

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4f934567c832f8d2f36f33173299d