### PR TITLE
Improve portfolio chart resolution and theme styling

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -716,9 +716,37 @@ function renderPortfolioPerformance(history) {
     maxTime = Number.NaN;
   }
 
-  const viewBoxWidth = 120;
-  const viewBoxHeight = 70;
-  const padding = { top: 8, right: 6, bottom: 10, left: 14 };
+  const containerRect = chartContainer.getBoundingClientRect();
+  const computedStyles = window.getComputedStyle(chartContainer);
+  const parsePaddingValue = (value) => {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  const containerPadding = {
+    top: parsePaddingValue(computedStyles.paddingTop),
+    right: parsePaddingValue(computedStyles.paddingRight),
+    bottom: parsePaddingValue(computedStyles.paddingBottom),
+    left: parsePaddingValue(computedStyles.paddingLeft),
+  };
+  const rawWidth = containerRect.width || chartContainer.clientWidth || chartContainer.offsetWidth || 720;
+  const rawHeight = containerRect.height || chartContainer.clientHeight || chartContainer.offsetHeight || 320;
+  const innerWidth = Math.max(
+    Math.round(rawWidth - containerPadding.left - containerPadding.right),
+    320,
+  );
+  const innerHeight = Math.max(
+    Math.round(rawHeight - containerPadding.top - containerPadding.bottom),
+    220,
+  );
+
+  const viewBoxWidth = innerWidth;
+  const viewBoxHeight = innerHeight;
+  const padding = {
+    top: Math.max(20, Math.round(innerHeight * 0.12)),
+    right: Math.max(28, Math.round(innerWidth * 0.06)),
+    bottom: Math.max(44, Math.round(innerHeight * 0.22)),
+    left: Math.max(56, Math.round(innerWidth * 0.08)),
+  };
   const chartWidth = viewBoxWidth - padding.left - padding.right;
   const chartHeight = viewBoxHeight - padding.top - padding.bottom;
   const chartLeft = padding.left;
@@ -963,7 +991,7 @@ function renderPortfolioPerformance(history) {
   yAxisGroup.appendChild(yAxisLine);
   yTicks.forEach((tick) => {
     const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    label.setAttribute("x", (chartLeft - 2).toFixed(2));
+    label.setAttribute("x", (chartLeft - 12).toFixed(2));
     label.setAttribute("y", tick.y.toFixed(2));
     label.setAttribute("text-anchor", "end");
     label.setAttribute("dominant-baseline", "middle");
@@ -985,7 +1013,7 @@ function renderPortfolioPerformance(history) {
     const x = chartLeft + tick.position * chartWidth;
     const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
     label.setAttribute("x", x.toFixed(2));
-    label.setAttribute("y", (chartBottom + 4).toFixed(2));
+    label.setAttribute("y", (chartBottom + 18).toFixed(2));
     label.setAttribute("text-anchor", "middle");
     label.setAttribute("dominant-baseline", "hanging");
     label.classList.add("portfolio-chart-axis-label", "portfolio-chart-axis-label--x");

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1511,14 +1511,18 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 
 .portfolio-chart-area {
   fill: rgba(var(--color-primary-rgb), 0.16);
+  fill: color-mix(in srgb, var(--color-primary) 22%, transparent);
+  transition: fill 0.3s ease;
 }
 
 .portfolio-chart-line {
   fill: none;
   stroke: var(--color-primary);
-  stroke-width: 2;
+  stroke: color-mix(in srgb, var(--color-primary) 78%, var(--color-text) 22%);
+  stroke-width: 2.6;
   stroke-linecap: round;
   stroke-linejoin: round;
+  transition: stroke 0.3s ease;
 }
 
 .portfolio-chart-grid {
@@ -1542,13 +1546,14 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 
 .portfolio-chart-axis-label {
   fill: var(--color-text-muted);
-  font-size: 3.2px;
-  letter-spacing: 0.06px;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  font-weight: 500;
   pointer-events: none;
 }
 
 .portfolio-chart-axis-label--x {
-  font-size: 3px;
+  font-size: 11px;
 }
 
 .portfolio-chart-point {
@@ -1603,22 +1608,46 @@ body[data-theme="dark"] .portfolio-change[data-direction='down'] {
 
 .portfolio-chart[data-direction='up'] .portfolio-chart-line {
   stroke: var(--color-success);
+  stroke: color-mix(in srgb, var(--color-success) 78%, var(--color-text) 22%);
 }
 
 .portfolio-chart[data-direction='up'] .portfolio-chart-area {
   fill: rgba(76, 175, 80, 0.2);
+  fill: color-mix(in srgb, var(--color-success) 26%, transparent);
 }
 
 .portfolio-chart[data-direction='down'] .portfolio-chart-line {
   stroke: var(--color-danger);
+  stroke: color-mix(in srgb, var(--color-danger) 80%, var(--color-text) 20%);
 }
 
 .portfolio-chart[data-direction='down'] .portfolio-chart-area {
   fill: rgba(244, 67, 54, 0.2);
+  fill: color-mix(in srgb, var(--color-danger) 28%, transparent);
+}
+
+body[data-theme="dark"] .portfolio-chart-line {
+  stroke: color-mix(in srgb, var(--color-primary) 82%, #0b101d 18%);
 }
 
 body[data-theme="dark"] .portfolio-chart-area {
-  fill: rgba(var(--color-primary-rgb), 0.2);
+  fill: color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+body[data-theme="dark"] .portfolio-chart[data-direction='up'] .portfolio-chart-line {
+  stroke: color-mix(in srgb, var(--color-success) 82%, rgba(9, 12, 21, 0.35) 18%);
+}
+
+body[data-theme="dark"] .portfolio-chart[data-direction='up'] .portfolio-chart-area {
+  fill: color-mix(in srgb, var(--color-success) 32%, transparent);
+}
+
+body[data-theme="dark"] .portfolio-chart[data-direction='down'] .portfolio-chart-line {
+  stroke: color-mix(in srgb, var(--color-danger) 84%, rgba(9, 12, 21, 0.45) 16%);
+}
+
+body[data-theme="dark"] .portfolio-chart[data-direction='down'] .portfolio-chart-area {
+  fill: color-mix(in srgb, var(--color-danger) 34%, transparent);
 }
 
 body[data-theme="dark"] .portfolio-chart-point {


### PR DESCRIPTION
## Summary
- align the SVG viewBox with the rendered chart size and update axis label placement after recalculating padding
- refresh chart axis typography and adopt theme-aware colours for line and area states across light and dark modes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d647670058832f907c450b14e87da3