### PR TITLE
Track catalogue request counts

### DIFF
--- a/kartoteka/pricing.py
+++ b/kartoteka/pricing.py
@@ -647,11 +647,15 @@ def list_set_cards(
     rapidapi_host: Optional[str] = None,
     session: Optional[requests.sessions.Session] = None,
     timeout: float = 10.0,
-) -> list[dict[str, Any]]:
-    """Return a selection of cards belonging to ``set_code``."""
+) -> tuple[list[dict[str, Any]], int]:
+    """Return a selection of cards belonging to ``set_code``.
+
+    The function returns a tuple containing the cards and the number of HTTP
+    requests issued to the PokémonTCG API so callers can track quota usage.
+    """
 
     if not set_code:
-        return []
+        return [], 0
 
     http = session or requests
     api_key = rapidapi_key if rapidapi_key is not None else POKEMONTCG_API_KEY
@@ -682,6 +686,7 @@ def list_set_cards(
     page_size = 250
     results: list[dict[str, Any]] = []
     fetched_total = 0
+    request_count = 0
 
     while True:
         params = {
@@ -696,16 +701,20 @@ def list_set_cards(
                 headers=headers,
                 timeout=timeout,
             )
+        except requests.Timeout:
+            request_count += 1
+            logger.warning("Request timed out")
+            break
+        except (requests.RequestException, ValueError) as exc:  # pragma: no cover
+            request_count += 1
+            logger.warning("Fetching cards for set %s failed: %s", set_code, exc)
+            break
+        else:
+            request_count += 1
             if response.status_code != 200:
                 logger.warning("API error: %s", response.status_code)
                 break
             payload = response.json()
-        except requests.Timeout:
-            logger.warning("Request timed out")
-            break
-        except (requests.RequestException, ValueError) as exc:  # pragma: no cover
-            logger.warning("Fetching cards for set %s failed: %s", set_code, exc)
-            break
 
         cards = []
         total_count = 0
@@ -742,6 +751,6 @@ def list_set_cards(
 
     results.sort(key=_card_sort_key)
     if limit and limit > 0:
-        return results[:limit]
-    return results
+        results = results[:limit]
+    return results, request_count
 

--- a/kartoteka_web/catalogue.py
+++ b/kartoteka_web/catalogue.py
@@ -394,11 +394,11 @@ def refresh_catalogue(
             break
 
         logger.info(
-            "Synchronising set %s (%s/%s) [request %s/%s]",
+            "Synchronising set %s (%s/%s); requests used %s/%s",
             set_code,
             position + 1,
             total_sets,
-            requests_used + 1,
+            requests_used,
             CATALOGUE_REQUEST_LIMIT,
         )
         _notify(
@@ -407,12 +407,15 @@ def refresh_catalogue(
             index=position + 1,
             total_sets=total_sets,
             request_number=requests_used + 1,
+            requests_used=requests_used,
             request_limit=CATALOGUE_REQUEST_LIMIT,
         )
-        cards = pricing.list_set_cards(set_code, limit=0)
-        card_count = len(cards or [])
-        if not cards:
-            requests_used += 1
+        cards, set_request_count = pricing.list_set_cards(set_code, limit=0)
+        set_request_count = int(set_request_count or 0)
+        card_list = list(cards or [])
+        card_count = len(card_list)
+        requests_used += set_request_count
+        if not card_list:
             processed_sets += 1
             processed_cards += card_count
             last_completed_set = set_code
@@ -434,10 +437,12 @@ def refresh_catalogue(
                 processed_sets=processed_sets,
                 processed_cards=processed_cards,
                 remaining_sets=remaining_sets,
+                request_count=set_request_count,
+                requests_used=requests_used,
             )
             continue
         changed_for_set = 0
-        for payload in cards:
+        for payload in card_list:
             record, changed = upsert_card_record(session, payload)
             if record is None:
                 continue
@@ -450,7 +455,6 @@ def refresh_catalogue(
             total_changed += changed_for_set
         else:
             session.rollback()
-        requests_used += 1
         processed_sets += 1
         processed_cards += card_count
         last_completed_set = set_code
@@ -472,6 +476,8 @@ def refresh_catalogue(
             processed_sets=processed_sets,
             processed_cards=processed_cards,
             remaining_sets=remaining_sets,
+            request_count=set_request_count,
+            requests_used=requests_used,
         )
 
     completed_all_sets = (start_index + processed_sets) >= total_sets and (

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -171,11 +171,12 @@ def test_list_set_cards_fetches_all_pages(monkeypatch):
     monkeypatch.setattr(pricing.requests, "get", fake_get)
     monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
-    results = pricing.list_set_cards("base1", limit=0)
+    results, request_count = pricing.list_set_cards("base1", limit=0)
 
     assert len(results) == 3
     assert [item["number"] for item in results] == ["1", "2", "3"]
-    assert len(captured) == 2
+    assert request_count == 2
+    assert len(captured) == request_count
     assert captured[0]["url"] == pricing.POKEMONTCG_API_URL
     assert captured[0]["params"]["page"] == "1"
     assert captured[1]["params"]["page"] == "2"
@@ -215,10 +216,11 @@ def test_list_set_cards_respects_limit(monkeypatch):
     monkeypatch.setattr(pricing.requests, "get", fake_get)
     monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", None)
 
-    results = pricing.list_set_cards("base1", limit=2)
+    results, request_count = pricing.list_set_cards("base1", limit=2)
 
     assert len(results) == 2
     assert [item["number"] for item in results] == ["1", "5"]
+    assert request_count == 1
     assert captured["params"]["pageSize"] == "250"
 
 
@@ -234,10 +236,11 @@ def test_list_set_cards_uses_api_key_header(monkeypatch):
     monkeypatch.setattr(pricing.requests, "get", fake_get)
     monkeypatch.setattr(pricing, "POKEMONTCG_API_KEY", "secret")
 
-    pricing.list_set_cards("base1", limit=1)
+    _cards, request_count = pricing.list_set_cards("base1", limit=1)
 
     assert captured["headers"]["X-Api-Key"] == "secret"
     assert captured["headers"]["User-Agent"] == "kartoteka/1.0"
+    assert request_count == 1
 
 
 def test_fetch_card_price_respects_session_user_agent():

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -45,7 +45,7 @@ def _configure_test_environment(db_path, monkeypatch):
 
     monkeypatch.setattr("kartoteka.pricing.fetch_card_price", fake_price)
     monkeypatch.setattr("kartoteka.pricing.search_cards", lambda *a, **k: [])
-    monkeypatch.setattr("kartoteka.pricing.list_set_cards", lambda *a, **k: [])
+    monkeypatch.setattr("kartoteka.pricing.list_set_cards", lambda *a, **k: ([], 0))
     monkeypatch.setattr("kartoteka_web.utils.images.cache_card_images", lambda payload, **_: payload)
     monkeypatch.setattr("kartoteka_web.utils.images.ensure_local_path", lambda value, **_: value)
     monkeypatch.setattr("kartoteka_web.auth.get_password_hash", lambda password: f"hashed:{password}")

--- a/tests/web/test_catalogue_sync.py
+++ b/tests/web/test_catalogue_sync.py
@@ -1,0 +1,145 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlmodel import SQLModel, Session, create_engine, select
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kartoteka import pricing  # noqa: E402
+from kartoteka_web import catalogue, models  # noqa: E402
+
+
+@pytest.fixture()
+def in_memory_session(monkeypatch, tmp_path):
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        connection.exec_driver_sql(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS cardrecord_search
+            USING fts5(
+                card_id UNINDEXED,
+                name_normalized,
+                set_name_normalized
+            )
+            """
+        )
+
+    marker_file = tmp_path / "marker.txt"
+    progress_file = tmp_path / "progress.txt"
+
+    monkeypatch.setattr(catalogue, "CATALOGUE_MARKER_FILE", marker_file)
+    monkeypatch.setattr(catalogue, "CATALOGUE_PROGRESS_FILE", progress_file)
+    monkeypatch.setattr(catalogue, "CATALOGUE_REQUEST_LIMIT", 3)
+    monkeypatch.setattr(
+        catalogue.image_utils, "cache_card_images", lambda payload, **_: payload
+    )
+
+    with Session(engine) as session:
+        yield session
+
+
+def test_refresh_catalogue_tracks_requests_and_markers(in_memory_session, monkeypatch):
+    set_codes = ["alpha", "beta", "gamma"]
+    monkeypatch.setattr(catalogue, "iter_known_set_codes", lambda: list(set_codes))
+
+    set_infos = {
+        "alpha": {"code": "alpha", "name": "Alpha", "total": 2, "era": "Test"},
+        "beta": {"code": "beta", "name": "Beta", "total": 1, "era": "Test"},
+        "gamma": {"code": "gamma", "name": "Gamma", "total": 1, "era": "Test"},
+    }
+    monkeypatch.setattr(
+        catalogue.set_utils,
+        "get_set_info",
+        lambda set_code=None, set_name=None: set_infos.get(set_code)
+        or set_infos.get(str(set_name or "").lower()),
+    )
+
+    payloads = {
+        "alpha": (
+            [
+                {
+                    "name": "Alpha One",
+                    "number": "1",
+                    "set_name": "Alpha",
+                    "set_code": "alpha",
+                },
+                {
+                    "name": "Alpha Two",
+                    "number": "2",
+                    "set_name": "Alpha",
+                    "set_code": "alpha",
+                },
+            ],
+            2,
+        ),
+        "beta": (
+            [
+                {
+                    "name": "Beta Ace",
+                    "number": "1",
+                    "set_name": "Beta",
+                    "set_code": "beta",
+                }
+            ],
+            2,
+        ),
+        "gamma": (
+            [
+                {
+                    "name": "Gamma Solo",
+                    "number": "1",
+                    "set_name": "Gamma",
+                    "set_code": "gamma",
+                }
+            ],
+            1,
+        ),
+    }
+
+    call_order: list[str] = []
+
+    def fake_list_set_cards(code, limit=0, **_kwargs):
+        call_order.append(code)
+        cards, request_count = payloads[code]
+        return cards, request_count
+
+    monkeypatch.setattr(pricing, "list_set_cards", fake_list_set_cards)
+
+    events: list[tuple[str, dict]] = []
+
+    def progress_hook(event: str, payload: dict):
+        events.append((event, payload))
+
+    total_changed = catalogue.refresh_catalogue(
+        in_memory_session,
+        now=catalogue.dt.datetime(2024, 1, 1, tzinfo=catalogue.dt.timezone.utc),
+        force=True,
+        progress=progress_hook,
+    )
+
+    assert call_order == ["alpha", "beta"]
+    assert total_changed == 3
+
+    records = in_memory_session.exec(select(models.CardRecord)).all()
+    assert len(records) == 3
+
+    # Limit event should reflect the aggregated request counter
+    limit_events = [payload for name, payload in events if name == "limit"]
+    assert limit_events and limit_events[0]["requests_used"] == 4
+
+    complete_events = [payload for name, payload in events if name == "set.complete"]
+    assert complete_events[0]["request_count"] == 2
+    assert complete_events[0]["requests_used"] == 2
+    assert complete_events[1]["request_count"] == 2
+    assert complete_events[1]["requests_used"] == 4
+
+    # Only progress marker should be written because the sync stopped at the limit
+    assert catalogue.CATALOGUE_MARKER_FILE.exists() is False
+    assert catalogue.CATALOGUE_PROGRESS_FILE.read_text(encoding="utf-8") == "beta"
+


### PR DESCRIPTION
## Summary
- expose the number of PokémonTCG API requests from pricing.list_set_cards
- account for the real request usage in catalogue refresh notifications and counters
- cover the new behaviour with pricing and catalogue sync tests, including a multi-page scenario

## Testing
- pytest tests/test_pricing.py tests/web/test_catalogue_sync.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dba6e893f0832fb9789715742324cd