### PR TITLE
Refine add card toast notifications

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -398,20 +398,55 @@ async function apiFetch(path, options = {}) {
   return data;
 }
 
+const alertHideTimers = new WeakMap();
+const TOAST_TRANSITION_MS = 300;
+
+function hideToast(element) {
+  element.dataset.visible = "false";
+  window.setTimeout(() => {
+    element.hidden = true;
+    element.textContent = "";
+    delete element.dataset.variant;
+    element.removeAttribute("data-visible");
+  }, TOAST_TRANSITION_MS);
+}
+
 function showAlert(element, message, type = "error") {
   if (!element) return;
-  if (message) {
-    element.textContent = message;
-    element.hidden = false;
-    if (type === "success") {
-      element.classList.add("success");
+
+  const pendingTimer = alertHideTimers.get(element);
+  if (pendingTimer) {
+    window.clearTimeout(pendingTimer);
+    alertHideTimers.delete(element);
+  }
+
+  element.classList.remove("success", "error");
+
+  if (!message) {
+    if (element.id === "add-card-alert") {
+      hideToast(element);
     } else {
-      element.classList.remove("success");
+      element.textContent = "";
+      element.hidden = true;
+      delete element.dataset.variant;
+      element.removeAttribute("data-visible");
     }
-  } else {
-    element.textContent = "";
-    element.hidden = true;
-    element.classList.remove("success");
+    return;
+  }
+
+  element.textContent = message;
+  element.hidden = false;
+  element.dataset.variant = type;
+
+  if (element.id === "add-card-alert") {
+    element.dataset.visible = "true";
+    if (type === "success") {
+      const timeoutId = window.setTimeout(() => {
+        hideToast(element);
+        alertHideTimers.delete(element);
+      }, 4000);
+      alertHideTimers.set(element, timeoutId);
+    }
   }
 }
 

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -33,6 +33,7 @@
   --chart-text: rgba(226, 232, 240, 0.72);
   --radius-lg: 22px;
   --radius-md: 16px;
+  --spacing: 24px;
   font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
@@ -1308,18 +1309,71 @@ body[data-theme="light"] .form-checkbox {
 .alert {
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(244, 67, 54, 0.25);
-  background: rgba(244, 67, 54, 0.12);
-  color: var(--color-danger);
   font-weight: 500;
   width: 100%;
   box-shadow: inset 0 0 0 1px rgba(244, 67, 54, 0.08);
 }
 
-.alert.success {
-  border-color: rgba(76, 175, 80, 0.28);
+.alert[data-variant="error"],
+.alert:not([data-variant]) {
+  border: 1px solid rgba(244, 67, 54, 0.25);
+  background: rgba(244, 67, 54, 0.12);
+  color: var(--color-danger);
+}
+
+.alert[data-variant="success"] {
+  border: 1px solid rgba(76, 175, 80, 0.28);
   background: rgba(76, 175, 80, 0.12);
   color: var(--color-success);
+  box-shadow: inset 0 0 0 1px rgba(76, 175, 80, 0.1);
+}
+
+.toast-container {
+  position: fixed;
+  top: var(--spacing);
+  right: var(--spacing);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: auto;
+  max-width: min(420px, calc(100vw - 2 * var(--spacing)));
+  z-index: 20;
+  pointer-events: none;
+}
+
+#add-card-alert {
+  width: auto;
+  min-width: min(360px, calc(100vw - 2 * var(--spacing)));
+  max-width: min(420px, calc(100vw - 2 * var(--spacing)));
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid var(--surface-outline-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-soft), 0 24px 48px -28px rgba(5, 10, 28, 0.75);
+  opacity: 0;
+  transform: translateY(-12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: auto;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+#add-card-alert[data-visible="true"] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#add-card-alert[data-variant="success"] {
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: var(--shadow-soft), 0 0 0 1px rgba(34, 197, 94, 0.25);
+  color: var(--color-success);
+}
+
+#add-card-alert[data-variant="error"] {
+  border-color: rgba(239, 68, 68, 0.45);
+  box-shadow: var(--shadow-soft), 0 0 0 1px rgba(239, 68, 68, 0.25);
+  color: var(--color-danger);
 }
 
 .table-responsive {

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -35,7 +35,6 @@
     <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">
       <button type="submit" class="secondary" id="card-search-trigger">Szukaj</button>
-      <div class="alert" id="add-card-alert" hidden></div>
     </div>
   </form>
 </section>
@@ -85,4 +84,8 @@
     </button>
   </div>
 </section>
+
+<div class="toast-container">
+  <div class="alert" id="add-card-alert" role="status" aria-live="polite" hidden></div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move the add card alert into a dedicated toast container with accessibility roles
- restyle the toast for fixed positioning with fade animation and introduce a shared spacing variable
- update showAlert to drive the toast with data attributes and auto-dismiss successful add messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da34d93984832fbbb567725c27f369