### PR TITLE
Simplify card search to return full result set

### DIFF
--- a/app/app/search.tsx
+++ b/app/app/search.tsx
@@ -102,7 +102,7 @@ export default function SearchScreen() {
       }
 
       try {
-        const params = new URLSearchParams({ query: trimmedQuery, page: '1', page_size: '20' });
+        const params = new URLSearchParams({ query: trimmedQuery });
         const response = await fetch(`/cards/search?${params.toString()}`, {
           headers: {
             Authorization: `Bearer ${token}`,

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -37,6 +37,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for tests without rap
 router = APIRouter(prefix="/cards", tags=["cards"])
 
 SCORE_THRESHOLD = pricing.SEARCH_SCORE_THRESHOLD
+MAX_SEARCH_RESULTS = 200
 
 CARD_NUMBER_PATTERN = re.compile(
     r"(?i)([a-z]{0,5}\d+[a-z0-9]*)(?:\s*/\s*([a-z]{0,5}\d+[a-z0-9]*))?"
@@ -247,8 +248,7 @@ def _search_catalogue(
     number: str | None = None,
     total: str | None = None,
     set_name: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int | None = None,
 ) -> tuple[list["models.CardRecord"], int, "models.CardRecord" | None]:
     search_term = name or query
     name_norm = _normalise_search_value(search_term)
@@ -256,6 +256,10 @@ def _search_catalogue(
     total_clean = _sanitise_optional_number(total)
     set_norm = _normalise_search_value(set_name) if set_name else ""
     query_norm = pricing.normalize(query or search_term or "", keep_spaces=True)
+
+    result_cap = MAX_SEARCH_RESULTS
+    if limit is not None and limit > 0:
+        result_cap = max(1, min(limit, MAX_SEARCH_RESULTS))
 
     base_filters: list[Any] = []
     if number_clean:
@@ -265,7 +269,7 @@ def _search_catalogue(
     if set_norm:
         base_filters.append(models.CardRecord.set_name_normalized.contains(set_norm))
 
-    fetch_limit = max(offset + limit, limit * 4, 100)
+    fetch_limit = max(result_cap * 4, result_cap, 100)
     fetch_limit = max(1, min(fetch_limit, 500))
 
     records: list[models.CardRecord] = []
@@ -300,6 +304,13 @@ def _search_catalogue(
         filters = [*base_filters, models.CardRecord.name_normalized.contains(name_norm)]
         fallback_stmt = select(models.CardRecord).where(*filters)
         count_filters = filters
+        records = session.exec(fallback_stmt.limit(fetch_limit)).all()
+
+    if not records:
+        fallback_stmt = select(models.CardRecord)
+        if base_filters:
+            fallback_stmt = fallback_stmt.where(*base_filters)
+        count_filters = base_filters
         records = session.exec(fallback_stmt.limit(fetch_limit)).all()
 
     if not count_filters:
@@ -338,15 +349,13 @@ def _search_catalogue(
     threshold = SCORE_THRESHOLD
     filtered = [entry for entry in scored if entry[0] >= threshold]
     filtered_total = len(filtered)
-    paginated = [
-        record
-        for _score, record in filtered[offset : offset + max(1, limit)]
-    ]
+    visible = [record for _score, record in filtered[:result_cap]]
     if threshold and total_count:
         total_count = min(total_count, filtered_total)
     else:
         total_count = filtered_total
-    return paginated, total_count, best_entry[1] if best_entry else None
+    total_count = min(total_count, result_cap)
+    return visible, total_count, best_entry[1] if best_entry else None
 
 
 def _select_best_record(
@@ -766,8 +775,6 @@ def search_cards_endpoint(
     number: str | None = None,
     total: str | None = None,
     set_name: str | None = None,
-    page: int = 1,
-    page_size: int = 20,
     limit: int | None = None,
     current_user: models.User = Depends(get_current_user),
     session: Session = Depends(get_session),
@@ -783,38 +790,17 @@ def search_cards_endpoint(
     name_value = (name or parsed_name or "").strip()
     number_value = number or parsed_number
     total_value = total or parsed_total
+    result_cap = MAX_SEARCH_RESULTS
     if limit is not None and limit > 0:
-        page_size = limit
-
-    cleaned_page_size = max(1, min(page_size, 200))
-    requested_page = max(1, page)
+        result_cap = max(1, min(limit, MAX_SEARCH_RESULTS))
     search_query = query or _compose_query(name_value, number_value, set_name)
     if not (search_query or name_value):
         return schemas.CardSearchResponse(
             items=[],
             total=0,
-            page=1,
-            page_size=cleaned_page_size,
         )
     if not name_value:
         name_value = search_query
-
-    def _run_search(
-        page_index: int,
-    ) -> tuple[list[models.CardRecord], int, int, str | None]:
-        safe_page = max(1, page_index)
-        page_offset = (safe_page - 1) * cleaned_page_size
-        results, total_count, suggestion = _search_catalogue(
-            session,
-            query=search_query,
-            name=name_value,
-            number=number_value,
-            total=total_value,
-            set_name=set_name,
-            limit=cleaned_page_size,
-            offset=page_offset,
-        )
-        return results, total_count, safe_page, _suggested_query_label(suggestion)
 
     def _apply_assets(records: Sequence[models.CardRecord]) -> None:
         updated = False
@@ -823,18 +809,25 @@ def search_cards_endpoint(
         if updated:
             session.commit()
 
-    records, total_count, resolved_page, suggestion_name = _run_search(requested_page)
+    records, total_count, suggestion_record = _search_catalogue(
+        session,
+        query=search_query,
+        name=name_value,
+        number=number_value,
+        total=total_value,
+        set_name=set_name,
+        limit=result_cap,
+    )
+    suggestion_name = _suggested_query_label(suggestion_record)
     _apply_assets(records)
 
     if not records:
-        requested_offset = (resolved_page - 1) * cleaned_page_size
-        remote_limit = max(cleaned_page_size, requested_offset + cleaned_page_size)
         api_results = pricing.search_cards(
             name=name_value,
             number=number_value,
             total=total_value,
             set_name=set_name,
-            limit=remote_limit,
+            limit=result_cap,
         )
         stored = False
         cached_records: list[models.CardRecord] = []
@@ -848,34 +841,33 @@ def search_cards_endpoint(
                 stored = True
         if stored:
             session.commit()
-            records, total_count, resolved_page, suggestion_name = _run_search(resolved_page)
+            records, total_count, suggestion_record = _search_catalogue(
+                session,
+                query=search_query,
+                name=name_value,
+                number=number_value,
+                total=total_value,
+                set_name=set_name,
+                limit=result_cap,
+            )
+            suggestion_name = _suggested_query_label(suggestion_record)
             _apply_assets(records)
         elif cached_records:
-            records = cached_records[
-                requested_offset : requested_offset + cleaned_page_size
-            ]
-            total_count = max(total_count, len(cached_records))
+            records = cached_records[:result_cap]
+            total_count = min(len(cached_records), result_cap)
+            suggestion_name = _suggested_query_label(cached_records[0])
             _apply_assets(records)
         else:
             records = []
-            total_count = max(total_count, len(cached_records))
-
-        total_count = max(total_count, len(cached_records))
-
-    total_pages = (total_count + cleaned_page_size - 1) // cleaned_page_size if total_count else 0
-    if total_pages and resolved_page > total_pages:
-        resolved_page = max(1, total_pages)
-        records, total_count, resolved_page, suggestion_name = _run_search(resolved_page)
-        _apply_assets(records)
-    elif total_count == 0:
-        resolved_page = 1
+            total_count = 0
+            if not suggestion_name:
+                suggestion_name = _suggested_query_label(suggestion_record)
 
     items = [_record_to_search_schema(record) for record in records]
+    total_value = len(items)
     return schemas.CardSearchResponse(
         items=items,
-        total=total_count,
-        page=resolved_page,
-        page_size=cleaned_page_size,
+        total=total_value,
         suggested_query=suggestion_name,
     )
 

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -73,8 +73,6 @@ class CardSearchResult(SQLModel):
 class CardSearchResponse(SQLModel):
     items: List[CardSearchResult] = Field(default_factory=list)
     total: int = 0
-    page: int = 1
-    page_size: int = 0
     suggested_query: Optional[str] = None
 
 

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1280,11 +1280,6 @@ function setupCardSearch(form) {
   const resultsContainer = document.getElementById("card-search-results");
   const summary = document.getElementById("card-search-summary");
   const statusMessage = document.getElementById("card-search-empty");
-  const pagination = document.getElementById("card-search-pagination");
-  const pageInfo = document.getElementById("card-search-page-info");
-  const prevButton = pagination?.querySelector('[data-page-action="prev"]') ?? null;
-  const nextButton = pagination?.querySelector('[data-page-action="next"]') ?? null;
-  const pageList = pagination?.querySelector('[data-page-list]') ?? null;
   const sortSelect = document.getElementById("card-search-sort");
   const hintElement = document.getElementById("card-search-hint");
 
@@ -1302,8 +1297,6 @@ function setupCardSearch(form) {
     items: [],
     total: 0,
     sortMode: sortSelect?.value || "relevance",
-    currentPage: 1,
-    pageSize: 20,
     suggestedQuery: "",
     lastQuery: "",
   };
@@ -1447,80 +1440,6 @@ function setupCardSearch(form) {
     }
   };
 
-  const getTotalPages = (total = state.total) => {
-    const safeTotal = Number.isFinite(total) ? Math.max(0, total) : Math.max(0, state.total);
-    return safeTotal > 0 ? Math.ceil(safeTotal / state.pageSize) : 1;
-  };
-
-  const renderPageButtons = (totalPages) => {
-    if (!pageList) {
-      return;
-    }
-    pageList.innerHTML = "";
-    if (totalPages <= 0) {
-      return;
-    }
-    const fragment = document.createDocumentFragment();
-    for (let page = 1; page <= totalPages; page += 1) {
-      const button = document.createElement("button");
-      button.type = "button";
-      button.className = "card-search-page-number";
-      button.dataset.page = String(page);
-      button.textContent = String(page);
-      if (page === state.currentPage) {
-        button.classList.add("is-active");
-        button.setAttribute("aria-current", "page");
-        button.disabled = true;
-      }
-      fragment.appendChild(button);
-    }
-    pageList.appendChild(fragment);
-  };
-
-  const updatePaginationControls = (total = state.total) => {
-    if (!pagination || !pageInfo) {
-      return;
-    }
-    const safeTotal = Number.isFinite(total) ? Math.max(0, total) : Math.max(0, state.total);
-    if (!safeTotal) {
-      pagination.hidden = true;
-      pageInfo.textContent = "";
-      if (prevButton) prevButton.disabled = true;
-      if (nextButton) nextButton.disabled = true;
-      if (pageList) {
-        pageList.innerHTML = "";
-      }
-      return;
-    }
-    const totalPages = getTotalPages(safeTotal);
-    if (state.currentPage > totalPages) {
-      state.currentPage = totalPages;
-    }
-    pagination.hidden = false;
-    pageInfo.textContent = `Strona ${state.currentPage} z ${totalPages}`;
-    if (prevButton) {
-      prevButton.disabled = state.currentPage <= 1;
-    }
-    if (nextButton) {
-      nextButton.disabled = state.currentPage >= totalPages;
-    }
-    renderPageButtons(totalPages);
-  };
-
-  const goToPage = (page) => {
-    const totalPages = getTotalPages();
-    const nextPage = Math.min(Math.max(1, page), totalPages);
-    if (nextPage === state.currentPage) {
-      renderResults();
-      return Promise.resolve(state.items);
-    }
-    state.currentPage = nextPage;
-    return loadResults(nextPage).catch((error) => {
-      console.error(error);
-      return [];
-    });
-  };
-
   const createResultItem = (card) => {
     const item = document.createElement("article");
     item.className = "card-search-item";
@@ -1630,7 +1549,6 @@ function setupCardSearch(form) {
       resultsContainer.appendChild(fragment);
     }
 
-    updatePaginationControls(state.total);
     updateSelectionHighlight();
   };
 
@@ -1659,12 +1577,11 @@ function setupCardSearch(form) {
     updateSearchHint();
   };
 
-  const loadResults = async (page = 1) => {
+  const loadResults = async () => {
     const query = queryInput.value.trim();
     if (!query) {
       state.items = [];
       state.total = 0;
-      state.currentPage = 1;
       state.lastQuery = "";
       state.suggestedQuery = "";
       updateSummary(0);
@@ -1674,20 +1591,18 @@ function setupCardSearch(form) {
       if (resultsSection) {
         resultsSection.hidden = true;
       }
-      updatePaginationControls(0);
       updateSortDisabled();
       updateSearchHint();
       return [];
     }
 
+    clearSelection();
+
     const params = new URLSearchParams({
       query,
-      page: String(Math.max(1, page)),
-      page_size: String(state.pageSize),
     });
 
     const currentRequest = ++requestId;
-    state.currentPage = Math.max(1, page);
     state.sortMode = sortSelect?.value || state.sortMode || "relevance";
     if (resultsSection) {
       resultsSection.hidden = false;
@@ -1696,7 +1611,6 @@ function setupCardSearch(form) {
     updateStatus("Wyszukiwanie kart...", "loading");
     resultsContainer.innerHTML = "";
     resultsContainer.hidden = true;
-    updatePaginationControls(0);
     updateSortDisabled();
 
     try {
@@ -1709,15 +1623,6 @@ function setupCardSearch(form) {
       const responseTotal = Number.isFinite(payload?.total)
         ? Math.max(0, Number(payload.total))
         : responseItems.length;
-      const responsePageSize = Number.isFinite(payload?.page_size)
-        ? Math.max(1, Number(payload.page_size))
-        : state.pageSize;
-      const responsePage = Number.isFinite(payload?.page)
-        ? Math.max(1, Number(payload.page))
-        : state.currentPage;
-
-      state.pageSize = responsePageSize;
-      state.currentPage = responsePage;
       state.items = responseItems;
       state.total = responseTotal;
       state.lastQuery = query;
@@ -1737,8 +1642,6 @@ function setupCardSearch(form) {
       updateSummary(state.total);
       if (!state.total) {
         updateStatus("Nie znaleziono kart dla podanych kryteriów.");
-      } else if (!state.items.length) {
-        updateStatus("Brak wyników na tej stronie.", "info");
       } else {
         updateStatus("");
       }
@@ -1767,7 +1670,7 @@ function setupCardSearch(form) {
 
   const search = () => {
     clearSelection();
-    return loadResults(1);
+    return loadResults();
   };
 
   const handleInputChange = () => {
@@ -1780,50 +1683,10 @@ function setupCardSearch(form) {
 
   sortSelect?.addEventListener("change", () => {
     state.sortMode = sortSelect.value || "relevance";
-    state.currentPage = 1;
     renderResults();
   });
 
-  pagination?.addEventListener("click", (event) => {
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) {
-      return;
-    }
-    const button = target.closest("[data-page-action]");
-    if (!(button instanceof HTMLElement)) {
-      return;
-    }
-    const action = button.dataset.pageAction;
-    if (!action) {
-      return;
-    }
-    event.preventDefault();
-    if (action === "prev") {
-      void goToPage(state.currentPage - 1);
-    } else if (action === "next") {
-      void goToPage(state.currentPage + 1);
-    }
-  });
-
-  pageList?.addEventListener("click", (event) => {
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) {
-      return;
-    }
-    const button = target.closest(".card-search-page-number");
-    if (!(button instanceof HTMLElement)) {
-      return;
-    }
-    const page = Number.parseInt(button.dataset.page || "", 10);
-    if (!Number.isFinite(page)) {
-      return;
-    }
-    event.preventDefault();
-    void goToPage(page);
-  });
-
   updateSortDisabled();
-  updatePaginationControls(0);
 
   const api = {
     getSelectedCard: () => selectedCard,
@@ -1834,7 +1697,6 @@ function setupCardSearch(form) {
       clearSelection();
       state.items = [];
       state.total = 0;
-      state.currentPage = 1;
       state.lastQuery = "";
       state.suggestedQuery = "";
       updateSummary(0);
@@ -1844,7 +1706,6 @@ function setupCardSearch(form) {
       if (resultsSection) {
         resultsSection.hidden = true;
       }
-      updatePaginationControls(0);
       updateSortDisabled();
       updateSearchHint();
     },

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -63,26 +63,6 @@
   <p id="card-search-summary" class="card-search-summary" hidden aria-live="polite"></p>
   <div id="card-search-results" class="card-search-results" role="list"></div>
   <p id="card-search-empty" class="card-search-empty" hidden aria-live="polite"></p>
-  <div id="card-search-pagination" class="card-search-pagination" hidden>
-    <button
-      type="button"
-      class="card-search-page-button"
-      data-page-action="prev"
-      aria-label="Poprzednia strona wyników"
-    >
-      Poprzednia
-    </button>
-    <div id="card-search-page-list" class="card-search-page-list" data-page-list></div>
-    <span id="card-search-page-info" class="card-search-page-info" aria-live="polite"></span>
-    <button
-      type="button"
-      class="card-search-page-button"
-      data-page-action="next"
-      aria-label="Następna strona wyników"
-    >
-      Następna
-    </button>
-  </div>
 </section>
 
 <div class="toast-container">

--- a/tests/test_card_search_remote_pagination.py
+++ b/tests/test_card_search_remote_pagination.py
@@ -50,7 +50,7 @@ def _build_remote_payloads(total: int) -> list[dict[str, str]]:
     return results
 
 
-def test_remote_search_fetches_second_page(monkeypatch, search_session):
+def test_remote_search_fetches_all_results(monkeypatch, search_session):
     from kartoteka_web.routes import cards
     from kartoteka_web import models
 
@@ -66,19 +66,16 @@ def test_remote_search_fetches_second_page(monkeypatch, search_session):
 
     response = cards.search_cards_endpoint(
         query="Remote Card",
-        page=2,
-        page_size=20,
+        limit=30,
         current_user=object(),
         session=search_session,
     )
 
-    assert captured_limit["value"] == 40
+    assert captured_limit["value"] == 30
     assert response.total == len(remote_payloads)
-    assert response.page == 2
-    assert response.page_size == 20
 
     returned_names = {item.name for item in response.items}
-    expected_names = {payload["name"] for payload in remote_payloads[20:]}
+    expected_names = {payload["name"] for payload in remote_payloads}
     assert returned_names == expected_names
 
     stored_records = search_session.exec(select(models.CardRecord)).all()

--- a/tests/test_card_search_suggestions.py
+++ b/tests/test_card_search_suggestions.py
@@ -56,8 +56,6 @@ def test_card_search_suggests_and_filters(monkeypatch, search_session):
 
     response = cards.search_cards_endpoint(
         query="Sharzard",
-        page=1,
-        page_size=10,
         current_user=object(),
         session=search_session,
     )

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -436,8 +436,6 @@ def test_card_search_endpoint(api_client, monkeypatch):
     assert res.status_code == 200
     results = res.json()
     assert results["total"] == 1
-    assert results["page"] == 1
-    assert results["page_size"] >= 1
     assert len(results["items"]) == 1
     item = results["items"][0]
     assert item["name"] == "Pikachu"


### PR DESCRIPTION
## Summary
- return capped full result sets from the card search endpoint and catalogue helper while preserving suggestions
- remove pagination UI/state from the web client and adjust the mobile client to request unpaginated searches
- update search response schema and tests to reflect the new payload structure

## Testing
- pytest tests/test_card_search_remote_pagination.py tests/test_card_search_suggestions.py tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68db909408d4832fba7ebd349078ced5