### PR TITLE
Adjust service worker caching for dynamic API requests

### DIFF
--- a/kartoteka_web/static/service-worker.js
+++ b/kartoteka_web/static/service-worker.js
@@ -28,24 +28,70 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+const STATIC_EXTENSIONS = [
+  '.css',
+  '.js',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.webp',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf'
+];
+
+const HTML_ROUTES = ['/', '/register', '/dashboard', '/portfolio'];
+
+const isStaticAsset = (url) => {
+  return STATIC_EXTENSIONS.some((ext) => url.pathname.endsWith(ext));
+};
+
+const isCacheableHtmlRoute = (url) => {
+  return HTML_ROUTES.includes(url.pathname);
+};
+
 self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
     return;
   }
+
+  const requestUrl = new URL(request.url);
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+  const hasAuthHeader = request.headers.has('Authorization');
+  const isDynamicApiRequest =
+    hasAuthHeader ||
+    (isSameOrigin && (requestUrl.pathname.startsWith('/users/') || requestUrl.pathname.startsWith('/cards/')));
+
+  if (isDynamicApiRequest) {
+    event.respondWith(fetch(request));
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
+    caches.match(request).then((cachedResponse) => {
       if (cachedResponse) {
         return cachedResponse;
       }
-      return fetch(event.request)
+
+      return fetch(request)
         .then((response) => {
-          if (!response || response.status !== 200 || response.type === 'opaque') {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
             return response;
           }
-          const cloned = response.clone();
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, cloned);
-          });
+
+          if (isSameOrigin && (isStaticAsset(requestUrl) || isCacheableHtmlRoute(requestUrl))) {
+            const cloned = response.clone();
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(request, cloned);
+            });
+          }
+
           return response;
         })
         .catch(() => caches.match('/'));


### PR DESCRIPTION
## Summary
- bypass runtime caching for requests that hit dynamic API endpoints or include authorization headers
- limit cache writes to static assets and known HTML routes when fetching uncached resources

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d834df65e8832fb4ae432fb751a6c5