### PR TITLE
Recommend related cards by character

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1842,6 +1842,9 @@ function renderRelatedCardsList(cards) {
   const empty = document.getElementById("related-empty");
   if (!container) return;
   container.innerHTML = "";
+  if (empty) {
+    empty.textContent = "Nie znaleziono innych kart z tą postacią.";
+  }
   if (!Array.isArray(cards) || !cards.length) {
     if (empty) empty.hidden = false;
     return;

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -82,11 +82,11 @@
 <section class="panel card-detail-related">
   <div class="panel-header">
     <div>
-      <h2>Inne karty z tego setu</h2>
-      <p>Poznaj dodatkowe karty z wybranego dodatku.</p>
+      <h2>Polecane karty z tą postacią</h2>
+      <p>Odkryj inne wydania tej postaci w różnych dodatkach.</p>
     </div>
   </div>
   <div class="related-grid" id="related-cards-list"></div>
-  <p class="related-empty" id="related-empty" hidden>Nie znaleziono innych kart z tego dodatku.</p>
+  <p class="related-empty" id="related-empty" hidden>Nie znaleziono innych kart z tą postacią.</p>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fetch related catalogue entries by normalised character name and refresh them via search when needed
- update the card detail page copy to highlight character-based recommendations
- extend API tests to cover character recommendations across sets and stub hashing during tests

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6520b01d8832f9ec75a8c642e2910