### PR TITLE
Filter weak card search results and expose suggestions

### DIFF
--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -20,6 +20,10 @@ HOLO_REVERSE_MULTIPLIER = float(os.getenv("HOLO_REVERSE_MULTIPLIER", "3.5"))
 RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
 RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
 DEFAULT_EXCHANGE_RATE = float(os.getenv("DEFAULT_EUR_PLN", "4.265"))
+# ``_score`` values in :func:`search_cards` peak around 6--7 for confident
+# matches.  Mapping them to a percentage keeps the API consistent with the
+# catalogue scoring, where fuzzy ratios already span 0--100.
+SEARCH_SCORE_THRESHOLD = float(os.getenv("SEARCH_SCORE_THRESHOLD", "88"))
 
 _exchange_rate_lock = threading.Lock()
 _exchange_rate_cache: dict[str, Any] = {"value": None, "date": None}
@@ -505,6 +509,7 @@ def search_cards(
     set_norm = normalize(set_name) if set_name else ""
 
     suggestions: list[dict[str, Any]] = []
+    threshold = SEARCH_SCORE_THRESHOLD
     for card in cards or []:
         payload = _build_card_payload(card)
         if not payload:
@@ -540,6 +545,7 @@ def search_cards(
         if not payload.get("image_small") and payload.get("image_large"):
             payload["image_small"] = payload.get("image_large")
         payload["_score"] = score
+        payload["_score_value"] = score * 20
         suggestions.append(payload)
 
     suggestions.sort(
@@ -554,11 +560,14 @@ def search_cards(
     seen: set[tuple[str | None, str]] = set()
     results: list[dict] = []
     for item in suggestions:
+        if threshold and item.get("_score_value", 0) < threshold:
+            continue
         key = (item.get("set_code"), item.get("number"))
         if key in seen:
             continue
         seen.add(key)
         item.pop("_score", None)
+        item.pop("_score_value", None)
         if not item.get("image_small") and item.get("image_large"):
             item["image_small"] = item["image_large"]
         results.append(item)

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -61,6 +61,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for tests without rap
 
 router = APIRouter(prefix="/cards", tags=["cards"])
 
+SCORE_THRESHOLD = pricing.SEARCH_SCORE_THRESHOLD
+
 CARD_NUMBER_PATTERN = re.compile(
     r"(?i)([a-z]{0,5}\d+[a-z0-9]*)(?:\s*/\s*([a-z]{0,5}\d+[a-z0-9]*))?"
 )
@@ -256,6 +258,12 @@ def _fetch_cardrecord_candidate_ids(match_query: str, limit: int) -> list[int]:
         return [int(row[0]) for row in rows if row[0] is not None]
 
 
+def _suggested_query_label(record: "models.CardRecord" | None) -> str | None:
+    if not record:
+        return None
+    return record.name or record.number_display or record.number or None
+
+
 def _search_catalogue(
     session: Session,
     *,
@@ -266,7 +274,7 @@ def _search_catalogue(
     set_name: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> tuple[list["models.CardRecord"], int]:
+) -> tuple[list["models.CardRecord"], int, "models.CardRecord" | None]:
     search_term = name or query
     name_norm = _normalise_search_value(search_term)
     number_clean = _sanitise_optional_number(number)
@@ -379,6 +387,7 @@ def _search_catalogue(
     total_count = int(total_count or 0)
 
     scored = []
+    best_entry: tuple[float, models.CardRecord] | None = None
     for record in records:
         base_score = _score_card_record(
             record,
@@ -389,6 +398,8 @@ def _search_catalogue(
         )
         fuzzy_score = fuzzy_priorities.get(record.id, 0.0)
         final_score = max(base_score, fuzzy_score)
+        if best_entry is None or final_score > best_entry[0]:
+            best_entry = (final_score, record)
         scored.append((final_score, fuzzy_score, record))
 
     scored.sort(
@@ -400,11 +411,18 @@ def _search_catalogue(
             item[2].name or "",
         )
     )
+    threshold = SCORE_THRESHOLD
+    filtered = [entry for entry in scored if entry[0] >= threshold]
+    filtered_total = len(filtered)
     paginated = [
         record
-        for _score, _fuzzy, record in scored[offset : offset + max(1, limit)]
+        for _score, _fuzzy, record in filtered[offset : offset + max(1, limit)]
     ]
-    return paginated, total_count
+    if threshold and total_count:
+        total_count = min(total_count, filtered_total)
+    else:
+        total_count = filtered_total
+    return paginated, total_count, best_entry[1] if best_entry else None
 
 
 def _select_best_record(
@@ -857,10 +875,12 @@ def search_cards_endpoint(
     if not name_value:
         name_value = search_query
 
-    def _run_search(page_index: int) -> tuple[list[models.CardRecord], int, int]:
+    def _run_search(
+        page_index: int,
+    ) -> tuple[list[models.CardRecord], int, int, str | None]:
         safe_page = max(1, page_index)
         page_offset = (safe_page - 1) * cleaned_page_size
-        results, total_count = _search_catalogue(
+        results, total_count, suggestion = _search_catalogue(
             session,
             query=search_query,
             name=name_value,
@@ -870,7 +890,7 @@ def search_cards_endpoint(
             limit=cleaned_page_size,
             offset=page_offset,
         )
-        return results, total_count, safe_page
+        return results, total_count, safe_page, _suggested_query_label(suggestion)
 
     def _apply_assets(records: Sequence[models.CardRecord]) -> None:
         updated = False
@@ -879,7 +899,7 @@ def search_cards_endpoint(
         if updated:
             session.commit()
 
-    records, total_count, resolved_page = _run_search(requested_page)
+    records, total_count, resolved_page, suggestion_name = _run_search(requested_page)
     _apply_assets(records)
 
     if not records:
@@ -904,7 +924,7 @@ def search_cards_endpoint(
                 stored = True
         if stored:
             session.commit()
-            records, total_count, resolved_page = _run_search(resolved_page)
+            records, total_count, resolved_page, suggestion_name = _run_search(resolved_page)
             _apply_assets(records)
         elif cached_records:
             records = cached_records[
@@ -921,7 +941,7 @@ def search_cards_endpoint(
     total_pages = (total_count + cleaned_page_size - 1) // cleaned_page_size if total_count else 0
     if total_pages and resolved_page > total_pages:
         resolved_page = max(1, total_pages)
-        records, total_count, resolved_page = _run_search(resolved_page)
+        records, total_count, resolved_page, suggestion_name = _run_search(resolved_page)
         _apply_assets(records)
     elif total_count == 0:
         resolved_page = 1
@@ -932,6 +952,7 @@ def search_cards_endpoint(
         total=total_count,
         page=resolved_page,
         page_size=cleaned_page_size,
+        suggested_query=suggestion_name,
     )
 
 
@@ -993,7 +1014,7 @@ def card_info(
         set_name=set_name,
     )
     if record is None:
-        records, _total = _search_catalogue(
+        records, _total, _suggestion = _search_catalogue(
             session,
             query=search_query,
             name=name,
@@ -1023,7 +1044,7 @@ def card_info(
                 set_name=set_name,
             )
             if record is None:
-                records, _total = _search_catalogue(
+                records, _total, _suggestion = _search_catalogue(
                     session,
                     query=search_query,
                     name=name,
@@ -1060,7 +1081,7 @@ def card_info(
                 set_name=set_name,
             )
             if record is None:
-                records, _total = _search_catalogue(
+                records, _total, _suggestion = _search_catalogue(
                     session,
                     query=search_query,
                     name=name,

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -75,6 +75,7 @@ class CardSearchResponse(SQLModel):
     total: int = 0
     page: int = 1
     page_size: int = 0
+    suggested_query: Optional[str] = None
 
 
 class PricePoint(SQLModel):

--- a/tests/test_card_search_ft.py
+++ b/tests/test_card_search_ft.py
@@ -98,14 +98,14 @@ def _run_search(session: Session, *, use_fts: bool):
     try:
         if not use_fts:
             with _override_attribute(cards, "_fetch_cardrecord_candidate_ids", lambda *a, **k: []):
-                records, _total = cards._search_catalogue(
+                records, _total, _suggestion = cards._search_catalogue(
                     session,
                     query="Charizard",
                     name="Charizard",
                     limit=1,
                 )
         else:
-            records, _total = cards._search_catalogue(
+            records, _total, _suggestion = cards._search_catalogue(
                 session,
                 query="Charizard",
                 name="Charizard",
@@ -166,7 +166,7 @@ def test_card_search_fuzzy_misspelling(monkeypatch, search_db):
 
         monkeypatch.setattr(cards, "_fetch_cardrecord_candidate_ids", lambda *a, **k: [])
 
-        results, total_count = cards._search_catalogue(
+        results, total_count, _suggestion = cards._search_catalogue(
             session,
             query="Sharizard",
             name="Sharizard",

--- a/tests/test_card_search_suggestions.py
+++ b/tests/test_card_search_suggestions.py
@@ -1,0 +1,109 @@
+import sys
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture()
+def search_session(tmp_path, monkeypatch):
+    db_path = tmp_path / "search.db"
+    db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("KARTOTEKA_DATABASE_URL", db_url)
+
+    from kartoteka_web import database
+
+    with suppress(Exception):
+        database.engine.dispose()
+
+    connect_args = {"check_same_thread": False}
+    database.engine = create_engine(db_url, echo=False, connect_args=connect_args)
+    SQLModel.metadata.create_all(database.engine)
+    database.init_db()
+
+    with Session(database.engine) as session:
+        yield session
+
+
+def _seed_charizard(session: Session) -> None:
+    from kartoteka_web import catalogue
+
+    payload = {
+        "name": "Charizard",
+        "number": "4",
+        "set_name": "Base Set",
+    }
+    record, created = catalogue.upsert_card_record(session, payload)
+    if record is not None and created:
+        session.add(record)
+    session.commit()
+
+
+def test_card_search_suggests_and_filters(monkeypatch, search_session):
+    from kartoteka_web.routes import cards
+
+    _seed_charizard(search_session)
+
+    original_search_cards = cards.pricing.search_cards
+    monkeypatch.setattr(cards.pricing, "search_cards", lambda **_: [])
+    monkeypatch.setattr(cards, "_ensure_record_assets", lambda *a, **k: False)
+
+    response = cards.search_cards_endpoint(
+        query="Sharzard",
+        page=1,
+        page_size=10,
+        current_user=object(),
+        session=search_session,
+    )
+
+    assert response.items == []
+    assert response.total == 0
+    assert response.suggested_query == "Charizard"
+
+    monkeypatch.setattr(cards.pricing, "search_cards", original_search_cards)
+
+    from kartoteka import pricing
+
+    class _DummyResponse:
+        status_code = 200
+
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    captured = {"called": 0}
+
+    def fake_get(_url, params=None, headers=None, timeout=None):
+        captured["called"] += 1
+        data = {
+            "cards": [
+                {
+                    "name": "Charizard",
+                    "number": "4",
+                    "total": "102",
+                    "set": {"name": "Base Set", "code": "BS"},
+                },
+                {
+                    "name": "Charoad",
+                    "number": "4",
+                    "total": "102",
+                    "set": {"name": "Base Set", "code": "BS"},
+                },
+            ]
+        }
+        return _DummyResponse(data)
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    results = pricing.search_cards(name="Charizard", number="4", limit=10)
+
+    assert captured["called"] == 1
+    assert [item["name"] for item in results] == ["Charizard"]


### PR DESCRIPTION
## Summary
- add a shared score threshold for catalogue and remote card searches and ignore results below it
- surface the best matching catalogue entry as suggested_query on the card search endpoint
- extend tests to cover pagination updates and the new suggestion behaviour

## Testing
- pytest tests/test_card_search_ft.py tests/test_card_search_remote_pagination.py tests/test_card_search_suggestions.py tests/test_pricing.py

------
https://chatgpt.com/codex/tasks/task_e_68d83ac91770832f8dbbe496bcf6cb8e