### PR TITLE
Add persistent auth token storage and routing guard

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Platform } from 'react-native';
 import { useEffect, useState } from 'react';
 import { setupErrorLogging } from '../utils/errorLogger';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { AuthProvider } from '../context/AuthContext';
 
 const STORAGE_KEY = 'emulated_device';
 
@@ -46,6 +47,7 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
+      <AuthProvider>
         <GestureHandlerRootView style={{ flex: 1 }}>
           <Stack
             screenOptions={{
@@ -54,6 +56,7 @@ export default function RootLayout() {
             }}
           />
         </GestureHandlerRootView>
+      </AuthProvider>
     </SafeAreaProvider>
   );
 }

--- a/app/app/auth.tsx
+++ b/app/app/auth.tsx
@@ -5,7 +5,7 @@ import { commonStyles, colors } from '../styles/commonStyles';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import Icon from '../components/Icon';
-import { storeAuthToken } from '../utils/authToken';
+import { useAuth } from '../context/AuthContext';
 
 export default function AuthScreen() {
   const [isLogin, setIsLogin] = useState(true);
@@ -13,6 +13,8 @@ export default function AuthScreen() {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [username, setUsername] = useState('');
+
+  const { signIn } = useAuth();
 
   const handleAuth = async () => {
     const trimmedEmail = email.trim();
@@ -73,14 +75,14 @@ export default function AuthScreen() {
           return;
         }
 
-        await storeAuthToken(token);
+        await signIn(token);
         router.replace('/home');
         return;
       }
 
       const registerToken = responseData?.access_token;
       if (registerToken) {
-        await storeAuthToken(registerToken);
+        await signIn(registerToken);
         router.replace('/home');
         return;
       }
@@ -119,7 +121,7 @@ export default function AuthScreen() {
           return;
         }
 
-        await storeAuthToken(token);
+        await signIn(token);
         router.replace('/home');
       } catch (loginError) {
         console.error('Automatic login error:', loginError);

--- a/app/app/index.tsx
+++ b/app/app/index.tsx
@@ -1,13 +1,21 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import { Redirect } from 'expo-router';
+import { useAuth } from '../context/AuthContext';
 
 export default function Index() {
-  // Check if user is logged in (for now, we'll redirect to auth)
-  const [isLoggedIn] = useState(false);
-  
+  const { isLoggedIn, isLoading, refreshAuthState } = useAuth();
+
+  useEffect(() => {
+    refreshAuthState();
+  }, [refreshAuthState]);
+
+  if (isLoading) {
+    return null;
+  }
+
   if (isLoggedIn) {
     return <Redirect href="/home" />;
   }
-  
+
   return <Redirect href="/auth" />;
 }

--- a/app/app/profile.tsx
+++ b/app/app/profile.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import Icon from '../components/Icon';
 import SimpleBottomSheet from '../components/BottomSheet';
+import { useAuth } from '../context/AuthContext';
 
 export default function ProfileScreen() {
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
@@ -21,13 +22,22 @@ export default function ProfileScreen() {
     walletBalance: 1250,
   };
 
+  const { signOut } = useAuth();
+
   const handleLogout = () => {
     Alert.alert(
       'Logout',
       'Are you sure you want to logout?',
       [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Logout', style: 'destructive', onPress: () => router.replace('/auth') },
+        {
+          text: 'Logout',
+          style: 'destructive',
+          onPress: async () => {
+            await signOut();
+            router.replace('/auth');
+          },
+        },
       ]
     );
   };

--- a/app/app/search.tsx
+++ b/app/app/search.tsx
@@ -14,7 +14,7 @@ import { commonStyles, colors } from '../styles/commonStyles';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import Icon from '../components/Icon';
-import { getAuthToken } from '../utils/authToken';
+import { useAuth } from '../context/AuthContext';
 
 type CardSummary = {
   id: string;
@@ -63,6 +63,8 @@ export default function SearchScreen() {
     { id: 'number-desc', name: 'Numer malejąco' },
   ];
 
+  const { token, isLoading: isAuthLoading } = useAuth();
+
   useEffect(() => {
     const trimmedQuery = searchQuery.trim();
 
@@ -78,12 +80,15 @@ export default function SearchScreen() {
     let isCancelled = false;
     const controller = new AbortController();
     const debounceTimer = setTimeout(async () => {
+      if (isAuthLoading) {
+        return;
+      }
+
       setIsLoading(true);
       setErrorMessage(null);
       setInfoMessage(null);
       setHasSearched(true);
 
-      const token = getAuthToken();
       if (!token) {
         if (!isCancelled) {
           setErrorMessage('Brak tokena autoryzacyjnego. Zaloguj się ponownie.');
@@ -182,7 +187,7 @@ export default function SearchScreen() {
       controller.abort();
       clearTimeout(debounceTimer);
     };
-  }, [searchQuery]);
+  }, [isAuthLoading, searchQuery, token]);
 
   const filteredCards = useMemo(() => {
     return cards.filter((card) => {

--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -1,0 +1,93 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { router, usePathname } from 'expo-router';
+import { clearAuthToken, getAuthToken, storeAuthToken } from '../utils/authToken';
+
+export type AuthContextValue = {
+  token: string | null;
+  isLoggedIn: boolean;
+  isLoading: boolean;
+  signIn: (newToken: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  refreshAuthState: () => Promise<string | null>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const pathname = usePathname();
+
+  const refreshAuthState = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const storedToken = await getAuthToken({ forceRefresh: true });
+      setToken(storedToken);
+      return storedToken;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshAuthState();
+  }, [refreshAuthState]);
+
+  const signIn = useCallback(async (newToken: string) => {
+    await storeAuthToken(newToken);
+    setToken(newToken);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await clearAuthToken();
+    setToken(null);
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    if (!pathname) {
+      return;
+    }
+
+    const isAuthRoute = pathname.startsWith('/auth');
+
+    if (!token && !isAuthRoute) {
+      router.replace('/auth');
+    } else if (token && isAuthRoute) {
+      router.replace('/home');
+    }
+  }, [isLoading, pathname, token]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      token,
+      isLoggedIn: Boolean(token),
+      isLoading,
+      signIn,
+      signOut,
+      refreshAuthState,
+    }),
+    [isLoading, refreshAuthState, signIn, signOut, token]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,7 @@
     "expo-linear-gradient": "^15.0.6",
     "expo-linking": "^8.0.7",
     "expo-router": "^6.0.0",
+    "expo-secure-store": "^13.0.3",
     "expo-splash-screen": "^31.0.8",
     "expo-status-bar": "~3.0.7",
     "expo-symbols": "^1.0.6",

--- a/app/utils/authToken.ts
+++ b/app/utils/authToken.ts
@@ -1,7 +1,94 @@
-let token: string | null = null;
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
 
-export const storeAuthToken = async (newToken: string): Promise<void> => {
-  token = newToken;
+const TOKEN_STORAGE_KEY = 'auth_token';
+
+let cachedToken: string | null | undefined = undefined;
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
 };
 
-export const getAuthToken = () => token;
+const getWebStorage = (): StorageLike | null => {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+
+  const candidate = (globalThis as Record<string, unknown>).localStorage;
+  if (!candidate) {
+    return null;
+  }
+
+  return candidate as StorageLike;
+};
+
+const readTokenFromStorage = async (): Promise<string | null> => {
+  if (Platform.OS === 'web') {
+    const storage = getWebStorage();
+    if (!storage) {
+      return null;
+    }
+
+    const storedValue = storage.getItem(TOKEN_STORAGE_KEY);
+    return storedValue ?? null;
+  }
+
+  const isAvailable = await SecureStore.isAvailableAsync();
+  if (!isAvailable) {
+    return null;
+  }
+
+  const storedValue = await SecureStore.getItemAsync(TOKEN_STORAGE_KEY);
+  return storedValue ?? null;
+};
+
+const persistToken = async (token: string | null) => {
+  if (Platform.OS === 'web') {
+    const storage = getWebStorage();
+    if (!storage) {
+      return;
+    }
+
+    if (token === null) {
+      storage.removeItem(TOKEN_STORAGE_KEY);
+    } else {
+      storage.setItem(TOKEN_STORAGE_KEY, token);
+    }
+    return;
+  }
+
+  const isAvailable = await SecureStore.isAvailableAsync();
+  if (!isAvailable) {
+    return;
+  }
+
+  if (token === null) {
+    await SecureStore.deleteItemAsync(TOKEN_STORAGE_KEY);
+  } else {
+    await SecureStore.setItemAsync(TOKEN_STORAGE_KEY, token);
+  }
+};
+
+export const storeAuthToken = async (newToken: string): Promise<void> => {
+  cachedToken = newToken;
+  await persistToken(newToken);
+};
+
+export const getAuthToken = async (
+  options: { forceRefresh?: boolean } = {}
+): Promise<string | null> => {
+  if (!options.forceRefresh && cachedToken !== undefined) {
+    return cachedToken;
+  }
+
+  const storedToken = await readTokenFromStorage();
+  cachedToken = storedToken;
+  return storedToken;
+};
+
+export const clearAuthToken = async (): Promise<void> => {
+  cachedToken = null;
+  await persistToken(null);
+};


### PR DESCRIPTION
## Summary
- store the auth token in persistent secure storage with a web fallback so it survives restarts
- introduce an AuthContext provider that restores tokens on launch, exposes sign-in/sign-out helpers, and guards protected routes
- update login, profile, index, and search screens to consume the shared auth state and react to token changes

## Testing
- npm run lint *(fails: eslint-plugin-import resolver misconfiguration in project template)*

------
https://chatgpt.com/codex/tasks/task_e_68da7e63a7e8832f97ab1209b403a41c