### PR TITLE
Pin bcrypt dependency to compatible release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ uvicorn[standard]==0.30.1
 sqlmodel==0.0.16
 SQLAlchemy>=1.4.51
 passlib[bcrypt]==1.7.4
+bcrypt>=3.2,<4
 python-jose[cryptography]==3.3.0
 aiofiles==23.2.1
 jinja2==3.1.4


### PR DESCRIPTION
## Summary
- add an explicit bcrypt version constraint to stay on the 3.x line compatible with passlib

## Testing
- pip install -r requirements.txt
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c8923eb4832f91a3729f1e83fd3e