### PR TITLE
Normalize user credential whitespace handling

### DIFF
--- a/kartoteka_web/auth.py
+++ b/kartoteka_web/auth.py
@@ -38,7 +38,8 @@ def get_password_hash(password: str) -> str:
 
 
 def authenticate_user(session: Session, username: str, password: str) -> Optional[User]:
-    user = session.exec(select(User).where(User.username == username)).first()
+    clean_username = username.strip()
+    user = session.exec(select(User).where(User.username == clean_username)).first()
     if not user:
         return None
     if not verify_password(password, user.hashed_password):

--- a/kartoteka_web/routes/users.py
+++ b/kartoteka_web/routes/users.py
@@ -20,14 +20,33 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 @router.post("/register", response_model=schemas.UserRead, status_code=status.HTTP_201_CREATED)
 def register_user(user_in: schemas.UserCreate, session: Session = Depends(get_session)):
-    existing = session.exec(select(models.User).where(models.User.username == user_in.username)).first()
+    clean_username = user_in.username.strip()
+    if not clean_username:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username cannot be empty",
+        )
+
+    clean_email = None
+    if user_in.email is not None:
+        stripped_email = user_in.email.strip()
+        clean_email = stripped_email or None
+
+    clean_avatar_url = None
+    if user_in.avatar_url is not None:
+        stripped_avatar = user_in.avatar_url.strip()
+        clean_avatar_url = stripped_avatar or None
+
+    existing = session.exec(
+        select(models.User).where(models.User.username == clean_username)
+    ).first()
     if existing:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already registered")
 
     user = models.User(
-        username=user_in.username,
-        email=user_in.email,
-        avatar_url=user_in.avatar_url,
+        username=clean_username,
+        email=clean_email,
+        avatar_url=clean_avatar_url,
         hashed_password=get_password_hash(user_in.password),
     )
     session.add(user)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_functions = test_* register_and_login

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -65,7 +65,12 @@ def api_client(db_path, monkeypatch):
         yield client, prices, server
 
 
