### PR TITLE
Enhance card search input, fuzzy lookup, and quick add control

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1043,6 +1043,43 @@ body[data-theme="dark"] .home-trends-column li {
   filter: drop-shadow(0 2px 6px rgba(17, 22, 63, 0.25));
 }
 
+.card-search-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card-search-add-button {
+  width: 42px;
+  height: 42px;
+  border-radius: 9999px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 1.4rem;
+  font-weight: 600;
+  font-family: inherit;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 18px 32px -26px rgba(17, 22, 63, 0.5);
+}
+
+.card-search-add-button:hover:not(:disabled),
+.card-search-add-button:focus-visible:not(:disabled) {
+  transform: translateY(-1px) scale(1.03);
+  box-shadow: 0 22px 40px -24px rgba(17, 22, 63, 0.55);
+}
+
+.card-search-add-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+}
+
 .card-search-pagination {
   display: flex;
   align-items: center;

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -6,8 +6,8 @@
     <p class="eyebrow">Rozszerz swoją kolekcję</p>
     <h1>Wyszukaj kartę w bazie</h1>
     <p>
-      Aby wyszukać kartę w bazie podaj jej nazwę, numer lub zestaw, a następnie wybierz
-      interesujący Cię wynik z listy.
+      Aby wyszukać kartę w bazie, wpisz jej nazwę lub nazwę z numerem w polu poniżej, a następnie
+      wybierz interesujący Cię wynik z listy.
     </p>
   </div>
 </section>
@@ -16,21 +16,20 @@
   <div class="panel-header">
     <div>
       <h2>Znajdź kartę w bazie</h2>
-      <p>Podaj szczegóły karty – wymagane jest co najmniej pole nazwy.</p>
+      <p>Wpisz nazwę karty – możesz dodać numer, aby szybciej odnaleźć konkretny egzemplarz.</p>
     </div>
   </div>
   <form id="add-card-form" class="form-grid" autocomplete="off">
     <label>
-      Nazwa karty
-      <input type="text" name="name" id="add-card-name" autocomplete="off" required />
-    </label>
-    <label>
-      Numer (opcjonalnie)
-      <input type="text" name="number" id="add-card-number" autocomplete="off" />
-    </label>
-    <label>
-      Set (opcjonalnie)
-      <input type="text" name="set_name" id="add-card-set" autocomplete="off" />
+      Nazwa lub numer karty
+      <input
+        type="text"
+        name="query"
+        id="add-card-query"
+        autocomplete="off"
+        placeholder="np. Giovanni's Charisma 78/132"
+        required
+      />
     </label>
     <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 aiofiles==23.2.1
 jinja2==3.1.4
+rapidfuzz==3.6.1


### PR DESCRIPTION
## Summary
- simplify the add-card page to a single query input and refresh the search messaging
- add a quick “+” button to each search result and fetch larger result sets with the updated frontend logic
- implement fuzzy card lookups in the API using RapidFuzz, parse combined queries, and cover the new behaviour with tests

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d500ce907c832fb3f25ade1cddc835