### PR TITLE
Normalize card detail metadata from catalogue records

### DIFF
--- a/server.py
+++ b/server.py
@@ -383,13 +383,15 @@ async def card_detail_page(request: Request, set_identifier: str, number: str) -
             )
 
         if record:
-            resolved_name = resolved_name or record.name
-            resolved_set_name = resolved_set_name or (record.set_name or "")
-            if not resolved_set_code:
+            if record.name:
+                resolved_name = record.name
+            if record.set_name:
+                resolved_set_name = record.set_name
+            if record.set_code_clean or record.set_code:
                 resolved_set_code = (
                     record.set_code_clean or record.set_code or ""
                 )
-            if not resolved_total and record.total:
+            if record.total:
                 resolved_total = record.total
             if not resolved_number:
                 resolved_number = record.number

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -455,6 +455,20 @@ def test_card_detail_page_prefills_dataset(api_client):
     assert 'data-total="102"' in html
     assert '<h1 id="card-detail-title">Pikachu</h1>' in html
 
+    # Even when the query provides conflicting metadata, the template should use
+    # the canonical catalogue values so the dataset remains consistent.
+    res = client.get(
+        "/cards/base/25",
+        params={"set_name": "151", "set_code": "sv3"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    html = res.text
+    assert 'data-set-code="base"' in html
+    assert 'data-set-name="Base Set"' in html
+    assert 'data-total="102"' in html
+    assert 'data-name="Pikachu"' in html
+
 
 def test_card_detail_page_missing_catalogue_returns_404(api_client):
     client, _prices, _server = api_client


### PR DESCRIPTION
## Summary
- ensure the card detail page replaces query metadata with canonical catalogue values
- extend the regression test to cover conflicting metadata in requests

## Testing
- pytest tests/web/test_api.py::test_card_detail_page_prefills_dataset

------
https://chatgpt.com/codex/tasks/task_e_68d679e97158832fae3ab0f050b3f608