### PR TITLE
Remove fuzzy catalogue fallback

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -19,7 +19,7 @@ from kartoteka import pricing
 from kartoteka_web import catalogue
 
 try:  # pragma: no cover - optional dependency
-    from rapidfuzz import fuzz, process
+    from rapidfuzz import fuzz
 except ModuleNotFoundError:  # pragma: no cover - fallback for tests without rapidfuzz
     import difflib
 
@@ -33,31 +33,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for tests without rap
             return difflib.SequenceMatcher(None, a or "", b or "").ratio() * 100
 
     fuzz = _FuzzFallback()  # type: ignore[assignment]
-
-    class _ProcessFallback:
-        @staticmethod
-        def extract(
-            query: str,
-            choices,
-            *,
-            limit: int = 5,
-            scorer=None,
-            processor=None,
-        ):
-            scorer = scorer or _FuzzFallback.WRatio
-            if isinstance(choices, dict):
-                iterable = choices.items()
-            else:  # pragma: no cover - defensive branch for unexpected inputs
-                iterable = enumerate(choices)
-            results = []
-            for key, value in iterable:
-                candidate = processor(value) if processor else value
-                score = float(scorer(query, candidate))
-                results.append((value, score, key))
-            results.sort(key=lambda item: item[1], reverse=True)
-            return results[:limit]
-
-    process = _ProcessFallback()  # type: ignore[assignment]
 
 router = APIRouter(prefix="/cards", tags=["cards"])
 
@@ -296,7 +271,6 @@ def _search_catalogue(
     records: list[models.CardRecord] = []
     name_filter_applied = False
     count_filters: list[Any] = []
-    fuzzy_priorities: dict[int, float] = {}
 
     if name_norm:
         match_query = _build_fts_match_query(name_norm, query_norm, set_norm)
@@ -328,53 +302,6 @@ def _search_catalogue(
         count_filters = filters
         records = session.exec(fallback_stmt.limit(fetch_limit)).all()
 
-    if not records and name_norm:
-        fuzzy_stmt = select(models.CardRecord)
-        if base_filters:
-            fuzzy_stmt = fuzzy_stmt.where(*base_filters)
-        fuzzy_candidates = session.exec(fuzzy_stmt.limit(fetch_limit)).all()
-        if not fuzzy_candidates and not base_filters:
-            fuzzy_candidates = session.exec(select(models.CardRecord).limit(fetch_limit)).all()
-
-        raw_query = (query or "").strip() or search_term
-        if raw_query and fuzzy_candidates:
-            choice_labels: dict[int, str] = {}
-            candidate_lookup: dict[int, models.CardRecord] = {}
-            for record in fuzzy_candidates:
-                parts = [
-                    record.name or "",
-                    record.number_display or record.number or "",
-                    record.set_name or "",
-                ]
-                label = " ".join(part for part in parts if part).strip() or (record.name or "")
-                if not label:
-                    continue
-                choice_labels[record.id] = label
-                candidate_lookup[record.id] = record
-
-            if choice_labels:
-                extracted = process.extract(
-                    raw_query,
-                    choice_labels,
-                    processor=None,
-                    scorer=fuzz.WRatio,
-                    limit=min(fetch_limit, len(choice_labels)),
-                )
-                ordered_records: list[models.CardRecord] = []
-                for _label, score, record_id in extracted:
-                    record = candidate_lookup.get(record_id)
-                    if record and record not in ordered_records:
-                        ordered_records.append(record)
-                        fuzzy_priorities[record.id] = float(score)
-                if ordered_records:
-                    records = ordered_records
-                    record_ids = [rec.id for rec in ordered_records]
-                    id_filter = models.CardRecord.id.in_(record_ids)
-                    if base_filters:
-                        count_filters = [*base_filters, id_filter]
-                    else:
-                        count_filters = [id_filter]
-
     if not count_filters:
         count_filters = base_filters
 
@@ -389,26 +316,23 @@ def _search_catalogue(
     scored = []
     best_entry: tuple[float, models.CardRecord] | None = None
     for record in records:
-        base_score = _score_card_record(
+        final_score = _score_card_record(
             record,
             query_text=query_norm or search_term,
             number_clean=number_clean,
             set_norm=set_norm,
             total_clean=total_clean,
         )
-        fuzzy_score = fuzzy_priorities.get(record.id, 0.0)
-        final_score = max(base_score, fuzzy_score)
         if best_entry is None or final_score > best_entry[0]:
             best_entry = (final_score, record)
-        scored.append((final_score, fuzzy_score, record))
+        scored.append((final_score, record))
 
     scored.sort(
         key=lambda item: (
             -item[0],
-            -item[1],
-            item[2].set_name or "",
-            item[2].number or "",
-            item[2].name or "",
+            item[1].set_name or "",
+            item[1].number or "",
+            item[1].name or "",
         )
     )
     threshold = SCORE_THRESHOLD
@@ -416,7 +340,7 @@ def _search_catalogue(
     filtered_total = len(filtered)
     paginated = [
         record
-        for _score, _fuzzy, record in filtered[offset : offset + max(1, limit)]
+        for _score, record in filtered[offset : offset + max(1, limit)]
     ]
     if threshold and total_count:
         total_count = min(total_count, filtered_total)

--- a/tests/test_card_search_ft.py
+++ b/tests/test_card_search_ft.py
@@ -145,21 +145,12 @@ def test_card_search_uses_fts(monkeypatch, search_db):
     assert fts_queries <= fallback_queries
 
 
-def test_card_search_fuzzy_misspelling(monkeypatch, search_db):
+def test_card_search_strict_misspelling(monkeypatch, search_db):
     monkeypatch.setattr(
         "kartoteka_web.utils.images.cache_card_images", lambda payload, **_: payload
     )
 
     from kartoteka_web.routes import cards
-
-    original_extract = cards.process.extract
-    call_counter = {"count": 0}
-
-    def tracking_extract(*args, **kwargs):
-        call_counter["count"] += 1
-        return original_extract(*args, **kwargs)
-
-    monkeypatch.setattr(cards.process, "extract", tracking_extract)
 
     with Session(search_db.engine) as session:
         _seed_char_family(session)
@@ -173,8 +164,5 @@ def test_card_search_fuzzy_misspelling(monkeypatch, search_db):
             limit=5,
         )
 
-    assert call_counter["count"] >= 1
-    assert total_count >= 1
-    assert results
-    assert results[0].name == "Charizard"
-    assert "Charizard" in {record.name for record in results}
+    assert total_count == 0
+    assert results == []


### PR DESCRIPTION
## Summary
- remove fuzzy matching fallback from the catalogue search route
- simplify scoring and imports after dropping fuzzy fallback logic
- update full-text search tests to expect strict matching behavior

## Testing
- pytest tests/test_card_search_ft.py

------
https://chatgpt.com/codex/tasks/task_e_68db8eb07600832f87eb9846a8fd8c9b