### PR TITLE
Fix card search fallback and update search UI

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -385,8 +385,10 @@ def _search_catalogue(
     stmt = stmt.limit(fetch_limit)
     records = session.exec(stmt).all()
 
-    if not records and name_filter_applied:
-        fallback_stmt = select(models.CardRecord)
+    if not records and name_filter_applied and name_norm:
+        fallback_stmt = select(models.CardRecord).where(
+            models.CardRecord.name_normalized.contains(name_norm)
+        )
         if number_clean:
             fallback_stmt = fallback_stmt.where(models.CardRecord.number == number_clean)
         if total_clean:

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -864,7 +864,7 @@ function setupCardSearch(form) {
     baseResults: [],
     sortMode: sortSelect?.value || "relevance",
     currentPage: 1,
-    pageSize: 20,
+    pageSize: Number.MAX_SAFE_INTEGER,
   };
 
   const buildResultKey = (card) => {
@@ -993,7 +993,7 @@ function setupCardSearch(form) {
       return;
     }
     const safeTotal = Number.isFinite(total) ? Math.max(0, total) : Math.max(0, state.baseResults.length);
-    if (!safeTotal) {
+    if (!safeTotal || safeTotal <= state.pageSize) {
       pagination.hidden = true;
       pageInfo.textContent = "";
       if (prevButton) prevButton.disabled = true;
@@ -1054,6 +1054,29 @@ function setupCardSearch(form) {
       placeholder.setAttribute("aria-hidden", "true");
       media.appendChild(placeholder);
     }
+
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.className = "card-search-add-button";
+    addButton.textContent = "+";
+    addButton.title = `Dodaj ${cardName} do kolekcji`;
+    addButton.setAttribute("aria-label", `Dodaj kartę ${cardName} do kolekcji`);
+    addButton.addEventListener("click", async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (addButton.disabled) {
+        return;
+      }
+      addButton.disabled = true;
+      addButton.dataset.loading = "true";
+      try {
+        await addCard(form, cardSearchApi, card);
+      } finally {
+        addButton.disabled = false;
+        delete addButton.dataset.loading;
+      }
+    });
+    media.appendChild(addButton);
     link.appendChild(media);
 
     const info = document.createElement("div");
@@ -1093,32 +1116,6 @@ function setupCardSearch(form) {
       }
       applySuggestion(card);
     });
-
-    const actions = document.createElement("div");
-    actions.className = "card-search-actions";
-    const addButton = document.createElement("button");
-    addButton.type = "button";
-    addButton.className = "card-search-add-button";
-    addButton.textContent = "+";
-    addButton.title = `Dodaj ${cardName} do kolekcji`;
-    addButton.setAttribute("aria-label", `Dodaj kartę ${cardName} do kolekcji`);
-    addButton.addEventListener("click", async (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (addButton.disabled) {
-        return;
-      }
-      addButton.disabled = true;
-      addButton.dataset.loading = "true";
-      try {
-        await addCard(form, cardSearchApi, card);
-      } finally {
-        addButton.disabled = false;
-        delete addButton.dataset.loading;
-      }
-    });
-    actions.appendChild(addButton);
-    item.appendChild(actions);
 
     return item;
   };

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -985,6 +985,7 @@ body[data-theme="dark"] .home-trends-column li {
   aspect-ratio: 3 / 4;
   border-radius: 16px;
   overflow: hidden;
+  position: relative;
   background: rgba(var(--color-primary-rgb), 0.08);
   display: flex;
   align-items: center;
@@ -1053,7 +1054,7 @@ body[data-theme="dark"] .home-trends-column li {
   height: 42px;
   border-radius: 9999px;
   border: none;
-  background: var(--color-primary);
+  background: var(--color-danger);
   color: #fff;
   font-size: 1.4rem;
   font-weight: 600;
@@ -1062,6 +1063,10 @@ body[data-theme="dark"] .home-trends-column li {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
   box-shadow: 0 18px 32px -26px rgba(17, 22, 63, 0.5);
@@ -1071,6 +1076,7 @@ body[data-theme="dark"] .home-trends-column li {
 .card-search-add-button:focus-visible:not(:disabled) {
   transform: translateY(-1px) scale(1.03);
   box-shadow: 0 22px 40px -24px rgba(17, 22, 63, 0.55);
+  background-color: #b02a37;
 }
 
 .card-search-add-button:disabled {


### PR DESCRIPTION
## Summary
- ensure catalogue fallback respects the current search term so irrelevant Giovanni results no longer appear
- allow the search page to return every match while moving the add-to-collection button into the card preview
- restyle the add button with the requested red overlay treatment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51255704c832fb2b595654bc5ec60