### PR TITLE
Switch pricing search to official Pokémon TCG API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
+# Keep the official Pokémon TCG API key outside of version control (.env only)
+POKEMONTCG_API_KEY=
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
 # API key for OpenAI (required for card text recognition via Vision)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ browser.  To start the server locally use uvicorn:
 uvicorn server:app --reload
 ```
 
-### RapidAPI configuration
+### Pricing API configuration
 
 Price lookups use the same configuration as the desktop app.  Provide a
 RapidAPI host and key either via shell variables (`export RAPIDAPI_HOST=…`,
@@ -41,7 +41,10 @@ cp .env.example .env
 
 Both the Tkinter UI (`python main.py`) and the web server (`uvicorn
 server:app --reload`) load this file automatically on startup, so the
-credentials only need to be set once.
+credentials only need to be set once.  Card search and set synchronisation now
+use the official Pokémon TCG API.  Place the corresponding `POKEMONTCG_API_KEY`
+in your local `.env` file (or export it in the shell) and keep it outside of
+version control.
 
 By default the API stores data in `kartoteka.db` (SQLite).  Override the
 location with the `KARTOTEKA_DATABASE_URL` environment variable if you prefer

--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -21,6 +21,10 @@ HOLO_REVERSE_MULTIPLIER = float(os.getenv("HOLO_REVERSE_MULTIPLIER", "3.5"))
 RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
 RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
 DEFAULT_EXCHANGE_RATE = float(os.getenv("DEFAULT_EUR_PLN", "4.265"))
+POKEMONTCG_API_URL = os.getenv(
+    "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards"
+)
+POKEMONTCG_API_KEY = os.getenv("POKEMONTCG_API_KEY")
 # ``_score`` values in :func:`search_cards` peak around 6--7 for confident
 # matches.  Mapping them to a percentage keeps the API consistent with the
 # catalogue scoring, where fuzzy ratios already span 0--100.
@@ -462,7 +466,7 @@ def search_cards(
     session: Optional[requests.sessions.Session] = None,
     timeout: float = 10.0,
 ) -> list[dict]:
-    """Return card suggestions from the TCGGO API.
+    """Return card suggestions from the official Pokémon TCG API.
 
     The returned dictionaries contain enough data to populate the collection
     form without persisting any information yet.
@@ -472,8 +476,6 @@ def search_cards(
         return []
 
     http = session or requests
-    rapidapi_key = rapidapi_key if rapidapi_key is not None else RAPIDAPI_KEY
-    rapidapi_host = rapidapi_host if rapidapi_host is not None else RAPIDAPI_HOST
 
     number_part = ""
     number_total = ""
@@ -486,27 +488,52 @@ def search_cards(
     total_clean = sanitize_number(number_total) if number_total else ""
 
     name_api = normalize(name, keep_spaces=True)
-    params: dict[str, str] = {}
+    api_key = rapidapi_key if rapidapi_key is not None else POKEMONTCG_API_KEY
+    url = POKEMONTCG_API_URL
     headers: dict[str, str] = {}
-    url = "https://www.tcggo.com/api/cards/"
+    _apply_default_user_agent(headers, session)
+    if api_key:
+        headers["X-Api-Key"] = api_key
 
-    if rapidapi_key and rapidapi_host:
-        url = f"https://{rapidapi_host}/cards/search"
-        params = {"search": name_api}
-        headers = {
-            "X-RapidAPI-Key": rapidapi_key,
-            "X-RapidAPI-Host": rapidapi_host,
-        }
-        _apply_default_user_agent(headers, session)
-    else:
-        params = {"name": name_api}
-        if number_clean:
-            params["number"] = number_clean
-        if total_clean:
-            params["total"] = total_clean
-        if set_name:
-            params["set"] = normalize(set_name, keep_spaces=True)
-        _apply_default_user_agent(headers, session)
+    def _escape_query(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', r"\"")
+
+    query_parts: list[str] = []
+    if name_api:
+        query_parts.append(f'name:"*{_escape_query(name_api)}*"')
+    if number_clean:
+        query_parts.append(f'number:"{_escape_query(number_clean)}"')
+    if set_name:
+        set_query = normalize(set_name, keep_spaces=True)
+        if set_query:
+            escaped = _escape_query(set_query)
+            query_parts.append(
+                "(" +
+                " OR ".join(
+                    (
+                        f'set.id:"{escaped}"',
+                        f'set.ptcgoCode:"{escaped}"',
+                        f'set.name:"*{escaped}*"',
+                    )
+                ) +
+                ")"
+            )
+    if total_clean:
+        escaped_total = _escape_query(total_clean)
+        query_parts.append(
+            f"(set.total:{escaped_total} OR set.printedTotal:{escaped_total})"
+        )
+
+    if not query_parts:
+        return []
+
+    page_size = max(limit * 5, 50)
+    page_size = min(page_size, 250)
+    params = {
+        "q": " and ".join(query_parts),
+        "page": "1",
+        "pageSize": str(page_size),
+    }
 
     try:
         response = http.get(url, params=params, headers=headers, timeout=timeout)
@@ -518,11 +545,11 @@ def search_cards(
         logger.warning("Request timed out")
         return []
     except (requests.RequestException, ValueError) as exc:  # pragma: no cover
-        logger.warning("Fetching cards from TCGGO failed: %s", exc)
+        logger.warning("Fetching cards from the Pokémon TCG API failed: %s", exc)
         return []
 
     if isinstance(cards, dict):
-        cards = cards.get("cards") or cards.get("data") or []
+        cards = cards.get("data") or cards.get("cards") or []
 
     name_norm = normalize(name)
     total_norm = total_clean
@@ -627,48 +654,91 @@ def list_set_cards(
         return []
 
     http = session or requests
-    rapidapi_key = rapidapi_key if rapidapi_key is not None else RAPIDAPI_KEY
-    rapidapi_host = rapidapi_host if rapidapi_host is not None else RAPIDAPI_HOST
-
-    params: dict[str, str] = {}
+    api_key = rapidapi_key if rapidapi_key is not None else POKEMONTCG_API_KEY
     headers: dict[str, str] = {}
-    url = "https://www.tcggo.com/api/cards/"
-    if rapidapi_key and rapidapi_host:
-        url = f"https://{rapidapi_host}/cards/search"
-        params = {"set": set_code}
-        headers = {
-            "X-RapidAPI-Key": rapidapi_key,
-            "X-RapidAPI-Host": rapidapi_host,
-        }
-    else:
-        params = {"set": set_code}
+    _apply_default_user_agent(headers, session)
+    if api_key:
+        headers["X-Api-Key"] = api_key
 
-    try:
-        response = http.get(url, params=params, headers=headers, timeout=timeout)
-        if response.status_code != 200:
-            logger.warning("API error: %s", response.status_code)
-            return []
-        cards = response.json()
-    except requests.Timeout:
-        logger.warning("Request timed out")
-        return []
-    except (requests.RequestException, ValueError) as exc:  # pragma: no cover
-        logger.warning("Fetching cards for set %s failed: %s", set_code, exc)
-        return []
+    def _escape_query(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', r"\"")
 
-    if isinstance(cards, dict):
-        cards = cards.get("cards") or cards.get("data") or cards.get("results") or []
+    set_value = set_code.strip()
+    normalized = normalize(set_code, keep_spaces=True)
+    escaped_value = _escape_query(set_value)
+    set_filters = {
+        f'set.id:"{escaped_value}"',
+        f'set.ptcgoCode:"{escaped_value}"',
+        f'set.name:"*{escaped_value}*"',
+    }
+    if normalized and normalized != set_value:
+        escaped_normalized = _escape_query(normalized)
+        set_filters.add(f'set.id:"{escaped_normalized}"')
+        set_filters.add(f'set.ptcgoCode:"{escaped_normalized}"')
+        set_filters.add(f'set.name:"*{escaped_normalized}*"')
 
+    query = "(" + " OR ".join(sorted(set_filters)) + ")"
+    page = 1
+    page_size = 250
     results: list[dict[str, Any]] = []
-    for card in cards or []:
-        payload = _build_card_payload(card)
-        if not payload:
-            continue
-        if not payload.get("name"):
-            payload["name"] = card.get("name") or ""
-        if not payload.get("image_small") and payload.get("image_large"):
-            payload["image_small"] = payload.get("image_large")
-        results.append(payload)
+    fetched_total = 0
+
+    while True:
+        params = {
+            "q": query,
+            "page": str(page),
+            "pageSize": str(page_size),
+        }
+        try:
+            response = http.get(
+                POKEMONTCG_API_URL,
+                params=params,
+                headers=headers,
+                timeout=timeout,
+            )
+            if response.status_code != 200:
+                logger.warning("API error: %s", response.status_code)
+                break
+            payload = response.json()
+        except requests.Timeout:
+            logger.warning("Request timed out")
+            break
+        except (requests.RequestException, ValueError) as exc:  # pragma: no cover
+            logger.warning("Fetching cards for set %s failed: %s", set_code, exc)
+            break
+
+        cards = []
+        total_count = 0
+        if isinstance(payload, dict):
+            cards = payload.get("data") or []
+            total_count = int(payload.get("totalCount") or 0)
+        elif isinstance(payload, list):
+            cards = payload
+
+        if not cards:
+            break
+
+        for card in cards:
+            item = _build_card_payload(card)
+            if not item:
+                continue
+            if not item.get("name"):
+                item["name"] = card.get("name") or ""
+            if not item.get("image_small") and item.get("image_large"):
+                item["image_small"] = item.get("image_large")
+            results.append(item)
+
+        fetched_total += len(cards)
+        if limit and limit > 0 and len(results) >= limit:
+            break
+
+        if total_count:
+            if fetched_total >= total_count:
+                break
+        elif len(cards) < page_size:
+            break
+
+        page += 1
 
     results.sort(key=_card_sort_key)
     if limit and limit > 0:

--- a/tests/test_card_search_suggestions.py
+++ b/tests/test_card_search_suggestions.py
@@ -77,33 +77,43 @@ def test_card_search_suggests_and_filters(monkeypatch, search_session):
         def json(self):
             return self._data
 
-    captured = {"called": 0}
+    captured = {"called": 0, "params": None, "headers": None, "url": None}
 
-    def fake_get(_url, params=None, headers=None, timeout=None):
+    def fake_get(url, params=None, headers=None, timeout=None):
         captured["called"] += 1
+        captured["params"] = params
+        captured["headers"] = headers
+        captured["url"] = url
         data = {
-            "cards": [
+            "data": [
                 {
                     "name": "Charizard",
                     "number": "4",
-                    "total": "102",
-                    "set": {"name": "Base Set", "code": "BS"},
+                    "set": {"name": "Base Set", "id": "base1", "total": 102},
                 },
                 {
                     "name": "Charoad",
                     "number": "4",
-                    "total": "102",
-                    "set": {"name": "Base Set", "code": "BS"},
+                    "set": {"name": "Base Set", "id": "base1", "total": 102},
                 },
-            ]
+            ],
+            "totalCount": 2,
         }
         return _DummyResponse(data)
 
     monkeypatch.setattr(pricing.requests, "get", fake_get)
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
     results = pricing.search_cards(name="Charizard", number="4", limit=10)
 
     assert captured["called"] == 1
+    assert captured["url"] == pricing.POKEMONTCG_API_URL
+    assert captured["params"]["page"] == "1"
+    assert captured["params"]["pageSize"] == "50"
+    query = captured["params"]["q"]
+    assert 'name:"*charizard*"' in query
+    assert 'number:"4"' in query
+    assert "X-Api-Key" not in (captured["headers"] or {})
     assert [item["name"] for item in results] == ["Charizard"]
 
 
@@ -119,28 +129,34 @@ def test_search_cards_allows_typo_without_number(monkeypatch):
         def json(self):
             return self._data
 
-    def fake_get(_url, params=None, headers=None, timeout=None):
+    captured = {"params": None}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
         data = {
-            "cards": [
+            "data": [
                 {
                     "name": "Charizard",
                     "number": "4",
-                    "total": "102",
-                    "set": {"name": "Base Set", "code": "BS"},
+                    "set": {"name": "Base Set", "id": "base1", "total": 102},
                 },
                 {
                     "name": "Pikachu",
                     "number": "25",
-                    "set": {"name": "Base Set", "code": "BS"},
+                    "set": {"name": "Base Set", "id": "base1", "total": 102},
                 },
             ]
         }
         return _DummyResponse(data)
 
     monkeypatch.setattr(pricing.requests, "get", fake_get)
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
     results = pricing.search_cards(name="Charoad", set_name="Base Set", limit=5)
 
+    query = captured["params"]["q"]
+    assert 'name:"*charoad*"' in query
+    assert 'set.name:"*base set*"' in query
     assert [item["name"] for item in results] == ["Charizard"]
 
 
@@ -151,7 +167,7 @@ def test_search_cards_sets_default_user_agent(monkeypatch):
         status_code = 200
 
         def json(self):
-            return {"cards": []}
+            return {"data": []}
 
     captured: dict[str, dict | None] = {"headers": None}
 
@@ -160,20 +176,23 @@ def test_search_cards_sets_default_user_agent(monkeypatch):
         return _DummyResponse()
 
     monkeypatch.setattr(pricing.requests, "get", fake_get)
+
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
     pricing.search_cards(name="Charizard", number="4", rapidapi_key=None, rapidapi_host=None)
 
     assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+    assert "X-Api-Key" not in captured["headers"]
 
 
-def test_search_cards_sets_user_agent_for_rapidapi(monkeypatch):
+def test_search_cards_uses_api_key_header(monkeypatch):
     from kartoteka import pricing
 
     class _DummyResponse:
         status_code = 200
 
         def json(self):
-            return {"cards": []}
+            return {"data": []}
 
     captured: dict[str, dict | None] = {"headers": None}
 
@@ -183,25 +202,20 @@ def test_search_cards_sets_user_agent_for_rapidapi(monkeypatch):
 
     monkeypatch.setattr(pricing.requests, "get", fake_get)
 
-    pricing.search_cards(
-        name="Charizard",
-        rapidapi_key="test-key",
-        rapidapi_host="example.com",
-    )
+    pricing.search_cards(name="Charizard", rapidapi_key="test-key")
 
     assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
-    assert captured["headers"]["X-RapidAPI-Key"] == "test-key"
-    assert captured["headers"]["X-RapidAPI-Host"] == "example.com"
+    assert captured["headers"]["X-Api-Key"] == "test-key"
 
 
-def test_search_cards_respects_session_user_agent():
+def test_search_cards_respects_session_user_agent(monkeypatch):
     from kartoteka import pricing
 
     class _DummyResponse:
         status_code = 200
 
         def json(self):
-            return {"cards": []}
+            return {"data": []}
 
     class DummySession:
         def __init__(self):
@@ -213,6 +227,8 @@ def test_search_cards_respects_session_user_agent():
             return _DummyResponse()
 
     session = DummySession()
+
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
     pricing.search_cards(name="Charizard", session=session, rapidapi_key=None, rapidapi_host=None)
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -124,6 +125,119 @@ def test_fetch_card_price_sets_user_agent_for_rapidapi(monkeypatch):
     assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
     assert captured["headers"]["X-RapidAPI-Key"] == "test-key"
     assert captured["headers"]["X-RapidAPI-Host"] == "example.com"
+
+
+def test_list_set_cards_fetches_all_pages(monkeypatch):
+    from kartoteka import pricing
+
+    responses = [
+        {
+            "data": [
+                {
+                    "name": "Card A",
+                    "number": "1",
+                    "set": {"name": "Example", "id": "base1", "total": 3},
+                },
+                {
+                    "name": "Card B",
+                    "number": "2",
+                    "set": {"name": "Example", "id": "base1", "total": 3},
+                },
+            ],
+            "totalCount": 3,
+        },
+        {
+            "data": [
+                {
+                    "name": "Card C",
+                    "number": "3",
+                    "set": {"name": "Example", "id": "base1", "total": 3},
+                }
+            ],
+            "totalCount": 3,
+        },
+    ]
+
+    captured: list[dict[str, Any]] = []
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured.append({
+            "url": url,
+            "params": params,
+            "headers": headers,
+        })
+        return _DummyHTTPResponse(responses.pop(0))
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
+
+    results = pricing.list_set_cards("base1", limit=0)
+
+    assert len(results) == 3
+    assert [item["number"] for item in results] == ["1", "2", "3"]
+    assert len(captured) == 2
+    assert captured[0]["url"] == pricing.POKEMONTCG_API_URL
+    assert captured[0]["params"]["page"] == "1"
+    assert captured[1]["params"]["page"] == "2"
+    assert 'set.id:"base1"' in captured[0]["params"]["q"]
+
+
+def test_list_set_cards_respects_limit(monkeypatch):
+    from kartoteka import pricing
+
+    payload = {
+        "data": [
+            {
+                "name": "Card A",
+                "number": "10",
+                "set": {"name": "Example", "id": "base1", "total": 3},
+            },
+            {
+                "name": "Card B",
+                "number": "5",
+                "set": {"name": "Example", "id": "base1", "total": 3},
+            },
+            {
+                "name": "Card C",
+                "number": "1",
+                "set": {"name": "Example", "id": "base1", "total": 3},
+            },
+        ],
+        "totalCount": 3,
+    }
+
+    captured = {"params": None}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        return _DummyHTTPResponse(payload)
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
+
+    results = pricing.list_set_cards("base1", limit=2)
+
+    assert len(results) == 2
+    assert [item["number"] for item in results] == ["1", "5"]
+    assert captured["params"]["pageSize"] == "250"
+
+
+def test_list_set_cards_uses_api_key_header(monkeypatch):
+    from kartoteka import pricing
+
+    captured = {"headers": None}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return _DummyHTTPResponse({"data": []})
+
+    monkeypatch.setattr(pricing.requests, "get", fake_get)
+    monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", "secret")
+
+    pricing.list_set_cards("base1", limit=1)
+
+    assert captured["headers"]["X-Api-Key"] == "secret"
+    assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
 
 
 def test_fetch_card_price_respects_session_user_agent():


### PR DESCRIPTION
## Summary
- add configuration for the official Pokémon TCG API and reuse the default User-Agent while applying the API key only when present
- rewrite card search and set listing to query the Pokémon TCG API, normalise responses, handle pagination, and keep scoring/limits intact
- refresh tests, environment docs, and README instructions to cover the new API payloads, pagination, and header handling

## Testing
- pytest tests/test_card_search_suggestions.py tests/test_pricing.py

------
https://chatgpt.com/codex/tasks/task_e_68dba3c35874832f95f9f426d63ab2ba