### PR TITLE
Add SQLite write lock for shared session handling

### DIFF
--- a/kartoteka_web/database.py
+++ b/kartoteka_web/database.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import logging
 import os
-from contextlib import contextmanager
+import threading
+from contextlib import contextmanager, nullcontext
 from typing import Iterator
 
 from sqlmodel import Session, SQLModel, create_engine
 
 DATABASE_URL = os.getenv("KARTOTEKA_DATABASE_URL", "sqlite:///./kartoteka.db")
 
-connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+USING_SQLITE = DATABASE_URL.startswith("sqlite")
+connect_args = {"check_same_thread": False} if USING_SQLITE else {}
 engine = create_engine(DATABASE_URL, echo=False, connect_args=connect_args)
+
+DATABASE_WRITE_LOCK = threading.RLock() if USING_SQLITE else nullcontext()
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +25,14 @@ logger = logging.getLogger(__name__)
 def session_scope() -> Iterator[Session]:
     """Provide a transactional scope around a series of operations."""
 
-    with Session(engine) as session:
-        try:
-            yield session
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
+    with DATABASE_WRITE_LOCK:
+        with Session(engine) as session:
+            try:
+                yield session
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
 
 
 def init_db() -> None:
@@ -72,5 +77,6 @@ def init_db() -> None:
 def get_session() -> Iterator[Session]:
     """FastAPI dependency returning a new SQLModel session."""
 
-    with Session(engine) as session:
-        yield session
+    with DATABASE_WRITE_LOCK:
+        with Session(engine) as session:
+            yield session


### PR DESCRIPTION
## Summary
- detect when the web database is backed by SQLite and create a shared write lock
- guard `session_scope` and `get_session` so SQLite sessions serialise commits and rollbacks

## Testing
- pytest tests/web/test_api.py -k users

------
https://chatgpt.com/codex/tasks/task_e_68d823ef3690832f9ee1e9b2e31dba3f