### PR TITLE
Add pagination metadata to card search

### DIFF
--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -70,6 +70,13 @@ class CardSearchResult(SQLModel):
     release_date: Optional[str] = None
 
 
+class CardSearchResponse(SQLModel):
+    items: List[CardSearchResult] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 0
+
+
 class PricePoint(SQLModel):
     price: float
     recorded_at: dt.datetime

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -240,12 +240,16 @@ def test_card_search_endpoint(api_client, monkeypatch):
     )
     assert res.status_code == 200
     results = res.json()
-    assert len(results) == 1
-    assert results[0]["name"] == "Pikachu"
-    assert results[0]["set_name"] == "Base Set"
-    assert results[0]["number"] == "25"
-    assert "set_icon" in results[0]
-    assert results[0]["image_small"] == sample[0]["image_small"]
+    assert results["total"] == 1
+    assert results["page"] == 1
+    assert results["page_size"] >= 1
+    assert len(results["items"]) == 1
+    item = results["items"][0]
+    assert item["name"] == "Pikachu"
+    assert item["set_name"] == "Base Set"
+    assert item["number"] == "25"
+    assert "set_icon" in item
+    assert item["image_small"] == sample[0]["image_small"]
 
 
 def test_card_search_query_parameter(api_client):
@@ -274,9 +278,10 @@ def test_card_search_query_parameter(api_client):
     res = client.get("/cards/search", params={"query": "giovani 78"}, headers=headers)
     assert res.status_code == 200, res.text
     payload = res.json()
-    assert payload, payload
-    assert payload[0]["name"] == "Giovanni's Charisma"
-    assert payload[0]["number"] == "78"
+    assert payload["items"], payload
+    assert payload["total"] >= 1
+    assert payload["items"][0]["name"] == "Giovanni's Charisma"
+    assert payload["items"][0]["number"] == "78"
 
 
 def test_card_info_endpoint(api_client, monkeypatch):


### PR DESCRIPTION
## Summary
- add a paginated CardSearchResponse schema and expose metadata from `/cards/search`
- update catalogue queries to support offset+count and adjust the search endpoint for pagination
- request paginated results on the frontend and refresh pagination controls; update API tests

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6695a4934832fae24c9f9e49d0e67