### PR TITLE
Hide header on scroll and add QA checklist entry

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -314,6 +314,58 @@ function setupNavigation() {
   updateUserBadge({ username: initialUsername, avatar_url: initialAvatar });
 }
 
+function setupHeaderVisibility() {
+  const header = document.querySelector("header.app-header");
+  if (!header) {
+    return;
+  }
+
+  const setHeaderVisibility = (visible) => {
+    header.dataset.headerVisible = visible ? "true" : "false";
+  };
+
+  setHeaderVisibility(true);
+
+  let lastKnownScrollY = window.scrollY;
+  let ticking = false;
+  const threshold = 4;
+
+  const updateVisibility = () => {
+    const currentScrollY = Math.max(window.scrollY, 0);
+    const atTop = currentScrollY <= 0;
+
+    if (atTop) {
+      setHeaderVisibility(true);
+    } else if (currentScrollY > lastKnownScrollY + threshold) {
+      setHeaderVisibility(false);
+    } else if (currentScrollY < lastKnownScrollY - threshold) {
+      setHeaderVisibility(true);
+    }
+
+    lastKnownScrollY = currentScrollY;
+    ticking = false;
+  };
+
+  const requestTick = () => {
+    if (!ticking) {
+      window.requestAnimationFrame(updateVisibility);
+      ticking = true;
+    }
+  };
+
+  const resetVisibility = () => {
+    lastKnownScrollY = window.scrollY;
+    setHeaderVisibility(true);
+    requestTick();
+  };
+
+  window.addEventListener("scroll", requestTick, { passive: true });
+  window.addEventListener("resize", resetVisibility);
+  window.addEventListener("orientationchange", resetVisibility);
+
+  requestTick();
+}
+
 async function registerServiceWorker() {
   if (!("serviceWorker" in navigator)) {
     return;
@@ -2532,6 +2584,7 @@ async function ensureAuthenticated() {
 window.addEventListener("DOMContentLoaded", async () => {
   setupThemeToggle();
   setupNavigation();
+  setupHeaderVisibility();
   const loginForm = document.getElementById("login-form");
   if (loginForm) {
     loginForm.addEventListener("submit", (event) => {

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -168,6 +168,21 @@ img {
   align-items: center;
   gap: 24px;
   z-index: 5;
+  transform: translateY(0);
+  opacity: 1;
+  transition: transform 0.35s ease, opacity 0.25s ease;
+  will-change: transform, opacity;
+}
+
+.app-header[data-header-visible='false'] {
+  transform: translateY(calc(-100% - 32px));
+  opacity: 0;
+  pointer-events: none;
+}
+
+.app-header[data-header-visible='true'] {
+  transform: translateY(0);
+  opacity: 1;
 }
 
 .brand {

--- a/tests/QA_CHECKLIST.md
+++ b/tests/QA_CHECKLIST.md
@@ -1,0 +1,3 @@
+# Manual QA Checklist
+
+- [ ] **Header visibility:** Open the web dashboard in a desktop browser, scroll downward until the content moves past the hero section and confirm the sticky header hides. Scroll up or return to the top and verify the header smoothly reappears. Refresh the page or resize the browser window and confirm the header is visible again before scrolling.


### PR DESCRIPTION
## Summary
- add a scroll-driven visibility controller for the sticky header using requestAnimationFrame
- animate header transitions with CSS transforms and opacity tied to a data attribute
- document a manual QA step verifying header hide/show and reset behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d657b46960832fac8e15f7877a5e6a