### PR TITLE
Enhance portfolio chart visualization

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1438,14 +1438,20 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
   width: 100%;
   min-height: 240px;
   border-radius: 18px;
-  background: var(--color-surface);
+  background: linear-gradient(
+    160deg,
+    rgba(var(--color-primary-rgb), 0.08) 0%,
+    var(--color-surface) 55%,
+    var(--color-surface-strong) 100%
+  );
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-soft);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 16px;
+  padding: 20px;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .portfolio-chart-meta {
@@ -1504,18 +1510,95 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 }
 
 .portfolio-chart-area {
-  fill: rgba(var(--color-primary-rgb), 0.1);
+  fill: rgba(var(--color-primary-rgb), 0.16);
 }
 
 .portfolio-chart-line {
   fill: none;
   stroke: var(--color-primary);
-  stroke-width: 1.6;
+  stroke-width: 2;
   stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-.portfolio-chart-dot {
+.portfolio-chart-grid {
+  pointer-events: none;
+}
+
+.portfolio-chart-grid-line {
+  stroke: rgba(var(--color-primary-rgb), 0.22);
+  stroke-width: 0.35;
+  shape-rendering: geometricPrecision;
+}
+
+.portfolio-chart-grid-line--vertical {
+  stroke-dasharray: 1 2;
+}
+
+.portfolio-chart-axis line {
+  stroke: var(--color-border-strong);
+  stroke-width: 0.6;
+}
+
+.portfolio-chart-axis-label {
+  fill: var(--color-text-muted);
+  font-size: 3.2px;
+  letter-spacing: 0.06px;
+  pointer-events: none;
+}
+
+.portfolio-chart-axis-label--x {
+  font-size: 3px;
+}
+
+.portfolio-chart-point {
   fill: var(--color-primary);
+  stroke: var(--color-surface);
+  stroke-width: 0.6;
+  transition: transform 0.2s ease, stroke-width 0.2s ease, stroke 0.2s ease;
+}
+
+.portfolio-chart-point:hover,
+.portfolio-chart-point:focus-visible {
+  transform: scale(1.35);
+  stroke-width: 0.9;
+  stroke: rgba(var(--color-primary-rgb), 0.35);
+}
+
+.portfolio-chart-tooltip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -110%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 8px 12px;
+  box-shadow: var(--shadow-card);
+  pointer-events: none;
+  font-size: 0.78rem;
+  line-height: 1.25;
+  opacity: 0;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.portfolio-chart-tooltip[data-visible="true"] {
+  opacity: 1;
+  transform: translate(-50%, -140%);
+}
+
+.portfolio-chart-tooltip-date {
+  font-weight: 600;
+}
+
+.portfolio-chart-tooltip-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 
 .portfolio-chart[data-direction='up'] .portfolio-chart-line {
@@ -1523,7 +1606,7 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 }
 
 .portfolio-chart[data-direction='up'] .portfolio-chart-area {
-  fill: rgba(76, 175, 80, 0.16);
+  fill: rgba(76, 175, 80, 0.2);
 }
 
 .portfolio-chart[data-direction='down'] .portfolio-chart-line {
@@ -1531,15 +1614,44 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 }
 
 .portfolio-chart[data-direction='down'] .portfolio-chart-area {
-  fill: rgba(244, 67, 54, 0.16);
+  fill: rgba(244, 67, 54, 0.2);
 }
 
 body[data-theme="dark"] .portfolio-chart-area {
-  fill: rgba(var(--color-primary-rgb), 0.14);
+  fill: rgba(var(--color-primary-rgb), 0.2);
 }
 
-body[data-theme="dark"] .portfolio-chart-dot {
-  fill: rgba(var(--color-primary-rgb), 0.95);
+body[data-theme="dark"] .portfolio-chart-point {
+  fill: rgba(var(--color-primary-rgb), 0.9);
+  stroke: rgba(9, 12, 21, 0.65);
+}
+
+body[data-theme="dark"] .portfolio-chart {
+  background: linear-gradient(
+    160deg,
+    rgba(var(--color-primary-rgb), 0.12) 0%,
+    rgba(17, 20, 32, 0.92) 48%,
+    rgba(9, 12, 21, 0.96) 100%
+  );
+  border-color: rgba(var(--color-primary-rgb), 0.24);
+}
+
+body[data-theme="dark"] .portfolio-chart-grid-line {
+  stroke: rgba(var(--color-primary-rgb), 0.18);
+}
+
+body[data-theme="dark"] .portfolio-chart-axis line {
+  stroke: rgba(var(--color-primary-rgb), 0.38);
+}
+
+body[data-theme="dark"] .portfolio-chart-axis-label {
+  fill: rgba(222, 223, 231, 0.7);
+}
+
+body[data-theme="dark"] .portfolio-chart-tooltip {
+  background: rgba(17, 20, 32, 0.92);
+  border-color: rgba(var(--color-primary-rgb), 0.22);
+  box-shadow: 0 18px 38px -24px rgba(0, 0, 0, 0.65);
 }
 
 .portfolio-chart-empty,

--- a/kartoteka_web/templates/portfolio.html
+++ b/kartoteka_web/templates/portfolio.html
@@ -16,7 +16,7 @@
 <section class="panel portfolio-performance-panel">
   <div class="panel-header">
     <div>
-      <h2>Wartość portfela</h2>
+      <h2 id="portfolio-chart-heading">Wartość portfela</h2>
       <p>Monitoruj zmianę wartości kolekcji w czasie.</p>
     </div>
     <div class="portfolio-change" id="portfolio-change" data-direction="flat">
@@ -28,7 +28,13 @@
     </div>
   </div>
   <div class="portfolio-chart-wrapper">
-    <div class="portfolio-chart" id="portfolio-chart" role="img" aria-live="polite">
+    <div
+      class="portfolio-chart"
+      id="portfolio-chart"
+      role="group"
+      aria-live="polite"
+      aria-labelledby="portfolio-chart-heading"
+    >
       <p>Ładuję dane wykresu…</p>
     </div>
     <div class="portfolio-chart-meta">


### PR DESCRIPTION
## Summary
- enrich the portfolio performance renderer with axes, gridlines, data point markers, accessible metadata, and hover/focus tooltips
- refresh the chart styling to support the new axes and tooltip, keeping contrast in both light and dark themes
- update the portfolio template markup so the chart container references its heading for assistive technologies

## Testing
- pytest *(fails: passlib bcrypt backend rejects >72 byte probe during hashing in tests/web/test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d638745854832fad44bdf00d1d913d