-def register_and_login(client: TestClient, username: str = "ash", password: str = "pikachu") -> str:
+def perform_register_and_login(
+    client: TestClient,
+    username: str = "ash",
+    password: str = "pikachu",
+    login_username: str | None = None,
+) -> str:
     res = client.post(
         "/users/register",
         json={"username": username, "password": password},
@@ -74,7 +79,7 @@ def register_and_login(client: TestClient, username: str = "ash", password: str 
 
     res = client.post(
         "/users/login",
-        json={"username": username, "password": password},
+        json={"username": login_username or username, "password": password},
     )
     assert res.status_code == 200
     token = res.json()["access_token"]
@@ -82,9 +87,30 @@ def register_and_login(client: TestClient, username: str = "ash", password: str 
     return token
 
 
+def register_and_login(api_client):
+    client, _prices, _server = api_client
+    registration_username = "   ash   "
+    login_username = "\tash\n"
+
+    res = client.post(
+        "/users/register",
+        json={"username": registration_username, "password": "pikachu"},
+    )
+    assert res.status_code == 201, res.text
+    payload = res.json()
+    assert payload["username"] == "ash"
+
+    res = client.post(
+        "/users/login",
+        json={"username": login_username, "password": "pikachu"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["access_token"]
+
+
 def test_collection_crud_and_summary(api_client):
     client, prices, server = api_client
-    token = register_and_login(client)
+    token = perform_register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
 
     from kartoteka_web import database, models
@@ -152,7 +178,7 @@ def test_requires_authentication(api_client):
     res = client.get("/cards/")
     assert res.status_code == 401
 
-    token = register_and_login(client, username="misty", password="starmie")
+    token = perform_register_and_login(client, username="misty", password="starmie")
     headers = {"Authorization": f"Bearer {token}"}
     res = client.post(
         "/cards/",
@@ -205,7 +231,7 @@ def test_card_info_allows_anonymous_access(api_client):
 
 def test_card_info_authenticated_features_intact(api_client):
     client, _prices, _ = api_client
-    token = register_and_login(client, username="brock", password="onix")
+    token = perform_register_and_login(client, username="brock", password="onix")
     headers = {"Authorization": f"Bearer {token}"}
 
     from kartoteka_web import catalogue, database
@@ -274,7 +300,7 @@ def test_card_info_authenticated_features_intact(api_client):
 
 def test_user_profile_settings(api_client):
     client, _prices, _ = api_client
-    token = register_and_login(client, username="leaf", password="bulbasaur")
+    token = perform_register_and_login(client, username="leaf", password="bulbasaur")
     headers = {"Authorization": f"Bearer {token}"}
 
     res = client.patch(
@@ -316,7 +342,7 @@ def test_card_search_endpoint(api_client, monkeypatch):
     res = client.get("/cards/search", params={"name": "Pikachu", "number": "25"})
     assert res.status_code == 401
 
-    token = register_and_login(client, username="brock", password="onix")
+    token = perform_register_and_login(client, username="brock", password="onix")
     headers = {"Authorization": f"Bearer {token}"}
 
     sample = [
@@ -358,7 +384,7 @@ def test_card_search_endpoint(api_client, monkeypatch):
 
 def test_card_search_query_parameter(api_client):
     client, _prices, _ = api_client
-    token = register_and_login(client, username="gio", password="charisma")
+    token = perform_register_and_login(client, username="gio", password="charisma")
     headers = {"Authorization": f"Bearer {token}"}
 
     from kartoteka import pricing
@@ -390,7 +416,7 @@ def test_card_search_query_parameter(api_client):
 
 def test_card_info_endpoint(api_client, monkeypatch):
     client, prices, _ = api_client
-    token = register_and_login(client, username="gary", password="eevee")
+    token = perform_register_and_login(client, username="gary", password="eevee")
     headers = {"Authorization": f"Bearer {token}"}
 
     prices["value"] = 19.75
@@ -459,7 +485,7 @@ def test_card_info_endpoint(api_client, monkeypatch):
 
 def test_card_info_related_by_character(api_client):
     client, _prices, _ = api_client
-    token = register_and_login(client, username="brock", password="onix")
+    token = perform_register_and_login(client, username="brock", password="onix")
     headers = {"Authorization": f"Bearer {token}"}
 
     from kartoteka import pricing
@@ -523,7 +549,7 @@ def test_card_info_related_by_character(api_client):
 
 def test_card_detail_page_prefills_dataset(api_client):
     client, _prices, _server = api_client
-    token = register_and_login(client)
+    token = perform_register_and_login(client)
     headers = {"Authorization": f"Bearer {token}"}
 
     from kartoteka import pricing
@@ -576,7 +602,7 @@ def test_card_detail_page_prefills_dataset(api_client):
 
 def test_card_info_regression_for_set_slug(api_client, monkeypatch):
     client, prices, _server = api_client
-    token = register_and_login(client, username="mew", password="psyduck")
+    token = perform_register_and_login(client, username="mew", password="psyduck")
     headers = {"Authorization": f"Bearer {token}"}
 
     prices["value"] = 42.0
@@ -647,7 +673,7 @@ def test_card_info_regression_for_set_slug(api_client, monkeypatch):
 
 def test_card_detail_page_missing_catalogue_returns_404(api_client):
     client, _prices, _server = api_client
-    token = register_and_login(client, username="misty", password="staryu")
+    token = perform_register_and_login(client, username="misty", password="staryu")
     headers = {"Authorization": f"Bearer {token}"}
 
     res = client.get("/cards/base/25", headers=headers)


### PR DESCRIPTION
## Summary
- trim whitespace from usernames, emails, and avatar URLs during registration and login
- ensure authentication queries normalized usernames to keep login behavior consistent
- add a regression test for whitespace-padded credentials and configure pytest to collect it

## Testing
- pytest tests/web/test_api.py::register_and_login
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da51c0daa4832fbe5918eae7f3f088