### PR TITLE
Improve card search pagination and interactions

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1050,13 +1050,13 @@ body[data-theme="dark"] .home-trends-column li {
 }
 
 .card-search-add-button {
-  width: 42px;
-  height: 42px;
+  width: 34px;
+  height: 34px;
   border-radius: 9999px;
   border: none;
   background: var(--color-danger);
   color: #fff;
-  font-size: 1.4rem;
+  font-size: 1.1rem;
   font-weight: 600;
   font-family: inherit;
   line-height: 1;
@@ -1064,8 +1064,8 @@ body[data-theme="dark"] .home-trends-column li {
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 10px;
+  right: 10px;
   z-index: 2;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
@@ -1090,7 +1090,8 @@ body[data-theme="dark"] .home-trends-column li {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 12px;
   margin-top: 4px;
 }
 
@@ -1118,6 +1119,45 @@ body[data-theme="dark"] .home-trends-column li {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+.card-search-page-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.card-search-page-number {
+  border: none;
+  border-radius: 8px;
+  min-width: 38px;
+  padding: 0.45rem 0.75rem;
+  background: rgba(var(--color-primary-rgb), 0.08);
+  color: var(--color-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-search-page-number:hover:not(:disabled),
+.card-search-page-number:focus-visible:not(:disabled) {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px -22px rgba(17, 22, 63, 0.45);
+}
+
+.card-search-page-number.is-active {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: #fff;
+  cursor: default;
+  box-shadow: 0 16px 28px -24px rgba(17, 22, 63, 0.4);
+}
+
+.card-search-page-number.is-active:disabled {
+  opacity: 1;
 }
 
 .card-search-page-info {

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -33,7 +33,7 @@
     </label>
     <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">
-      <button type="button" class="secondary" id="card-search-trigger">Szukaj</button>
+      <button type="submit" class="secondary" id="card-search-trigger">Szukaj</button>
       <div class="alert" id="add-card-alert" hidden></div>
     </div>
   </form>
@@ -72,6 +72,7 @@
     >
       Poprzednia
     </button>
+    <div id="card-search-page-list" class="card-search-page-list" data-page-list></div>
     <span id="card-search-page-info" class="card-search-page-info" aria-live="polite"></span>
     <button
       type="button"


### PR DESCRIPTION
## Summary
- limit the add-card search results to 20 items per page and render numbered pagination controls
- add clickable page numbers and keep the results panel visible with clearer navigation feedback
- shrink the card add button styling and enable Enter key submission on the search form

## Testing
- pytest *(fails: missing optional dependency `rapidfuzz` required by tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d52f0ef29c832fb204f4908acca1ef