### PR TITLE
Add default User-Agent header for pricing API calls

### DIFF
--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -31,6 +31,20 @@ _exchange_rate_lock = threading.Lock()
 _exchange_rate_cache: dict[str, Any] = {"value": None, "date": None}
 
 
+def _apply_default_user_agent(
+    headers: dict[str, str],
+    session: Optional[requests.sessions.Session],
+) -> None:
+    """Set the default ``User-Agent`` without overriding custom headers."""
+
+    session_headers = getattr(session, "headers", None) or {}
+    user_agent = session_headers.get("User-Agent") if session_headers else None
+    if user_agent:
+        headers.setdefault("User-Agent", str(user_agent))
+    else:
+        headers.setdefault("User-Agent", "kartoteka/1.0")
+
+
 def _current_date() -> dt.date:
     return dt.datetime.now(dt.timezone.utc).date()
 
@@ -356,6 +370,7 @@ def fetch_card_price(
                 "X-RapidAPI-Key": rapidapi_key,
                 "X-RapidAPI-Host": rapidapi_host,
             }
+            _apply_default_user_agent(headers, session)
         else:
             url = "https://www.tcggo.com/api/cards/"
             params = {
@@ -363,6 +378,7 @@ def fetch_card_price(
                 "number": number_input,
                 "set": set_code,
             }
+            _apply_default_user_agent(headers, session)
 
         response = http.get(url, params=params, headers=headers, timeout=timeout)
         if response.status_code != 200:
@@ -481,6 +497,7 @@ def search_cards(
             "X-RapidAPI-Key": rapidapi_key,
             "X-RapidAPI-Host": rapidapi_host,
         }
+        _apply_default_user_agent(headers, session)
     else:
         params = {"name": name_api}
         if number_clean:
@@ -489,6 +506,7 @@ def search_cards(
             params["total"] = total_clean
         if set_name:
             params["set"] = normalize(set_name, keep_spaces=True)
+        _apply_default_user_agent(headers, session)
 
     try:
         response = http.get(url, params=params, headers=headers, timeout=timeout)

--- a/tests/test_card_search_suggestions.py
+++ b/tests/test_card_search_suggestions.py
@@ -142,3 +142,78 @@ def test_search_cards_allows_typo_without_number(monkeypatch):
     results = pricing.search_cards(name="Charoad", set_name="Base Set", limit=5)
 
     assert [item["name"] for item in results] == ["Charizard"]
+
+
+def test_search_cards_sets_default_user_agent(monkeypatch):
+    from kartoteka import pricing
+
+    class _DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {"cards": []}
+
+    captured: dict[str, dict | None] = {"headers": None}
+
+    def fake_get(_url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return _DummyResponse()
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    pricing.search_cards(name="Charizard", number="4", rapidapi_key=None, rapidapi_host=None)
+
+    assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+
+
+def test_search_cards_sets_user_agent_for_rapidapi(monkeypatch):
+    from kartoteka import pricing
+
+    class _DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {"cards": []}
+
+    captured: dict[str, dict | None] = {"headers": None}
+
+    def fake_get(_url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return _DummyResponse()
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    pricing.search_cards(
+        name="Charizard",
+        rapidapi_key="test-key",
+        rapidapi_host="example.com",
+    )
+
+    assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+    assert captured["headers"]["X-RapidAPI-Key"] == "test-key"
+    assert captured["headers"]["X-RapidAPI-Host"] == "example.com"
+
+
+def test_search_cards_respects_session_user_agent():
+    from kartoteka import pricing
+
+    class _DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {"cards": []}
+
+    class DummySession:
+        def __init__(self):
+            self.headers = {"User-Agent": "custom-agent/1.0"}
+            self.captured = None
+
+        def get(self, url, params=None, headers=None, timeout=None):
+            self.captured = headers
+            return _DummyResponse()
+
+    session = DummySession()
+
+    pricing.search_cards(name="Charizard", session=session, rapidapi_key=None, rapidapi_host=None)
+
+    assert session.captured["User-Agent"] == "custom-agent/1.0"

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,4 +1,10 @@
 import datetime as dt
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from kartoteka import pricing
 
@@ -64,3 +70,82 @@ def test_get_exchange_rate_refreshes_each_day(monkeypatch):
     current_day["value"] = dt.date(2024, 1, 2)
     refreshed = pricing.get_exchange_rate()
     assert refreshed == 4.7
+
+
+class _DummyHTTPResponse:
+    status_code = 200
+
+    def __init__(self, payload: dict | list | None = None):
+        self._payload = payload or []
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_card_price_sets_default_user_agent(monkeypatch):
+    captured: dict[str, dict | None] = {"headers": None}
+
+    def fake_get(_url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return _DummyHTTPResponse([])
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    pricing.fetch_card_price(
+        name="Charizard",
+        number="4",
+        set_name="Base",
+        rapidapi_key=None,
+        rapidapi_host=None,
+        get_rate=lambda: 4.5,
+    )
+
+    assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+
+
+def test_fetch_card_price_sets_user_agent_for_rapidapi(monkeypatch):
+    captured: dict[str, dict | None] = {"headers": None}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return _DummyHTTPResponse({"cards": []})
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    pricing.fetch_card_price(
+        name="Charizard",
+        number="4",
+        set_name="Base",
+        rapidapi_key="test-key",
+        rapidapi_host="example.com",
+        get_rate=lambda: 4.5,
+    )
+
+    assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+    assert captured["headers"]["X-RapidAPI-Key"] == "test-key"
+    assert captured["headers"]["X-RapidAPI-Host"] == "example.com"
+
+
+def test_fetch_card_price_respects_session_user_agent():
+    class DummySession:
+        def __init__(self):
+            self.headers = {"User-Agent": "custom-agent/2.0"}
+            self.captured = None
+
+        def get(self, url, params=None, headers=None, timeout=None):
+            self.captured = headers
+            return _DummyHTTPResponse([])
+
+    session = DummySession()
+
+    pricing.fetch_card_price(
+        name="Charizard",
+        number="4",
+        set_name="Base",
+        rapidapi_key=None,
+        rapidapi_host=None,
+        get_rate=lambda: 4.5,
+        session=session,
+    )
+
+    assert session.captured["User-Agent"] == "custom-agent/2.0"


### PR DESCRIPTION
## Summary
- ensure pricing requests include a default kartoteka/1.0 User-Agent without overriding custom headers
- share a helper so both RapidAPI and TCGGO code paths apply the default header consistently
- add focused unit tests covering the new header behaviour for search and pricing functions

## Testing
- pytest tests/test_pricing.py tests/test_card_search_suggestions.py

------
https://chatgpt.com/codex/tasks/task_e_68db9bb71f3c832fa81e4c525cfe95c8