### PR TITLE
Add full-range option for card detail history view

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ logging in, registering new users, managing the collection and monitoring the
 portfolio value.  JavaScript widgets communicate with the REST API to perform
 CRUD operations on stored cards.
 
+### Card detail dashboard
+
+The card-detail view exposes interactive price history charts with range
+toggles for the last day, week, month or the entire dataset ("Całość").  When a
+shorter window would be empty the UI automatically highlights the full-range
+option so the chart stays populated whenever historical data exists.
+
 ## Set validation
 
 OpenAI responses normally validate set and era names against a built-in list.

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -70,6 +70,7 @@
       <button type="button" class="secondary" data-range="1d">1 dzień</button>
       <button type="button" class="secondary" data-range="1w">1 tydzień</button>
       <button type="button" class="secondary active" data-range="1m">1 miesiąc</button>
+      <button type="button" class="secondary" data-range="all">Całość</button>
     </div>
   </div>
   <div class="card-chart-wrapper">


### PR DESCRIPTION
## Summary
- add an "all" range to the card history filter with automatic fallback when shorter windows are empty
- surface the new range selector button in the card detail template and only show the empty-state when no history exists
- document the behaviour in the README for the card detail dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6499ba280832faf0b2e843ba346f9