### PR TITLE
Simplify web collection experience

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1,1907 +1,830 @@
-const TOKEN_KEY = "kartoteka_token";
-const THEME_KEY = "kartoteka_theme";
-const LIGHT_THEME_COLOR = "#f9fafb";
-const DARK_THEME_COLOR = "#05060f";
-let cachedCollectionEntries = [];
+(() => {
+  const TOKEN_KEY = "kartoteka_token";
+  let collectionCache = [];
+  let currentUser = null;
 
-const getToken = () => window.localStorage.getItem(TOKEN_KEY);
-const setToken = (token) => window.localStorage.setItem(TOKEN_KEY, token);
-const clearToken = () => window.localStorage.removeItem(TOKEN_KEY);
-
-function debounce(fn, delay = 250) {
-  let timer;
-  return (...args) => {
-    window.clearTimeout(timer);
-    timer = window.setTimeout(() => fn(...args), delay);
-  };
-}
-
-function getStoredTheme() {
-  try {
-    return window.localStorage.getItem(THEME_KEY);
-  } catch (error) {
-    console.warn("Unable to read stored theme", error);
-    return null;
-  }
-}
-
-function applyTheme(theme) {
-  const normalized = theme === "dark" ? "dark" : "light";
-  const body = document.body;
-  if (body) {
-    body.dataset.theme = normalized;
-  }
-  const root = document.documentElement;
-  if (root) {
-    root.style.colorScheme = normalized;
-  }
-  const meta = document.querySelector("[data-theme-color]");
-  if (meta) {
-    const color = normalized === "dark" ? DARK_THEME_COLOR : LIGHT_THEME_COLOR;
-    meta.setAttribute("content", color);
-  }
-  const toggle = document.querySelector("[data-theme-toggle]");
-  if (toggle) {
-    const icon = toggle.querySelector("span");
-    const label = normalized === "dark" ? "Włącz jasny motyw" : "Włącz ciemny motyw";
-    toggle.setAttribute("aria-label", label);
-    if (icon) {
-      icon.textContent = normalized === "dark" ? "☀️" : "🌙";
+  const storage = (() => {
+    try {
+      const { localStorage } = window;
+      localStorage.getItem("__kartoteka_test__");
+      return localStorage;
+    } catch (error) {
+      console.warn("Local storage unavailable", error);
+      return null;
     }
-  }
-}
+  })();
 
-function determineTheme() {
-  const stored = getStoredTheme();
-  if (stored === "dark" || stored === "light") {
-    return stored;
-  }
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
+  const getToken = () => (storage ? storage.getItem(TOKEN_KEY) : null);
+  const setToken = (token) => {
+    if (!storage) return;
+    try {
+      storage.setItem(TOKEN_KEY, token);
+    } catch (error) {
+      console.warn("Unable to persist token", error);
+    }
+  };
+  const clearToken = () => {
+    if (!storage) return;
+    try {
+      storage.removeItem(TOKEN_KEY);
+    } catch (error) {
+      console.warn("Unable to remove token", error);
+    }
+  };
 
-function persistTheme(theme) {
-  try {
-    window.localStorage.setItem(THEME_KEY, theme);
-  } catch (error) {
-    console.warn("Unable to persist theme", error);
-  }
-}
+  const escapeHtml = (value) =>
+    String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
 
-function setupThemeToggle() {
-  const initial = determineTheme();
-  applyTheme(initial);
-  const toggle = document.querySelector("[data-theme-toggle]");
-  if (toggle) {
-    toggle.addEventListener("click", () => {
-      const current = document.body?.dataset.theme || initial;
-      const next = current === "dark" ? "light" : "dark";
-      persistTheme(next);
-      applyTheme(next);
-    });
-  }
-  const media = window.matchMedia("(prefers-color-scheme: dark)");
-  if (media && typeof media.addEventListener === "function") {
-    media.addEventListener("change", (event) => {
-      const stored = getStoredTheme();
-      if (stored === "dark" || stored === "light") {
-        return;
+  const formToJSON = (form) => {
+    const data = new FormData(form);
+    const result = {};
+    for (const [key, value] of data.entries()) {
+      if (Object.prototype.hasOwnProperty.call(result, key)) {
+        const existing = result[key];
+        if (Array.isArray(existing)) {
+          existing.push(value);
+        } else {
+          result[key] = [existing, value];
+        }
+      } else {
+        result[key] = value;
       }
-      applyTheme(event.matches ? "dark" : "light");
-    });
-  }
-}
-
-const plnFormatter = new Intl.NumberFormat("pl-PL", {
-  style: "currency",
-  currency: "PLN",
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
-function formatPln(value) {
-  if (typeof value !== "number" || Number.isNaN(value)) {
-    return null;
-  }
-  return plnFormatter.format(value);
-}
-
-function resolveTrendSymbol(direction) {
-  if (direction === "up") {
-    return "↑";
-  }
-  if (direction === "down") {
-    return "↓";
-  }
-  return "→";
-}
-
-function updateUserBadge(user) {
-  const payload =
-    typeof user === "string"
-      ? { username: user }
-      : user && typeof user === "object"
-        ? user
-        : { username: "" };
-  const username = payload.username ? String(payload.username).trim() : "";
-  const avatarUrl = payload.avatar_url ? String(payload.avatar_url).trim() : "";
-  const display = document.querySelector("[data-username-display]");
-  const logoutButton = document.getElementById("logout-button");
-  if (display) {
-    display.textContent = username || "Gość";
-    display.dataset.state = username ? "authenticated" : "anonymous";
-  }
-  const avatar = document.querySelector("[data-user-avatar]");
-  if (avatar) {
-    const initial = username ? username.charAt(0).toUpperCase() : "G";
-    if (avatarUrl) {
-      avatar.style.backgroundImage = `url(${avatarUrl})`;
-      avatar.textContent = "";
-    } else {
-      avatar.style.backgroundImage = "";
-      avatar.textContent = initial;
     }
-    avatar.dataset.state = username ? "authenticated" : "anonymous";
-  }
-  const profileLink = document.querySelector("[data-user-profile-link]");
-  if (profileLink) {
-    profileLink.dataset.state = username ? "authenticated" : "anonymous";
-    profileLink.setAttribute("aria-disabled", username ? "false" : "true");
-  }
-  const logout = logoutButton;
-  if (logout) {
-    logout.hidden = !username;
-  }
-  const loginButton = document.getElementById("login-button");
-  if (loginButton) {
-    loginButton.hidden = Boolean(username);
-  }
-}
-
-function setupNavigation() {
-  const nav = document.querySelector("[data-nav]");
-  const toggle = document.querySelector("[data-nav-toggle]");
-  if (nav && toggle) {
-    if (!nav.dataset.open) {
-      nav.dataset.open = "false";
-    }
-    const closeNav = () => {
-      nav.dataset.open = "false";
-      toggle.setAttribute("aria-expanded", "false");
-    };
-    toggle.addEventListener("click", () => {
-      const isOpen = nav.dataset.open === "true";
-      const nextState = String(!isOpen);
-      nav.dataset.open = nextState;
-      toggle.setAttribute("aria-expanded", nextState);
-    });
-    nav.querySelectorAll("a").forEach((link) => {
-      link.addEventListener("click", () => closeNav());
-    });
-    document.addEventListener("click", (event) => {
-      if (!nav.contains(event.target) && !toggle.contains(event.target)) {
-        closeNav();
-      }
-    });
-  }
-
-  const logoutButton = document.getElementById("logout-button");
-  if (logoutButton) {
-    logoutButton.addEventListener("click", () => {
-      clearToken();
-      updateUserBadge({ username: "" });
-      window.location.href = "/login";
-    });
-  }
-
-  const initialUsername = document.body?.dataset.username ?? "";
-  const initialAvatar = document.body?.dataset.avatar ?? "";
-  updateUserBadge({ username: initialUsername, avatar_url: initialAvatar });
-}
-
-function setupHeaderVisibility() {
-  const header = document.querySelector("header.app-header");
-  if (!header) {
-    return;
-  }
-
-  const setHeaderVisibility = (visible) => {
-    header.dataset.headerVisible = visible ? "true" : "false";
+    return result;
   };
 
-  setHeaderVisibility(true);
-
-  let lastKnownScrollY = window.scrollY;
-  let ticking = false;
-  const threshold = 4;
-
-  const updateVisibility = () => {
-    const currentScrollY = Math.max(window.scrollY, 0);
-    const atTop = currentScrollY <= 0;
-
-    if (atTop) {
-      setHeaderVisibility(true);
-    } else if (currentScrollY > lastKnownScrollY + threshold) {
-      setHeaderVisibility(false);
-    } else if (currentScrollY < lastKnownScrollY - threshold) {
-      setHeaderVisibility(true);
-    }
-
-    lastKnownScrollY = currentScrollY;
-    ticking = false;
-  };
-
-  const requestTick = () => {
-    if (!ticking) {
-      window.requestAnimationFrame(updateVisibility);
-      ticking = true;
-    }
-  };
-
-  const resetVisibility = () => {
-    lastKnownScrollY = window.scrollY;
-    setHeaderVisibility(true);
-    requestTick();
-  };
-
-  window.addEventListener("scroll", requestTick, { passive: true });
-  window.addEventListener("resize", resetVisibility);
-  window.addEventListener("orientationchange", resetVisibility);
-
-  requestTick();
-}
-
-async function registerServiceWorker() {
-  if (!("serviceWorker" in navigator)) {
-    return;
-  }
-  try {
-    await navigator.serviceWorker.register("/static/service-worker.js", { scope: "/" });
-  } catch (error) {
-    console.warn("Service worker registration failed", error);
-  }
-}
-
-async function apiFetch(path, options = {}) {
-  const headers = options.headers ? { ...options.headers } : {};
-  if (!headers["Content-Type"] && options.body) {
-    headers["Content-Type"] = "application/json";
-  }
-  const token = getToken();
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
-  }
-  const response = await fetch(path, { ...options, headers });
-  if (response.status === 204) {
-    return null;
-  }
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const message = data.detail || "Wystąpił błąd.";
-    throw new Error(message);
-  }
-  return data;
-}
-
-const alertHideTimers = new WeakMap();
-const TOAST_TRANSITION_MS = 300;
-
-function hideToast(element) {
-  element.dataset.visible = "false";
-  window.setTimeout(() => {
-    element.hidden = true;
-    element.textContent = "";
-    delete element.dataset.variant;
-    element.removeAttribute("data-visible");
-  }, TOAST_TRANSITION_MS);
-}
-
-function showAlert(element, message, type = "error") {
-  if (!element) return;
-
-  const pendingTimer = alertHideTimers.get(element);
-  if (pendingTimer) {
-    window.clearTimeout(pendingTimer);
-    alertHideTimers.delete(element);
-  }
-
-  element.classList.remove("success", "error");
-
-  if (!message) {
-    if (element.id === "add-card-alert") {
-      hideToast(element);
-    } else {
+  const showAlert = (element, message, variant = "info") => {
+    if (!element) return;
+    if (!message) {
       element.textContent = "";
       element.hidden = true;
       delete element.dataset.variant;
-      element.removeAttribute("data-visible");
-    }
-    return;
-  }
-
-  element.textContent = message;
-  element.hidden = false;
-  element.dataset.variant = type;
-
-  if (element.id === "add-card-alert") {
-    element.dataset.visible = "true";
-    if (type === "success") {
-      const timeoutId = window.setTimeout(() => {
-        hideToast(element);
-        alertHideTimers.delete(element);
-      }, 4000);
-      alertHideTimers.set(element, timeoutId);
-    }
-  }
-}
-
-function formToJSON(form) {
-  const data = new FormData(form);
-  const result = {};
-  for (const [key, value] of data.entries()) {
-    if (value === "on") {
-      result[key] = true;
-    } else if (value === "") {
-      result[key] = undefined;
-    } else {
-      result[key] = value;
-    }
-  }
-  return result;
-}
-
-function slugifyIdentifier(value) {
-  return String(value || "")
-    .trim()
-    .toLowerCase()
-    .normalize("NFKD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    || "unknown";
-}
-
-function extractCardTotal(card) {
-  if (!card) return "";
-  if (card.total) {
-    return String(card.total);
-  }
-  const display = card.number_display || "";
-  if (display.includes("/")) {
-    const [, totalPart] = display.split("/", 2);
-    return totalPart ? totalPart.trim() : "";
-  }
-  return "";
-}
-
-function buildCardDetailUrl(card) {
-  if (!card) return "/dashboard";
-  const number = encodeURIComponent(card.number || "");
-  const setCode = (card.set_code || "").trim();
-  const setName = card.set_name || "";
-  const slug = setCode ? encodeURIComponent(setCode.toLowerCase()) : encodeURIComponent(slugifyIdentifier(setName));
-  const params = new URLSearchParams();
-  if (card.name) params.set("name", card.name);
-  if (setName) params.set("set_name", setName);
-  const total = extractCardTotal(card);
-  if (total) params.set("total", total);
-  const query = params.toString();
-  return `/cards/${slug}/${number}${query ? `?${query}` : ""}`;
-}
-
-function buildAddCardUrl(card) {
-  if (!card) return "/cards/add";
-  const params = new URLSearchParams();
-  if (card.name) params.set("name", card.name);
-  if (card.number) params.set("number", card.number);
-  if (card.set_name) params.set("set_name", card.set_name);
-  if (card.set_code) params.set("set_code", card.set_code);
-  const total = extractCardTotal(card);
-  if (total) params.set("total", total);
-  const query = params.toString();
-  return `/cards/add${query ? `?${query}` : ""}`;
-}
-
-function resolveRaritySymbol(rarity) {
-  if (!rarity) {
-    return "";
-  }
-  const value = String(rarity).trim();
-  if (!value) {
-    return "";
-  }
-  const normalised = value.toLowerCase();
-  if (normalised.includes("common")) {
-    return "●";
-  }
-  if (normalised.includes("uncommon")) {
-    return "◆";
-  }
-  if (
-    normalised.includes("rare") ||
-    normalised.includes("promo") ||
-    normalised.includes("secret")
-  ) {
-    return "★";
-  }
-  return "";
-}
-
-function formatRarityLabel(rarity) {
-  if (!rarity) {
-    return "";
-  }
-  const symbol = resolveRaritySymbol(rarity);
-  return symbol ? `${symbol} ${rarity}` : rarity;
-}
-
-function formatCardNumber(card) {
-  if (!card) return "";
-  if (card.number_display) {
-    return card.number_display;
-  }
-  if (card.number && card.total) {
-    return `${card.number}/${card.total}`;
-  }
-  return card.number || "";
-}
-
-async function handleLogin(form) {
-  const alertBox = document.getElementById("login-alert");
-  showAlert(alertBox, "");
-  try {
-    const payload = formToJSON(form);
-    const data = await apiFetch("/users/login", {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    setToken(data.access_token);
-    window.location.href = "/dashboard";
-  } catch (error) {
-    showAlert(alertBox, error.message);
-  }
-}
-
-async function handleRegister(form) {
-  const alertBox = document.getElementById("register-alert");
-  showAlert(alertBox, "");
-  try {
-    const payload = formToJSON(form);
-    await apiFetch("/users/register", {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    showAlert(alertBox, "Konto utworzone. Możesz się zalogować.", "success");
-    form.reset();
-  } catch (error) {
-    showAlert(alertBox, error.message);
-  }
-}
-
-function renderCollection(entries) {
-  const body = document.getElementById("collection-table");
-  cachedCollectionEntries = Array.isArray(entries) ? entries : [];
-  if (!body) return;
-  body.innerHTML = "";
-  if (!entries.length) {
-    const emptyRow = document.createElement("tr");
-    emptyRow.innerHTML = `<td colspan="5" class="table-empty">Brak kart w kolekcji. Dodaj pierwszą kartę, aby rozpocząć.</td>`;
-    body.appendChild(emptyRow);
-    return;
-  }
-  for (const entry of entries) {
-    const tr = document.createElement("tr");
-    const purchaseValue =
-      typeof entry.purchase_price === "number"
-        ? entry.purchase_price.toFixed(2)
-        : entry.purchase_price ?? "-";
-    const detailUrl = buildCardDetailUrl(entry.card || {});
-    tr.innerHTML = `
-      <td data-label="Nazwa"><a class="table-link" href="${detailUrl}">${entry.card.name}</a></td>
-      <td data-label="Numer">${entry.card.number}</td>
-      <td data-label="Set">${entry.card.set_name}</td>
-      <td data-label="Ilość">${entry.quantity}</td>
-      <td data-label="Cena zakupu">${purchaseValue}</td>
-      <td data-label="Akcje">
-        <div class="table-actions">
-          <button class="ghost danger" data-action="delete" data-id="${entry.id}">Usuń</button>
-        </div>
-      </td>
-    `;
-    body.appendChild(tr);
-  }
-}
-
-function renderPortfolio(entries) {
-  const container = document.getElementById("portfolio-cards");
-  const empty = document.getElementById("portfolio-empty");
-  if (!container) return;
-  container.innerHTML = "";
-  if (!Array.isArray(entries) || !entries.length) {
-    if (empty) empty.hidden = false;
-    return;
-  }
-  if (empty) empty.hidden = true;
-  const fragment = document.createDocumentFragment();
-  entries.forEach((entry) => {
-    const card = entry.card || {};
-    const article = document.createElement("article");
-    article.className = "portfolio-card";
-    const link = document.createElement("a");
-    link.href = buildCardDetailUrl(card);
-    link.className = "portfolio-card-link";
-
-    const media = document.createElement("div");
-    media.className = "portfolio-card-media";
-    const imageSource = card.image_small || card.image_large;
-    if (imageSource) {
-      const img = document.createElement("img");
-      img.src = imageSource;
-      img.alt = `Podgląd ${card.name || "karty"}`;
-      img.loading = "lazy";
-      img.className = "portfolio-card-image";
-      media.appendChild(img);
-    } else {
-      const placeholder = document.createElement("div");
-      placeholder.className = "portfolio-card-placeholder";
-      placeholder.textContent = "🃏";
-      placeholder.setAttribute("aria-hidden", "true");
-      media.appendChild(placeholder);
-    }
-    link.appendChild(media);
-
-    const body = document.createElement("div");
-    body.className = "portfolio-card-body";
-
-    if (card.set_name) {
-      const setInfo = document.createElement("div");
-      setInfo.className = "portfolio-card-set";
-      const setName = document.createElement("span");
-      setName.textContent = card.set_name;
-      setInfo.appendChild(setName);
-      body.appendChild(setInfo);
-    }
-
-    const title = document.createElement("h3");
-    title.className = "portfolio-card-title";
-    title.textContent = card.name || "";
-    body.appendChild(title);
-
-    const meta = document.createElement("p");
-    meta.className = "portfolio-card-meta";
-    const numberText = formatCardNumber(card);
-    const rarity = card.rarity ? String(card.rarity) : "";
-    const quantity = entry.quantity ? `x${entry.quantity}` : "";
-    meta.textContent = [numberText, rarity, quantity].filter(Boolean).join(" • ");
-    body.appendChild(meta);
-
-    const purchase = document.createElement("p");
-    purchase.className = "portfolio-card-value";
-    if (typeof entry.purchase_price === "number") {
-      purchase.textContent = `Cena zakupu: ${entry.purchase_price.toFixed(2)} PLN`;
-    } else {
-      purchase.textContent = "Cena zakupu: -";
-    }
-    body.appendChild(purchase);
-
-    link.appendChild(body);
-    article.appendChild(link);
-    fragment.appendChild(article);
-  });
-  container.appendChild(fragment);
-}
-
-function renderPortfolioPerformance() {
-  const chartContainer = document.getElementById("portfolio-chart");
-  if (chartContainer) {
-    chartContainer.innerHTML = "";
-    const message = document.createElement("p");
-    message.className = "portfolio-chart-empty";
-    message.textContent = "Historia wartości jest niedostępna w uproszczonym trybie.";
-    chartContainer.appendChild(message);
-  }
-
-  const changeWrapper = document.getElementById("portfolio-change");
-  if (changeWrapper) {
-    changeWrapper.dataset.direction = "flat";
-    const icon = changeWrapper.querySelector(".portfolio-change-icon");
-    if (icon) {
-      icon.textContent = resolveTrendSymbol("flat");
-    }
-  }
-
-  const changeValue = document.getElementById("portfolio-change-value");
-  if (changeValue) {
-    changeValue.textContent = plnFormatter.format(0);
-  }
-
-  const latestValueElement = document.getElementById("portfolio-chart-latest");
-  if (latestValueElement) {
-    latestValueElement.textContent = "—";
-    latestValueElement.dataset.direction = "flat";
-  }
-
-  const minValueElement = document.getElementById("portfolio-chart-min");
-  if (minValueElement) {
-    minValueElement.textContent = "—";
-  }
-
-  const maxValueElement = document.getElementById("portfolio-chart-max");
-  if (maxValueElement) {
-    maxValueElement.textContent = "—";
-  }
-
-  const rangeElement = document.getElementById("portfolio-chart-range");
-  if (rangeElement) {
-    rangeElement.textContent = "Brak danych";
-  }
-
-  const totalValueElement = document.getElementById("portfolio-value");
-  if (totalValueElement) {
-    totalValueElement.dataset.direction = "flat";
-  }
-
-  const summaryValueElement = document.getElementById("summary-value");
-  if (summaryValueElement) {
-    summaryValueElement.dataset.direction = "flat";
-  }
-}
-
-function updateSummary(entries) {
-  const collection = Array.isArray(entries) ? entries : [];
-  const totalCards = collection.length;
-  const totalQuantity = collection.reduce((acc, entry) => acc + (Number(entry.quantity) || 0), 0);
-  const totalPurchase = collection.reduce((acc, entry) => {
-    if (typeof entry.purchase_price === "number") {
-      return acc + entry.purchase_price * (Number(entry.quantity) || 1);
-    }
-    return acc;
-  }, 0);
-
-  const count = document.getElementById("summary-count");
-  const quantity = document.getElementById("summary-quantity");
-  const value = document.getElementById("summary-value");
-  if (count) count.textContent = totalCards;
-  if (quantity) quantity.textContent = totalQuantity;
-  if (value) {
-    const formatted = formatPln(totalPurchase);
-    value.textContent = formatted || totalPurchase.toFixed(2);
-    value.dataset.direction = "flat";
-  }
-
-  const pCount = document.getElementById("portfolio-count");
-  const pQuantity = document.getElementById("portfolio-quantity");
-  const pValue = document.getElementById("portfolio-value");
-  if (pCount) pCount.textContent = totalCards;
-  if (pQuantity) pQuantity.textContent = totalQuantity;
-  if (pValue) {
-    const formatted = formatPln(totalPurchase);
-    pValue.textContent = formatted || totalPurchase.toFixed(2);
-    pValue.dataset.direction = "flat";
-  }
-}
-
-async function loadCollection() {
-  try {
-    const entries = await apiFetch("/cards/");
-    renderCollection(entries);
-    renderPortfolio(entries);
-    updateSummary(entries);
-  } catch (error) {
-    console.error(error);
-  }
-}
-
-async function loadPortfolioHistory(targetAlert) {
-  renderPortfolioPerformance();
-  if (targetAlert) {
-    showAlert(targetAlert, "");
-  }
-}
-
-async function loadSummary(targetAlert) {
-  updateSummary(cachedCollectionEntries);
-  if (targetAlert) {
-    showAlert(targetAlert, "");
-  }
-}
-
-async function loadPortfolioCards(targetAlert) {
-  renderPortfolio(cachedCollectionEntries);
-  if (targetAlert) {
-    showAlert(targetAlert, "");
-  }
-}
-
-function setupCardSearch(form) {
-  if (!form) return null;
-  const queryInput = form.querySelector('input[name="query"]');
-  const rarityInput = form.querySelector('input[name="rarity"]');
-  const resultsSection = document.getElementById("card-search-results-section");
-  const resultsContainer = document.getElementById("card-search-results");
-  const summary = document.getElementById("card-search-summary");
-  const statusMessage = document.getElementById("card-search-empty");
-  const sortSelect = document.getElementById("card-search-sort");
-  const hintElement = document.getElementById("card-search-hint");
-
-  if (!queryInput || !resultsSection || !resultsContainer) {
-    return null;
-  }
-
-  const eventTarget = form;
-  let selectedCard = null;
-  let selectedKey = "";
-  let requestId = 0;
-  let cardSearchApi = null;
-
-  const state = {
-    items: [],
-    total: 0,
-    sortMode: sortSelect?.value || "relevance",
-    suggestedQuery: "",
-    lastQuery: "",
-  };
-
-  const buildResultKey = (card) => {
-    const setCode = card?.set_code ?? "";
-    const setName = card?.set_name ?? "";
-    const number = card?.number ?? "";
-    const name = card?.name ?? "";
-    return [setCode, setName, number, name].join("|");
-  };
-
-  const formatResultsCount = (count) => {
-    if (count === 1) {
-      return "Znaleziono 1 kartę";
-    }
-    const mod10 = count % 10;
-    const mod100 = count % 100;
-    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
-      return `Znaleziono ${count} karty`;
-    }
-    return `Znaleziono ${count} kart`;
-  };
-
-  const updateSummary = (count) => {
-    if (!summary) return;
-    if (count > 0) {
-      summary.textContent = formatResultsCount(count);
-      summary.hidden = false;
-    } else {
-      summary.textContent = "";
-      summary.hidden = true;
-    }
-  };
-
-  const updateStatus = (message = "", stateAttr = "") => {
-    if (!statusMessage) return;
-    if (message) {
-      statusMessage.textContent = message;
-      statusMessage.hidden = false;
-      if (stateAttr) {
-        statusMessage.dataset.state = stateAttr;
-      } else {
-        delete statusMessage.dataset.state;
-      }
-    } else {
-      statusMessage.textContent = "";
-      statusMessage.hidden = true;
-      delete statusMessage.dataset.state;
-    }
-  };
-
-  const updateSearchHint = () => {
-    if (!hintElement || !queryInput) {
       return;
     }
-    const suggestion = (state.suggestedQuery || "").trim();
-    const query = queryInput.value.trim();
-    const hasQueryMatch = Boolean(query && state.lastQuery && query === state.lastQuery);
-    const isSameText =
-      suggestion && query
-        ? suggestion.localeCompare(query, undefined, { sensitivity: "accent" }) === 0
-        : false;
-    const shouldShow = Boolean(suggestion && hasQueryMatch && !selectedCard && !isSameText);
-    if (shouldShow) {
-      hintElement.textContent = `Może chodziło Ci o: ${suggestion}`;
-      hintElement.hidden = false;
-      queryInput.setAttribute("data-hint-active", "true");
-    } else {
-      hintElement.textContent = "";
-      hintElement.hidden = true;
-      queryInput.removeAttribute("data-hint-active");
+    element.textContent = message;
+    element.dataset.variant = variant;
+    element.hidden = false;
+  };
+
+  const updateUserBadge = (user) => {
+    const username = user && user.username ? String(user.username).trim() : "";
+    const label = document.querySelector("[data-username-display]");
+    if (label) {
+      label.textContent = username || "Gość";
+    }
+    const loginButton = document.getElementById("login-button");
+    if (loginButton) {
+      loginButton.hidden = Boolean(username);
+    }
+    const logoutButton = document.getElementById("logout-button");
+    if (logoutButton) {
+      logoutButton.hidden = !username;
     }
   };
 
-  const compareText = (left, right) =>
-    String(left || "").localeCompare(String(right || ""), undefined, { sensitivity: "base" });
-
-  const parseCardNumberValue = (card) => {
-    const raw = String(card?.number || card?.number_display || "");
-    const match = raw.match(/\d+/);
-    if (!match) {
-      return Number.NaN;
+  const apiFetch = async (path, options = {}) => {
+    const init = { ...options };
+    const headers = { Accept: "application/json", ...(options.headers || {}) };
+    if (init.body && !headers["Content-Type"]) {
+      headers["Content-Type"] = "application/json";
     }
-    const value = Number.parseInt(match[0], 10);
-    return Number.isNaN(value) ? Number.NaN : value;
-  };
-
-  const compareNumberAsc = (a, b) => {
-    const valueA = parseCardNumberValue(a);
-    const valueB = parseCardNumberValue(b);
-    const aIsNaN = Number.isNaN(valueA);
-    const bIsNaN = Number.isNaN(valueB);
-    if (!aIsNaN && !bIsNaN && valueA !== valueB) {
-      return valueA - valueB;
+    const token = getToken();
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
     }
-    if (aIsNaN && !bIsNaN) {
-      return 1;
-    }
-    if (!aIsNaN && bIsNaN) {
-      return -1;
-    }
-    return compareText(a?.number || a?.number_display, b?.number || b?.number_display);
-  };
-
-  const comparators = {
-    name_asc: (a, b) => compareText(a?.name, b?.name),
-    name_desc: (a, b) => compareText(b?.name, a?.name),
-    number_asc: compareNumberAsc,
-    number_desc: (a, b) => compareNumberAsc(b, a),
-    set_asc: (a, b) => compareText(a?.set_name, b?.set_name),
-    set_desc: (a, b) => compareText(b?.set_name, a?.set_name),
-  };
-
-  const getSortedResults = () => {
-    const base = [...state.items];
-    const comparator = state.sortMode ? comparators[state.sortMode] : null;
-    if (comparator) {
-      base.sort(comparator);
-    }
-    return base;
-  };
-
-  const updateSelectionHighlight = () => {
-    const items = resultsContainer.querySelectorAll("[data-result-key]");
-    items.forEach((item) => {
-      if (!(item instanceof HTMLElement)) {
-        return;
-      }
-      if (selectedKey && item.dataset.resultKey === selectedKey) {
-        item.classList.add("is-selected");
-      } else {
-        item.classList.remove("is-selected");
-      }
-    });
-  };
-
-  const updateSortDisabled = () => {
-    if (sortSelect) {
-      sortSelect.disabled = state.total <= 1;
-    }
-  };
-
-  const createResultItem = (card) => {
-    const item = document.createElement("article");
-    item.className = "card-search-item";
-    item.dataset.resultKey = buildResultKey(card);
-    item.setAttribute("role", "listitem");
-
-    const cardName = card?.name?.trim() || "Nieznana karta";
-
-    const link = document.createElement("a");
-    link.className = "card-search-link";
-    link.href = buildCardDetailUrl(card);
-    link.setAttribute("aria-label", `Przejdź do szczegółów karty ${cardName}`);
-
-    const media = document.createElement("div");
-    media.className = "card-search-thumb-wrapper";
-    if (card.image_small || card.image_large) {
-      const img = document.createElement("img");
-      img.className = "card-search-thumb";
-      img.src = card.image_small || card.image_large;
-      img.alt = card.name ? `Podgląd ${card.name}` : "Podgląd karty";
-      img.loading = "lazy";
-      media.appendChild(img);
-    } else {
-      const placeholder = document.createElement("div");
-      placeholder.className = "card-search-thumb placeholder";
-      placeholder.textContent = "🃏";
-      placeholder.setAttribute("aria-hidden", "true");
-      media.appendChild(placeholder);
-    }
-
-    const addButton = document.createElement("button");
-    addButton.type = "button";
-    addButton.className = "card-search-add-button";
-    addButton.textContent = "+";
-    addButton.title = `Dodaj ${cardName} do kolekcji`;
-    addButton.setAttribute("aria-label", `Dodaj kartę ${cardName} do kolekcji`);
-    addButton.addEventListener("click", async (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (addButton.disabled) {
-        return;
-      }
-      addButton.disabled = true;
-      addButton.dataset.loading = "true";
+    init.headers = headers;
+    const response = await fetch(path, init);
+    let payload = null;
+    if (response.status !== 204) {
       try {
-        await addCard(form, cardSearchApi, card);
-      } finally {
-        addButton.disabled = false;
-        delete addButton.dataset.loading;
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
       }
-    });
-    media.appendChild(addButton);
-    link.appendChild(media);
-
-    const info = document.createElement("div");
-    info.className = "card-search-info";
-
-    const title = document.createElement("h3");
-    title.className = "card-search-title";
-    title.textContent = cardName;
-    info.appendChild(title);
-
-    const numberMeta = document.createElement("p");
-    numberMeta.className = "card-search-number";
-    numberMeta.textContent = formatCardNumber(card) || card.number || "Brak numeru";
-    info.appendChild(numberMeta);
-
-    const setMeta = document.createElement("p");
-    setMeta.className = "card-search-set";
-    const setText = document.createElement("span");
-    setText.textContent = card.set_name || "Brak informacji o secie";
-    setMeta.appendChild(setText);
-    info.appendChild(setMeta);
-
-    link.appendChild(info);
-    item.appendChild(link);
-
-    item.addEventListener("click", (event) => {
-      const target = event.target;
-      if (target instanceof HTMLElement && target.closest(".card-search-add-button")) {
-        return;
-      }
-      applySuggestion(card);
-    });
-
-    return item;
-  };
-
-  const renderResults = () => {
-    const sorted = getSortedResults();
-    resultsContainer.innerHTML = "";
-    if (!sorted.length) {
-      resultsContainer.hidden = true;
-    } else {
-      const fragment = document.createDocumentFragment();
-      sorted.forEach((card) => {
-        fragment.appendChild(createResultItem(card));
-      });
-      resultsContainer.hidden = false;
-      resultsContainer.appendChild(fragment);
     }
-
-    updateSelectionHighlight();
-  };
-
-  const clearSelection = () => {
-    selectedCard = null;
-    selectedKey = "";
-    if (rarityInput) {
-      rarityInput.value = "";
-    }
-    updateSelectionHighlight();
-    eventTarget.dispatchEvent(new Event("cardsearch:clear"));
-    updateSearchHint();
-  };
-
-  const applySuggestion = (card) => {
-    selectedCard = card;
-    selectedKey = buildResultKey(card);
-    const numberLabel = formatCardNumber(card) || card.number || "";
-    const queryParts = [card.name || "", numberLabel].filter(Boolean);
-    queryInput.value = queryParts.join(" ").trim();
-    if (rarityInput) {
-      rarityInput.value = card.rarity || "";
-    }
-    updateSelectionHighlight();
-    eventTarget.dispatchEvent(new CustomEvent("cardsearch:select", { detail: { card } }));
-    updateSearchHint();
-  };
-
-  const loadResults = async () => {
-    const query = queryInput.value.trim();
-    if (!query) {
-      state.items = [];
-      state.total = 0;
-      state.lastQuery = "";
-      state.suggestedQuery = "";
-      updateSummary(0);
-      updateStatus("");
-      resultsContainer.innerHTML = "";
-      resultsContainer.hidden = true;
-      if (resultsSection) {
-        resultsSection.hidden = true;
+    if (!response.ok) {
+      if (response.status === 401) {
+        clearToken();
       }
-      updateSortDisabled();
-      updateSearchHint();
-      return [];
-    }
-
-    clearSelection();
-
-    const params = new URLSearchParams({
-      query,
-    });
-
-    const currentRequest = ++requestId;
-    state.sortMode = sortSelect?.value || state.sortMode || "relevance";
-    if (resultsSection) {
-      resultsSection.hidden = false;
-    }
-    updateSummary(0);
-    updateStatus("Wyszukiwanie kart...", "loading");
-    resultsContainer.innerHTML = "";
-    resultsContainer.hidden = true;
-    updateSortDisabled();
-
-    try {
-      const payload = await apiFetch(`/cards/search?${params.toString()}`);
-      if (currentRequest !== requestId) {
-        return [];
-      }
-
-      const responseItems = Array.isArray(payload?.items) ? payload.items : [];
-      const responseTotal = Number.isFinite(payload?.total)
-        ? Math.max(0, Number(payload.total))
-        : responseItems.length;
-      state.items = responseItems;
-      state.total = responseTotal;
-      state.lastQuery = query;
-      const payloadSuggestion =
-        typeof payload?.suggested_query === "string" ? payload.suggested_query.trim() : "";
-      if (payloadSuggestion) {
-        state.suggestedQuery = payloadSuggestion;
-      } else {
-        const fallback = responseItems.find(
-          (item) => typeof item?.name === "string" && item.name.trim()
-        );
-        state.suggestedQuery = fallback?.name?.trim() || "";
-      }
-
-      renderResults();
-      updateSortDisabled();
-      updateSummary(state.total);
-      if (!state.total) {
-        updateStatus("Nie znaleziono kart dla podanych kryteriów.");
-      } else {
-        updateStatus("");
-      }
-      eventTarget.dispatchEvent(
-        new CustomEvent("cardsearch:results", { detail: { count: state.total } })
-      );
-      updateSearchHint();
-      return state.items;
-    } catch (error) {
-      if (currentRequest !== requestId) {
-        return [];
-      }
-      state.items = [];
-      state.total = 0;
-      state.lastQuery = "";
-      state.suggestedQuery = "";
-      renderResults();
-      updateSummary(0);
-      updateStatus(error.message || "Nie udało się pobrać wyników.", "error");
-      updateSortDisabled();
-      eventTarget.dispatchEvent(new CustomEvent("cardsearch:results", { detail: { count: 0 } }));
-      updateSearchHint();
+      const error = new Error((payload && payload.detail) || "Wystąpił błąd.");
+      error.status = response.status;
       throw error;
     }
+    return payload;
   };
 
-  const search = () => {
-    clearSelection();
-    return loadResults();
-  };
-
-  const handleInputChange = () => {
-    clearSelection();
-    state.lastQuery = "";
-    updateSearchHint();
-  };
-
-  queryInput.addEventListener("input", handleInputChange);
-
-  sortSelect?.addEventListener("change", () => {
-    state.sortMode = sortSelect.value || "relevance";
-    renderResults();
-  });
-
-  updateSortDisabled();
-
-  const api = {
-    getSelectedCard: () => selectedCard,
-    clearSelection: () => {
-      clearSelection();
-    },
-    reset: () => {
-      clearSelection();
-      state.items = [];
-      state.total = 0;
-      state.lastQuery = "";
-      state.suggestedQuery = "";
-      updateSummary(0);
-      updateStatus("");
-      resultsContainer.innerHTML = "";
-      resultsContainer.hidden = true;
-      if (resultsSection) {
-        resultsSection.hidden = true;
+  const fetchCurrentUser = async () => {
+    const token = getToken();
+    if (!token) {
+      currentUser = null;
+      updateUserBadge(null);
+      return null;
+    }
+    try {
+      const user = await apiFetch("/users/me");
+      currentUser = user;
+      updateUserBadge(user);
+      return user;
+    } catch (error) {
+      currentUser = null;
+      updateUserBadge(null);
+      if (error.status === 401) {
+        console.warn("Authentication expired");
       }
-      updateSortDisabled();
-      updateSearchHint();
-    },
-    search,
-  };
-  cardSearchApi = api;
-  return api;
-}
-
-async function addCard(form, cardSearch, selectedCardOverride = null) {
-  const alertBox = document.getElementById("add-card-alert");
-  showAlert(alertBox, "");
-  const selectedCard = selectedCardOverride ?? cardSearch?.getSelectedCard?.();
-  if (!selectedCard) {
-    showAlert(alertBox, "Najpierw wyszukaj kartę i wybierz ją z listy wyników.");
-    return;
-  }
-  const data = formToJSON(form);
-  if (!data.name) data.name = selectedCard.name;
-  if (!data.number) data.number = selectedCard.number;
-  if (!data.set_name) data.set_name = selectedCard.set_name;
-  if (!data.set_code) data.set_code = selectedCard.set_code;
-  if (data.rarity === undefined && selectedCard.rarity) {
-    data.rarity = selectedCard.rarity;
-  }
-  const numberValue = String(data.number ?? "");
-  const numberParts = numberValue.includes("/")
-    ? numberValue.split("/", 1)[0]
-    : numberValue;
-  const payload = {
-    quantity: Number(data.quantity) || 1,
-    purchase_price: data.purchase_price ? Number(data.purchase_price) : undefined,
-    is_reverse: Boolean(data.is_reverse),
-    is_holo: Boolean(data.is_holo),
-    card: {
-      name: data.name,
-      number: numberParts.trim(),
-      set_name: data.set_name,
-      set_code: data.set_code || null,
-    },
-  };
-  if (data.rarity !== undefined) {
-    payload.card.rarity = data.rarity || undefined;
-  }
-  if (selectedCard.image_small) {
-    payload.card.image_small = selectedCard.image_small;
-  }
-  if (selectedCard.image_large) {
-    payload.card.image_large = selectedCard.image_large;
-  }
-  try {
-    await apiFetch("/cards/", {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    const shouldResetSearch = !selectedCardOverride;
-    if (shouldResetSearch) {
-      form.reset();
-      cardSearch?.reset?.();
-    } else {
-      cardSearch?.clearSelection?.();
+      return null;
     }
-    const hasCollection = document.getElementById("collection-table");
-    const hasSummary = document.getElementById("summary-count");
-    if (hasCollection) {
-      await loadCollection();
-      if (!hasSummary && document.getElementById("summary-count")) {
-        await loadSummary();
+  };
+
+  const setupNavigation = () => {
+    const nav = document.querySelector("[data-nav]");
+    const toggle = document.querySelector("[data-nav-toggle]");
+    if (nav && toggle) {
+      toggle.addEventListener("click", () => {
+        const expanded = toggle.getAttribute("aria-expanded") === "true";
+        const next = !expanded;
+        toggle.setAttribute("aria-expanded", String(next));
+        nav.dataset.open = String(next);
+      });
+      document.addEventListener("click", (event) => {
+        if (!nav.contains(event.target) && !toggle.contains(event.target)) {
+          nav.dataset.open = "false";
+          toggle.setAttribute("aria-expanded", "false");
+        }
+      });
+    }
+
+    const logoutButton = document.querySelector("[data-logout]");
+    if (logoutButton) {
+      logoutButton.addEventListener("click", () => {
+        clearToken();
+        currentUser = null;
+        updateUserBadge(null);
+        window.location.href = "/login";
+      });
+    }
+  };
+
+  const setupAuthForms = () => {
+    const loginForm = document.getElementById("login-form");
+    if (loginForm) {
+      const alertBox = document.getElementById("login-alert");
+      loginForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const payload = formToJSON(loginForm);
+        showAlert(alertBox, "");
+        try {
+          const data = await apiFetch("/users/login", {
+            method: "POST",
+            body: JSON.stringify(payload),
+          });
+          setToken(data.access_token);
+          await fetchCurrentUser();
+          window.location.href = "/collection";
+        } catch (error) {
+          showAlert(alertBox, error.message || "Nie udało się zalogować.", "error");
+        }
+      });
+    }
+
+    const registerForm = document.getElementById("register-form");
+    if (registerForm) {
+      const alertBox = document.getElementById("register-alert");
+      registerForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const payload = formToJSON(registerForm);
+        showAlert(alertBox, "");
+        try {
+          await apiFetch("/users/register", {
+            method: "POST",
+            body: JSON.stringify(payload),
+          });
+          showAlert(
+            alertBox,
+            "Konto utworzone. Możesz się zalogować.",
+            "success",
+          );
+          registerForm.reset();
+        } catch (error) {
+          showAlert(alertBox, error.message || "Nie udało się utworzyć konta.", "error");
+        }
+      });
+    }
+  };
+
+  const buildCollectionRow = (entry) => {
+    const tr = document.createElement("tr");
+    tr.dataset.entryId = String(entry.id);
+    const card = entry.card || {};
+    const purchase =
+      typeof entry.purchase_price === "number"
+        ? entry.purchase_price.toFixed(2)
+        : entry.purchase_price || "";
+    tr.innerHTML = `
+      <td data-label="Karta">
+        <strong>${escapeHtml(card.name || "Nieznana karta")}</strong>
+      </td>
+      <td data-label="Set">${escapeHtml(card.set_name || "–")}</td>
+      <td data-label="Numer">${escapeHtml(card.number || "–")}</td>
+      <td data-label="Ilość">
+        <input type="number" min="0" step="1" value="${entry.quantity}" data-field="quantity" />
+      </td>
+      <td data-label="Reverse" class="table-checkbox">
+        <input type="checkbox" data-field="is_reverse" ${entry.is_reverse ? "checked" : ""} />
+      </td>
+      <td data-label="Holo" class="table-checkbox">
+        <input type="checkbox" data-field="is_holo" ${entry.is_holo ? "checked" : ""} />
+      </td>
+      <td data-label="Cena zakupu">
+        <input
+          type="number"
+          min="0"
+          step="0.01"
+          inputmode="decimal"
+          placeholder="0.00"
+          value="${escapeHtml(purchase)}"
+          data-field="purchase_price"
+        />
+      </td>
+      <td data-label="Akcje" class="table-actions">
+        <button type="button" class="button inline" data-action="save" data-id="${entry.id}">Zapisz</button>
+        <button type="button" class="button inline danger" data-action="delete" data-id="${entry.id}">Usuń</button>
+      </td>
+    `;
+    return tr;
+  };
+
+  const renderCollection = (entries) => {
+    const body = document.getElementById("collection-table");
+    const emptyMessage = document.getElementById("collection-empty");
+    if (!body) return;
+    body.innerHTML = "";
+    if (!entries.length) {
+      if (emptyMessage) emptyMessage.hidden = false;
+      return;
+    }
+    if (emptyMessage) emptyMessage.hidden = true;
+    for (const entry of entries) {
+      body.appendChild(buildCollectionRow(entry));
+    }
+  };
+
+  const renderPortfolio = (entries) => {
+    const container = document.getElementById("portfolio-cards");
+    const emptyMessage = document.getElementById("portfolio-empty");
+    if (!container) return;
+    container.innerHTML = "";
+    if (!entries.length) {
+      if (emptyMessage) emptyMessage.hidden = false;
+      return;
+    }
+    if (emptyMessage) emptyMessage.hidden = true;
+    for (const entry of entries) {
+      const card = entry.card || {};
+      const item = document.createElement("article");
+      item.className = "portfolio-card";
+      const purchase =
+        typeof entry.purchase_price === "number"
+          ? `${entry.purchase_price.toFixed(2)} PLN`
+          : entry.purchase_price
+            ? `${entry.purchase_price} PLN`
+            : "–";
+      item.innerHTML = `
+        <header>
+          <h3>${escapeHtml(card.name || "Nieznana karta")}</h3>
+          <p>${escapeHtml(card.set_name || "")}</p>
+        </header>
+        <dl>
+          <div>
+            <dt>Numer</dt>
+            <dd>${escapeHtml(card.number || "–")}</dd>
+          </div>
+          <div>
+            <dt>Ilość</dt>
+            <dd>${entry.quantity}</dd>
+          </div>
+          <div>
+            <dt>Reverse</dt>
+            <dd>${entry.is_reverse ? "Tak" : "Nie"}</dd>
+          </div>
+          <div>
+            <dt>Holo</dt>
+            <dd>${entry.is_holo ? "Tak" : "Nie"}</dd>
+          </div>
+          <div>
+            <dt>Cena zakupu</dt>
+            <dd>${purchase}</dd>
+          </div>
+        </dl>
+        <footer>
+          <a class="button inline" href="/collection">Edytuj w tabeli</a>
+        </footer>
+      `;
+      container.appendChild(item);
+    }
+  };
+
+  const loadCollection = async (options = {}) => {
+    const alertElement = options.alert || null;
+    const token = getToken();
+    if (!token) {
+      return;
+    }
+    try {
+      const entries = await apiFetch("/cards/");
+      collectionCache = Array.isArray(entries) ? entries : [];
+      renderCollection(collectionCache);
+      renderPortfolio(collectionCache);
+      if (alertElement && options.message) {
+        showAlert(alertElement, options.message, "success");
       }
-    } else if (hasSummary) {
-      await loadSummary();
-    }
-    showAlert(alertBox, "Karta została dodana do kolekcji.", "success");
-  } catch (error) {
-    showAlert(alertBox, error.message);
-  }
-}
-
-async function deleteEntry(id) {
-  await apiFetch(`/cards/${id}`, { method: "DELETE" });
-  await loadCollection();
-  await loadSummary();
-}
-
-function renderRelatedCardsList(cards) {
-  const container = document.getElementById("related-cards-list");
-  const empty = document.getElementById("related-empty");
-  if (!container) return;
-  container.innerHTML = "";
-  if (empty) {
-    empty.textContent = "Nie znaleziono innych kart z tą postacią.";
-  }
-  if (!Array.isArray(cards) || !cards.length) {
-    if (empty) empty.hidden = false;
-    return;
-  }
-  if (empty) empty.hidden = true;
-  const fragment = document.createDocumentFragment();
-  cards.forEach((card) => {
-    const article = document.createElement("article");
-    article.className = "related-card";
-    const link = document.createElement("a");
-    link.href = buildCardDetailUrl(card);
-
-    if (card.image_small || card.image_large) {
-      const img = document.createElement("img");
-      img.className = "related-card-image";
-      img.src = card.image_small || card.image_large;
-      img.alt = `Podgląd ${card.name}`;
-      img.loading = "lazy";
-      link.appendChild(img);
-    } else {
-      const placeholder = document.createElement("div");
-      placeholder.className = "related-card-image related-card-placeholder";
-      placeholder.textContent = "🃏";
-      placeholder.setAttribute("aria-hidden", "true");
-      link.appendChild(placeholder);
-    }
-
-    const body = document.createElement("div");
-    body.className = "related-card-body";
-
-    if (card.set_name) {
-      const setWrapper = document.createElement("div");
-      setWrapper.className = "related-card-set";
-      const setName = document.createElement("span");
-      setName.textContent = card.set_name;
-      setWrapper.appendChild(setName);
-      body.appendChild(setWrapper);
-    }
-
-    const title = document.createElement("h3");
-    title.className = "related-card-title";
-    title.textContent = card.name || "";
-    body.appendChild(title);
-
-    const meta = document.createElement("p");
-    meta.className = "related-card-meta";
-    const numberText = formatCardNumber(card);
-    const rarity = card.rarity ? String(card.rarity) : "";
-    meta.textContent = [numberText ? `Nr ${numberText}` : "", rarity].filter(Boolean).join(" • ");
-    body.appendChild(meta);
-
-    link.appendChild(body);
-    article.appendChild(link);
-    fragment.appendChild(article);
-  });
-  container.appendChild(fragment);
-}
-
-function updateCardDetailImage(image, placeholder, card) {
-  if (!image) {
-    return;
-  }
-  const showPlaceholder = () => {
-    image.hidden = true;
-    image.setAttribute("hidden", "");
-    if (placeholder) {
-      placeholder.hidden = false;
+    } catch (error) {
+      if (alertElement) {
+        showAlert(
+          alertElement,
+          error.message || "Nie udało się pobrać danych kolekcji.",
+          "error",
+        );
+      }
+      if (error.status === 401) {
+        window.location.href = "/login";
+      }
     }
   };
-  const showImage = () => {
-    image.hidden = false;
-    image.removeAttribute("hidden");
-    if (placeholder) {
-      placeholder.hidden = true;
-    }
-  };
-  const imageSource = card?.image_large || card?.image_small || "";
-  const cardName = card?.name ? String(card.name).trim() : "";
-  const altText = cardName ? `Podgląd karty ${cardName}` : "Podgląd karty";
-  image.alt = altText;
-  if (!imageSource) {
-    image.removeAttribute("src");
-    image.onload = null;
-    image.onerror = null;
-    showPlaceholder();
-    return;
-  }
 
-  const handleLoad = () => {
-    showImage();
-  };
-  const handleError = () => {
-    image.removeAttribute("src");
-    showPlaceholder();
-  };
+  const readRowPayload = (row) => {
+    const quantityInput = row.querySelector('[data-field="quantity"]');
+    const reverseInput = row.querySelector('[data-field="is_reverse"]');
+    const holoInput = row.querySelector('[data-field="is_holo"]');
+    const priceInput = row.querySelector('[data-field="purchase_price"]');
 
-  image.onload = handleLoad;
-  image.onerror = handleError;
+    const quantity = quantityInput ? Number.parseInt(quantityInput.value, 10) : 0;
+    const purchaseRaw = priceInput ? priceInput.value.trim() : "";
+    const purchase = purchaseRaw ? Number.parseFloat(purchaseRaw.replace(",", ".")) : null;
 
-  if (image.src !== imageSource) {
-    showPlaceholder();
-    image.src = imageSource;
-  }
-
-  if (image.complete && image.naturalWidth > 0) {
-    handleLoad();
-  } else {
-    showPlaceholder();
-  }
-}
-
-async function addDetailCardToCollection(card, button) {
-  const alertBox = document.getElementById("card-detail-alert");
-  showAlert(alertBox, "");
-  if (!card || !card.name || !card.number || !card.set_name) {
-    showAlert(alertBox, "Brakuje danych karty. Spróbuj ponownie później.");
-    return;
-  }
-  try {
-    if (button) {
-      button.dataset.loading = "true";
-      button.disabled = true;
-    }
-    const payload = {
-      quantity: 1,
-      card: {
-        name: card.name,
-        number: card.number,
-        set_name: card.set_name,
-        set_code: card.set_code || null,
-      },
+    return {
+      quantity: Number.isFinite(quantity) && quantity >= 0 ? quantity : 0,
+      purchase_price:
+        purchaseRaw && Number.isFinite(purchase) && purchase >= 0 ? Number(purchase.toFixed(2)) : null,
+      is_reverse: Boolean(reverseInput && reverseInput.checked),
+      is_holo: Boolean(holoInput && holoInput.checked),
     };
-    if (card.rarity) {
-      payload.card.rarity = card.rarity;
+  };
+
+  const handleSaveEntry = async (id, row) => {
+    const alertBox = document.getElementById("collection-alert");
+    const payload = readRowPayload(row);
+    try {
+      const updated = await apiFetch(`/cards/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      });
+      collectionCache = collectionCache.map((entry) =>
+        entry.id === updated.id ? updated : entry,
+      );
+      renderCollection(collectionCache);
+      renderPortfolio(collectionCache);
+      showAlert(alertBox, "Wpis zaktualizowany.", "success");
+    } catch (error) {
+      showAlert(alertBox, error.message || "Nie udało się zapisać zmian.", "error");
     }
-    if (card.image_small) {
-      payload.card.image_small = card.image_small;
+  };
+
+  const handleDeleteEntry = async (id) => {
+    const alertBox = document.getElementById("collection-alert");
+    try {
+      await apiFetch(`/cards/${id}`, { method: "DELETE" });
+      collectionCache = collectionCache.filter((entry) => String(entry.id) !== String(id));
+      renderCollection(collectionCache);
+      renderPortfolio(collectionCache);
+      showAlert(alertBox, "Wpis usunięty z kolekcji.", "success");
+    } catch (error) {
+      showAlert(alertBox, error.message || "Nie udało się usunąć wpisu.", "error");
     }
-    if (card.image_large) {
-      payload.card.image_large = card.image_large;
+  };
+
+  const setupCollectionPage = () => {
+    const table = document.getElementById("collection-table");
+    if (table) {
+      table.addEventListener("click", (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        const action = target.dataset.action;
+        const id = target.dataset.id;
+        if (!action || !id) return;
+        const row = target.closest("tr");
+        if (!row) return;
+        if (action === "save") {
+          handleSaveEntry(id, row);
+        }
+        if (action === "delete") {
+          handleDeleteEntry(id);
+        }
+      });
     }
-    await apiFetch("/cards/", {
-      method: "POST",
-      body: JSON.stringify(payload),
-    });
-    const hasCollection = document.getElementById("collection-table");
-    const hasSummary = document.getElementById("summary-count");
-    if (hasCollection) {
-      await loadCollection();
-      if (!hasSummary && document.getElementById("summary-count")) {
-        await loadSummary();
+
+    const refreshButton = document.getElementById("refresh-collection");
+    if (refreshButton) {
+      refreshButton.addEventListener("click", () => {
+        const alertBox = document.getElementById("collection-alert");
+        showAlert(alertBox, "Ładuję dane…");
+        loadCollection({ alert: alertBox, message: "Lista została odświeżona." });
+      });
+    }
+  };
+
+  const setupPortfolioPage = () => {
+    const refreshButton = document.getElementById("refresh-portfolio");
+    if (refreshButton) {
+      refreshButton.addEventListener("click", () => {
+        const alertBox = document.getElementById("portfolio-alert");
+        showAlert(alertBox, "Ładuję dane…");
+        loadCollection({ alert: alertBox, message: "Dane zostały odświeżone." });
+      });
+    }
+  };
+
+  const buildCardPayload = (form) => ({
+    name: form.elements.card_name?.value?.trim() || "",
+    number: form.elements.card_number?.value?.trim() || "",
+    set_name: form.elements.card_set_name?.value?.trim() || "",
+    set_code: form.elements.card_set_code?.value?.trim() || null,
+    rarity: form.elements.card_rarity?.value?.trim() || null,
+    image_small: form.elements.card_image_small?.value?.trim() || null,
+    image_large: form.elements.card_image_large?.value?.trim() || null,
+  });
+
+  const renderSearchResults = (
+    items = [],
+    summaryElement,
+    emptyMessage,
+    totalCount = 0,
+  ) => {
+    const container = document.getElementById("card-search-results");
+    if (!container) return;
+    container.innerHTML = "";
+    if (!items.length) {
+      if (summaryElement) {
+        summaryElement.hidden = true;
+        summaryElement.textContent = "";
       }
-    } else if (hasSummary) {
-      await loadSummary();
+      if (emptyMessage) {
+        emptyMessage.hidden = false;
+        emptyMessage.textContent = "Nie znaleziono kart spełniających kryteria.";
+      }
+      return;
     }
-    showAlert(alertBox, "Karta została dodana do kolekcji.", "success");
-  } catch (error) {
-    showAlert(alertBox, error.message);
-  } finally {
-    if (button) {
-      button.disabled = false;
-      delete button.dataset.loading;
+    if (emptyMessage) emptyMessage.hidden = true;
+    if (summaryElement) {
+      summaryElement.hidden = false;
+      const totalLabel = totalCount && totalCount > items.length ? ` z ${totalCount}` : "";
+      summaryElement.textContent = `Znaleziono ${items.length}${totalLabel} wyników.`;
     }
-  }
-}
+    for (const item of items) {
+      const article = document.createElement("article");
+      article.className = "card-search-item";
+      const numberLabel = item.number_display || item.number;
+      article.innerHTML = `
+        <div class="card-search-info">
+          <h3>${escapeHtml(item.name)}</h3>
+          <p>${escapeHtml(item.set_name || "")}</p>
+          <p class="card-search-meta">${escapeHtml(numberLabel || "")}</p>
+        </div>
+        <form class="card-search-form" data-card-form>
+          <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
+          <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
+          <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
+          <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
+          <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
+          <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
+          <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
+          <label>
+            Ilość
+            <input type="number" name="quantity" min="0" step="1" value="1" />
+          </label>
+          <label>
+            Cena zakupu
+            <input type="number" name="purchase_price" min="0" step="0.01" inputmode="decimal" placeholder="0.00" />
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="is_reverse" /> Reverse
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="is_holo" /> Holo
+          </label>
+          <div class="form-footer">
+            <button type="submit" class="button primary">Dodaj do kolekcji</button>
+          </div>
+        </form>
+      `;
+      container.appendChild(article);
+    }
+  };
 
-async function loadCardDetail(container) {
-  const alertBox = document.getElementById("card-detail-alert");
-  showAlert(alertBox, "");
-  const params = new URLSearchParams();
-  const name = container.dataset.name?.trim();
-  const number = container.dataset.number?.trim();
-  const setCode = container.dataset.setCode?.trim();
-  const setName = container.dataset.setName?.trim();
-  const total = container.dataset.total?.trim();
-  if (name) params.set("name", name);
-  if (number) params.set("number", number);
-  if (setCode) params.set("set_code", setCode);
-  if (setName) params.set("set_name", setName);
-  if (total) params.set("total", total);
+  const setupAddCardPage = () => {
+    const form = document.querySelector("[data-card-search-form]");
+    if (!form) return;
+    const alertBox = document.getElementById("add-card-alert");
+    const summary = document.getElementById("card-search-summary");
+    const emptyMessage = document.getElementById("card-search-empty");
 
-  try {
-    const detail = await apiFetch(`/cards/info?${params.toString()}`);
-    const card = { ...(detail.card || {}) };
-    if (!card.name && container.dataset.name) {
-      card.name = container.dataset.name.trim();
-    }
-    if (!card.number && container.dataset.number) {
-      card.number = container.dataset.number.trim();
-    }
-    if (!card.set_name && container.dataset.setName) {
-      card.set_name = container.dataset.setName.trim();
-    }
-    if (!card.set_code && container.dataset.setCode) {
-      card.set_code = container.dataset.setCode.trim();
-    }
-    if (!card.total && container.dataset.total) {
-      card.total = container.dataset.total.trim();
-    }
-    renderRelatedCardsList(detail.related || []);
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const queryInput = form.querySelector("input[name='query']");
+      const query = queryInput ? queryInput.value.trim() : "";
+      if (!query) {
+        showAlert(alertBox, "Wpisz nazwę lub numer karty.", "error");
+        queryInput?.focus();
+        return;
+      }
+      showAlert(alertBox, "Szukam kart…");
+      try {
+        const params = new URLSearchParams({ query });
+        const data = await apiFetch(`/cards/search?${params.toString()}`);
+        renderSearchResults(data?.items || [], summary, emptyMessage, data?.total || 0);
+        showAlert(alertBox, "");
+      } catch (error) {
+        showAlert(alertBox, error.message || "Nie udało się pobrać wyników.", "error");
+      }
+    });
 
-    const fallbackTitle = container.dataset.name?.trim() || "Szczegóły karty";
+    const results = document.getElementById("card-search-results");
+    if (results) {
+      results.addEventListener("submit", async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLFormElement)) return;
+        event.preventDefault();
+        const alertTarget = document.getElementById("add-card-alert");
+        const quantity = Number.parseInt(target.elements.quantity?.value || "1", 10);
+        const priceRaw = target.elements.purchase_price?.value?.trim() || "";
+        const price = priceRaw ? Number.parseFloat(priceRaw.replace(",", ".")) : null;
+        const payload = {
+          quantity: Number.isFinite(quantity) && quantity >= 0 ? quantity : 0,
+          purchase_price:
+            priceRaw && Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : null,
+          is_reverse: Boolean(target.elements.is_reverse?.checked),
+          is_holo: Boolean(target.elements.is_holo?.checked),
+          card: buildCardPayload(target),
+        };
+        if (!payload.card.name || !payload.card.number || !payload.card.set_name) {
+          showAlert(alertTarget, "Brakuje danych karty.", "error");
+          return;
+        }
+        showAlert(alertTarget, "Dodaję kartę do kolekcji…");
+        try {
+          await apiFetch("/cards/", {
+            method: "POST",
+            body: JSON.stringify(payload),
+          });
+          showAlert(alertTarget, "Karta została dodana do kolekcji.", "success");
+          target.reset();
+          loadCollection();
+        } catch (error) {
+          showAlert(alertTarget, error.message || "Nie udało się dodać karty.", "error");
+        }
+      });
+    }
+  };
+
+  const renderCardDetail = (card) => {
+    if (!card) return;
     const title = document.getElementById("card-detail-title");
     if (title) {
-      title.textContent = card.name || fallbackTitle;
+      title.textContent = card.name || "Szczegóły karty";
     }
-    document.title = `${card.name || fallbackTitle} - Kartoteka`;
-
-    const era = document.getElementById("card-detail-era");
-    if (era) {
-      if (card.series) {
-        era.textContent = card.series;
-        era.hidden = false;
-      } else {
-        era.hidden = true;
-      }
-    }
+    const setName = document.getElementById("card-detail-set-name");
+    if (setName) setName.textContent = card.set_name || "";
+    const number = document.getElementById("card-detail-number");
+    if (number) number.textContent = card.number_display || card.number || "";
+    const rarity = document.getElementById("card-detail-rarity");
+    if (rarity) rarity.textContent = card.rarity || "";
+    const total = document.getElementById("card-detail-total");
+    if (total) total.textContent = card.total || "";
+    const release = document.getElementById("card-detail-release");
+    if (release) release.textContent = card.release_date || "";
 
     const image = document.getElementById("card-detail-image");
     const placeholder = document.getElementById("card-detail-placeholder");
-    updateCardDetailImage(image, placeholder, card);
-
-    const setNameTarget = document.getElementById("card-detail-set-name");
-    if (setNameTarget) {
-      setNameTarget.textContent = card.set_name || container.dataset.setName || "";
-    }
-
-    const artist = document.getElementById("card-detail-artist");
-    if (artist) {
-      if (card.artist) {
-        artist.textContent = `Ilustrator: ${card.artist}`;
-        artist.hidden = false;
+    if (image) {
+      if (card.image_large || card.image_small) {
+        image.src = card.image_large || card.image_small;
+        image.hidden = false;
+        if (placeholder) placeholder.hidden = true;
       } else {
-        artist.textContent = "";
-        artist.hidden = true;
+        image.hidden = true;
+        if (placeholder) placeholder.hidden = false;
       }
     }
+  };
 
-    const numberField = document.getElementById("card-detail-number");
-    if (numberField) {
-      numberField.textContent = formatCardNumber(card) || "—";
-    }
-
-    const rarityField = document.getElementById("card-detail-rarity");
-    if (rarityField) {
-      const rarityLabel = formatRarityLabel(card.rarity);
-      rarityField.textContent = rarityLabel || "—";
-    }
-
-    const totalField = document.getElementById("card-detail-total");
-    if (totalField) {
-      const totalValue = card.total || container.dataset.total || "";
-      totalField.textContent = totalValue || "—";
-    }
-
-    const releaseField = document.getElementById("card-detail-release");
-    if (releaseField) {
-      let label = card.release_date || "";
-      if (label) {
-        const parsed = new Date(label);
-        if (!Number.isNaN(parsed.getTime())) {
-          label = parsed.toLocaleDateString("pl-PL");
-        }
-      }
-      releaseField.textContent = label || "—";
-    }
-
-    const addButton = document.getElementById("detail-add-button");
-    if (addButton) {
-      const canAdd = Boolean(card.name && card.number && card.set_name);
-      addButton.disabled = !canAdd;
-      addButton.onclick = (event) => {
-        event.preventDefault();
-        if (!canAdd || addButton.dataset.loading === "true") {
-          return;
-        }
-        void addDetailCardToCollection(card, addButton);
-      };
-    }
-
-    const buyButton = document.getElementById("detail-buy-button");
-    if (buyButton) {
-      const query = [card.name, card.set_name].filter(Boolean).join(" ");
-      buyButton.href = `https://kartoteka.shop/search?q=${encodeURIComponent(query)}`;
-    }
-
-    showAlert(alertBox, "");
-  } catch (error) {
-    renderRelatedCardsList([]);
-    const fallbackTitle =
-      container.dataset.name?.trim() ||
-      (container.dataset.number?.trim()
-        ? `Karta ${container.dataset.number.trim()}`
-        : "Szczegóły karty");
-    const titleElement = document.getElementById("card-detail-title");
-    if (titleElement) {
-      titleElement.textContent = fallbackTitle;
-    }
-    document.title = `${fallbackTitle} - Kartoteka`;
-
-    const addButton = document.getElementById("detail-add-button");
-    if (addButton) {
-      addButton.disabled = true;
-      addButton.dataset.loading = "false";
-    }
-
-    showAlert(alertBox, error.message || "Nie udało się załadować danych karty.");
-  }
-}
-
-function bindCardDetail() {
-  const container = document.getElementById("card-detail-page");
-  if (!container) return;
-  loadCardDetail(container);
-}
-
-function applyAddCardPrefill(form, cardSearch) {
-  const params = new URLSearchParams(window.location.search);
-  if (!params.has("name")) {
-    return;
-  }
-  const name = params.get("name") || "";
-  const number = params.get("number") || "";
-  const setName = params.get("set_name") || "";
-  const setCode = params.get("set_code") || "";
-  const total = params.get("total") || "";
-
-  const queryInput = form.querySelector('input[name="query"]');
-  if (queryInput) {
-    const identifier = [
-      name,
-      total && number ? `${number}/${total}` : number,
-      setName,
-    ]
-      .filter((part) => part && part.trim())
-      .join(" ")
-      .trim();
-    if (identifier) {
-      queryInput.value = identifier;
-    } else if (name) {
-      queryInput.value = name;
-    }
-  }
-
-  cardSearch?.reset?.();
-  if (cardSearch?.search) {
-    cardSearch.search().catch((error) => {
-      console.error(error);
-    });
-  }
-  window.history.replaceState({}, document.title, window.location.pathname);
-}
-
-function bindDashboard() {
-  const refreshBtn = document.getElementById("refresh-collection");
-  if (refreshBtn) {
-    refreshBtn.addEventListener("click", () => {
-      loadCollection();
-      loadSummary();
-    });
-  }
-  const table = document.getElementById("collection-table");
-  if (table) {
-    table.addEventListener("click", (event) => {
-      const target = event.target;
-      if (!(target instanceof HTMLElement)) return;
-      const action = target.dataset.action;
-      const id = target.dataset.id;
-      if (!action || !id) return;
-      if (action === "delete") {
-        deleteEntry(id);
-      }
-    });
-  }
-  loadCollection();
-  loadSummary();
-}
-
-function bindAddCardPage() {
-  const page = document.getElementById("add-card-page");
-  if (!page) return;
-  const form = document.getElementById("add-card-form");
-  if (!form) return;
-  const alertBox = document.getElementById("add-card-alert");
-  const cardSearch = setupCardSearch(form);
-
-  const executeSearch = async () => {
-    const queryInput = form.querySelector('input[name="query"]');
-    if (!queryInput || !queryInput.value.trim()) {
-      showAlert(alertBox, "Wpisz nazwę lub numer karty, aby rozpocząć wyszukiwanie.");
-      queryInput?.focus();
+  const renderRelatedCards = (items) => {
+    const container = document.getElementById("related-cards-list");
+    const empty = document.getElementById("related-empty");
+    if (!container) return;
+    container.innerHTML = "";
+    if (!items || !items.length) {
+      if (empty) empty.hidden = false;
       return;
     }
-    showAlert(alertBox, "");
-    try {
-      await cardSearch?.search?.();
-    } catch (error) {
-      showAlert(alertBox, error.message || "Nie udało się wyszukać kart.");
+    if (empty) empty.hidden = true;
+    for (const item of items) {
+      const anchor = document.createElement("a");
+      anchor.className = "related-card";
+      const params = new URLSearchParams({
+        name: item.name,
+        number: item.number,
+        set_name: item.set_name,
+      });
+      if (item.set_code) params.set("set_code", item.set_code);
+      anchor.href = `/cards/${encodeURIComponent(item.set_code || item.set_name || "")}/${encodeURIComponent(item.number)}?${params.toString()}`;
+      anchor.innerHTML = `
+        <span class="related-card-name">${escapeHtml(item.name)}</span>
+        <span class="related-card-meta">${escapeHtml(item.set_name || "")}</span>
+      `;
+      container.appendChild(anchor);
     }
   };
 
-  form.addEventListener("submit", (event) => {
-    event.preventDefault();
-    executeSearch();
-  });
-
-  applyAddCardPrefill(form, cardSearch);
-}
-
-async function bindSettingsPage() {
-  const page = document.getElementById("settings-page");
-  if (!page) return;
-
-  const profileForm = document.getElementById("settings-profile-form");
-  const passwordForm = document.getElementById("settings-password-form");
-  const profileAlert = profileForm?.querySelector(".alert");
-  const passwordAlert = passwordForm?.querySelector(".alert");
-  const emailInput = profileForm?.querySelector('input[name="email"]');
-  const avatarInput = profileForm?.querySelector('input[name="avatar_url"]');
-  const avatarChoices = profileForm
-    ? Array.from(profileForm.querySelectorAll('input[name="avatar_choice"]'))
-    : [];
-
-  const syncAvatarChoices = (value) => {
-    if (!avatarChoices.length) return;
-    const target = typeof value === "string" ? value.trim() : "";
-    let matchedRadio = null;
-    for (const radio of avatarChoices) {
-      const radioUrl = (radio.dataset.url || "").trim();
-      const isCustom = radio.dataset.custom === "true";
-      if (!isCustom && target && radioUrl === target) {
-        matchedRadio = radio;
-        break;
-      }
+  const setupCardDetailPage = () => {
+    const container = document.getElementById("card-detail-page");
+    if (!container) return;
+    const alertBox = document.getElementById("card-detail-alert");
+    const params = new URLSearchParams();
+    const name = container.dataset.name || "";
+    const number = container.dataset.number || "";
+    if (!name || !number) {
+      showAlert(alertBox, "Brakuje danych karty.", "error");
+      return;
     }
-    avatarChoices.forEach((radio) => {
-      const isCustom = radio.dataset.custom === "true";
-      if (matchedRadio) {
-        radio.checked = radio === matchedRadio;
-      } else {
-        radio.checked = isCustom;
-      }
-    });
+    params.set("name", name);
+    params.set("number", number);
+    const total = container.dataset.total || "";
+    const setCode = container.dataset.setCode || "";
+    const setName = container.dataset.setName || "";
+    if (total) params.set("total", total);
+    if (setCode) params.set("set_code", setCode);
+    if (setName) params.set("set_name", setName);
+
+    apiFetch(`/cards/info?${params.toString()}`)
+      .then((data) => {
+        renderCardDetail(data?.card);
+        renderRelatedCards(data?.related || []);
+        showAlert(alertBox, "");
+      })
+      .catch((error) => {
+        showAlert(alertBox, error.message || "Nie udało się pobrać danych karty.", "error");
+      });
+
+    const addButton = document.getElementById("detail-add-button");
+    if (addButton) {
+      addButton.addEventListener("click", () => {
+        const redirect = new URL("/cards/add", window.location.origin);
+        redirect.searchParams.set("name", name);
+        redirect.searchParams.set("number", number);
+        if (setName) redirect.searchParams.set("set_name", setName);
+        if (setCode) redirect.searchParams.set("set_code", setCode);
+        if (total) redirect.searchParams.set("total", total);
+        window.location.href = redirect.toString();
+      });
+    }
   };
 
-  if (avatarInput && avatarChoices.length) {
-    avatarInput.addEventListener("input", () => {
-      syncAvatarChoices(avatarInput.value);
-    });
-    avatarChoices.forEach((radio) => {
-      radio.addEventListener("change", () => {
-        const isCustom = radio.dataset.custom === "true";
-        const url = (radio.dataset.url || "").trim();
-        if (!avatarInput) return;
-        if (isCustom) {
-          if (!avatarInput.value) {
-            avatarInput.value = "";
+  const setupSettingsPage = async () => {
+    const page = document.getElementById("settings-page");
+    if (!page) return;
+
+    const profileForm = document.getElementById("settings-profile-form");
+    const passwordForm = document.getElementById("settings-password-form");
+    const profileAlert = profileForm?.querySelector(".alert");
+    const passwordAlert = passwordForm?.querySelector(".alert");
+
+    const user = currentUser || (await fetchCurrentUser());
+    if (profileForm) {
+      const emailInput = profileForm.querySelector('input[name="email"]');
+      const avatarInput = profileForm.querySelector('input[name="avatar_url"]');
+      const avatarChoices = Array.from(
+        profileForm.querySelectorAll('input[name="avatar_choice"]'),
+      );
+
+      const syncAvatarChoices = (value) => {
+        if (!avatarChoices.length) return;
+        const target = (value || "").trim();
+        let matched = null;
+        for (const radio of avatarChoices) {
+          const url = (radio.dataset.url || "").trim();
+          if (target && url && url === target) {
+            matched = radio;
+            break;
           }
-          avatarInput.focus();
-        } else {
-          avatarInput.value = url;
-          avatarInput.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        avatarChoices.forEach((radio) => {
+          const isCustom = radio.dataset.custom === "true";
+          if (matched) {
+            radio.checked = radio === matched;
+          } else {
+            radio.checked = isCustom;
+          }
+        });
+      };
+
+      if (user) {
+        if (emailInput && user.email) {
+          emailInput.value = user.email;
+        }
+        if (avatarInput && user.avatar_url) {
+          avatarInput.value = user.avatar_url;
+        }
+      }
+
+      if (avatarInput && avatarChoices.length) {
+        avatarInput.addEventListener("input", () => {
+          syncAvatarChoices(avatarInput.value);
+        });
+        avatarChoices.forEach((radio) => {
+          radio.addEventListener("change", () => {
+            const isCustom = radio.dataset.custom === "true";
+            if (isCustom) {
+              avatarInput.focus();
+              return;
+            }
+            avatarInput.value = radio.dataset.url || "";
+            syncAvatarChoices(avatarInput.value);
+          });
+        });
+        syncAvatarChoices(avatarInput.value);
+      }
+
+      profileForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const payload = formToJSON(profileForm);
+        const body = {
+          email: payload.email ? String(payload.email).trim() || null : null,
+          avatar_url: payload.avatar_url ? String(payload.avatar_url).trim() || null : null,
+        };
+        showAlert(profileAlert, "Zapisuję dane profilu…");
+        try {
+          const updated = await apiFetch("/users/me", {
+            method: "PATCH",
+            body: JSON.stringify(body),
+          });
+          currentUser = updated;
+          updateUserBadge(updated);
+          showAlert(profileAlert, "Profil został zaktualizowany.", "success");
+        } catch (error) {
+          showAlert(profileAlert, error.message || "Nie udało się zapisać profilu.", "error");
         }
       });
-    });
-  }
+    }
 
-  const applyUserData = (user) => {
-    if (!user) return;
-    if (emailInput) {
-      emailInput.value = user.email || "";
+    if (passwordForm) {
+      passwordForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const payload = formToJSON(passwordForm);
+        const body = {
+          current_password: payload.current_password || "",
+          new_password: payload.new_password || "",
+        };
+        showAlert(passwordAlert, "Aktualizuję hasło…");
+        try {
+          await apiFetch("/users/me", {
+            method: "PATCH",
+            body: JSON.stringify(body),
+          });
+          showAlert(passwordAlert, "Hasło zostało zaktualizowane.", "success");
+          passwordForm.reset();
+        } catch (error) {
+          showAlert(passwordAlert, error.message || "Nie udało się zaktualizować hasła.", "error");
+        }
+      });
     }
-    if (avatarInput) {
-      avatarInput.value = user.avatar_url || "";
-    }
-    syncAvatarChoices(user.avatar_url || "");
-    if (document.body) {
-      document.body.dataset.username = user.username ?? "";
-      document.body.dataset.avatar = user.avatar_url ?? "";
-    }
-    updateUserBadge({ username: user.username ?? "", avatar_url: user.avatar_url ?? "" });
   };
 
-  try {
-    const user = await apiFetch("/users/me");
-    applyUserData(user);
-  } catch (error) {
-    if (profileAlert) {
-      showAlert(profileAlert, error.message || "Nie udało się pobrać danych konta.");
-    }
-  }
+  const init = async () => {
+    setupNavigation();
+    setupAuthForms();
+    setupCollectionPage();
+    setupPortfolioPage();
+    setupAddCardPage();
+    setupCardDetailPage();
 
-  if (profileForm) {
-    profileForm.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      showAlert(profileAlert, "");
-      const payload = formToJSON(profileForm);
-      const body = {
-        email: typeof payload.email === "string" ? payload.email.trim() : undefined,
-        avatar_url:
-          typeof payload.avatar_url === "string" ? payload.avatar_url.trim() : undefined,
-      };
-      try {
-        const user = await apiFetch("/users/me", {
-          method: "PATCH",
-          body: JSON.stringify(body),
-        });
-        applyUserData(user);
-        showAlert(profileAlert, "Dane profilu zostały zapisane.", "success");
-      } catch (error) {
-        showAlert(profileAlert, error.message || "Nie udało się zapisać zmian.");
-      }
-    });
-  }
+    await fetchCurrentUser();
 
-  if (passwordForm) {
-    passwordForm.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      showAlert(passwordAlert, "");
-      const payload = formToJSON(passwordForm);
-      const currentPassword = typeof payload.current_password === "string" ? payload.current_password : "";
-      const newPassword = typeof payload.new_password === "string" ? payload.new_password : "";
-      if (!currentPassword || !newPassword) {
-        showAlert(passwordAlert, "Uzupełnij oba pola hasła.");
-        return;
-      }
-      try {
-        await apiFetch("/users/me", {
-          method: "PATCH",
-          body: JSON.stringify({
-            current_password: currentPassword,
-            new_password: newPassword,
-          }),
-        });
-        passwordForm.reset();
-        showAlert(passwordAlert, "Hasło zostało zmienione.", "success");
-      } catch (error) {
-        showAlert(passwordAlert, error.message || "Nie udało się zmienić hasła.");
-      }
-    });
-  }
-}
-
-function bindPortfolio() {
-  const alertBox = document.getElementById("portfolio-alert");
-  const refreshBtn = document.getElementById("refresh-portfolio");
-  if (refreshBtn) {
-    refreshBtn.addEventListener("click", async () => {
+    const needsCollection = Boolean(document.getElementById("collection-table"));
+    const needsPortfolio = Boolean(document.getElementById("portfolio-cards"));
+    if (needsCollection || needsPortfolio) {
       await loadCollection();
-      loadSummary(alertBox);
-      loadPortfolioCards(alertBox);
-      loadPortfolioHistory(alertBox);
-    });
-  }
-  loadCollection().then(() => {
-    loadSummary(alertBox);
-    loadPortfolioCards(alertBox);
-    loadPortfolioHistory(alertBox);
-  });
-}
-
-async function hydrateUserContext() {
-  const token = getToken();
-  const result = { user: null, tokenPresent: Boolean(token), error: null };
-  if (!token) {
-    updateUserBadge({ username: "" });
-    if (document.body) {
-      document.body.dataset.username = "";
-      document.body.dataset.avatar = "";
     }
-    return result;
-  }
 
-  try {
-    const user = await apiFetch("/users/me");
-    if (document.body) {
-      document.body.dataset.username = user?.username ?? "";
-      document.body.dataset.avatar = user?.avatar_url ?? "";
-    }
-    updateUserBadge({ username: user?.username ?? "", avatar_url: user?.avatar_url ?? "" });
-    result.user = user;
-    return result;
-  } catch (error) {
-    result.error = error;
-    clearToken();
-    updateUserBadge({ username: "" });
-    if (document.body) {
-      document.body.dataset.username = "";
-      document.body.dataset.avatar = "";
-    }
-    return result;
-  }
-}
+    await setupSettingsPage();
+  };
 
-async function ensureAuthenticated() {
-  const { user, tokenPresent, error } = await hydrateUserContext();
-  if (user) {
-    return true;
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
   }
-
-  const alertBox = document.querySelector(".alert");
-  if (alertBox) {
-    const message = tokenPresent
-      ? "Sesja wygasła. Zaloguj się ponownie."
-      : "Wymagane logowanie.";
-    showAlert(alertBox, message);
-  }
-  if (tokenPresent && error) {
-    console.warn("Nie udało się pobrać danych użytkownika", error);
-  }
-  window.location.href = "/login";
-  return false;
-}
-
-window.addEventListener("DOMContentLoaded", async () => {
-  setupThemeToggle();
-  setupNavigation();
-  setupHeaderVisibility();
-  const loginForm = document.getElementById("login-form");
-  if (loginForm) {
-    loginForm.addEventListener("submit", (event) => {
-      event.preventDefault();
-      handleLogin(loginForm);
-    });
-  }
-
-  const registerForm = document.getElementById("register-form");
-  if (registerForm) {
-    registerForm.addEventListener("submit", (event) => {
-      event.preventDefault();
-      handleRegister(registerForm);
-    });
-  }
-
-  const needsDashboard = Boolean(document.getElementById("collection-table"));
-  const needsPortfolio = Boolean(document.getElementById("portfolio-overview"));
-  const needsDetail = Boolean(document.getElementById("card-detail-page"));
-  const needsAddCard = Boolean(document.getElementById("add-card-page"));
-  const needsSettings = Boolean(document.getElementById("settings-page"));
-
-  const requiresAuth = needsDashboard || needsPortfolio || needsAddCard || needsSettings;
-  if (requiresAuth) {
-    if (await ensureAuthenticated()) {
-      if (needsDashboard) {
-        bindDashboard();
-      }
-      if (needsAddCard) {
-        bindAddCardPage();
-      }
-      if (needsPortfolio) {
-        bindPortfolio();
-      }
-      if (needsDetail) {
-        bindCardDetail();
-      }
-      if (needsSettings) {
-        bindSettingsPage();
-      }
-    }
-  } else if (needsDetail) {
-    const { error, tokenPresent } = await hydrateUserContext();
-    if (tokenPresent && error) {
-      const alertBox = document.querySelector(".alert");
-      if (alertBox) {
-        showAlert(alertBox, "Sesja wygasła. Zaloguj się ponownie.");
-      }
-    }
-    bindCardDetail();
-  }
-});
-
-window.addEventListener("load", () => {
-  registerServiceWorker();
-});
+})();

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1,153 +1,64 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap');
-
 :root {
-  color-scheme: dark;
-  --color-primary: #6fd3ff;
-  --color-primary-dark: #3796ff;
-  --color-primary-rgb: 111, 211, 255;
-  --color-secondary: #f8d66d;
-  --color-accent: #ff7bd5;
-  --color-background: #05060f;
-  --color-background-alt: rgba(9, 16, 32, 0.92);
-  --color-surface: rgba(13, 21, 38, 0.9);
-  --color-surface-strong: rgba(16, 27, 49, 0.94);
-  --color-border: rgba(111, 211, 255, 0.14);
-  --color-border-strong: rgba(111, 211, 255, 0.24);
-  --surface-outline: rgba(111, 211, 255, 0.12);
-  --surface-outline-strong: rgba(111, 211, 255, 0.2);
-  --color-text: #e2e8f0;
-  --color-text-muted: rgba(226, 232, 240, 0.7);
-  --color-success: #4ade80;
-  --color-warning: #facc15;
-  --color-danger: #f87171;
-  --shadow-soft: 0 24px 56px -26px rgba(2, 12, 32, 0.88);
-  --shadow-card: 0 28px 72px -36px rgba(1, 8, 24, 0.92);
-  --gradient-start: #05060f;
-  --gradient-mid: #0b1224;
-  --gradient-end: #09101c;
-  --glow-primary: rgba(var(--color-primary-rgb), 0.28);
-  --glow-secondary: rgba(128, 90, 213, 0.18);
-  --chart-line: #6fd3ff;
-  --chart-fill: rgba(111, 211, 255, 0.22);
-  --chart-grid: rgba(111, 211, 255, 0.16);
-  --chart-text: rgba(226, 232, 240, 0.72);
-  --radius-lg: 22px;
-  --radius-md: 16px;
-  --spacing: 24px;
-  font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-
-body[data-theme="dark"] {
-  color-scheme: dark;
-}
-
-body[data-theme="light"] {
   color-scheme: light;
-  --color-primary: #2563eb;
-  --color-primary-dark: #1d4ed8;
-  --color-primary-rgb: 37, 99, 235;
-  --color-secondary: #f59e0b;
-  --color-accent: #f97316;
-  --color-background: #f9fafb;
-  --color-background-alt: #f1f5f9;
-  --color-surface: rgba(255, 255, 255, 0.92);
-  --color-surface-strong: rgba(248, 250, 252, 0.96);
-  --color-border: rgba(148, 163, 184, 0.28);
-  --color-border-strong: rgba(148, 163, 184, 0.42);
-  --surface-outline: rgba(148, 163, 184, 0.25);
-  --surface-outline-strong: rgba(148, 163, 184, 0.35);
+  --color-background: #f5f6fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f3fa;
+  --color-border: #d9deeb;
+  --color-border-strong: #c3c8d8;
   --color-text: #1f2937;
-  --color-text-muted: rgba(71, 85, 105, 0.78);
+  --color-muted: #5b6472;
+  --color-accent: #2563eb;
+  --color-accent-dark: #1d4ed8;
+  --color-accent-soft: #e6edff;
   --color-success: #16a34a;
-  --color-warning: #eab308;
   --color-danger: #dc2626;
-  --shadow-soft: 0 20px 44px -28px rgba(15, 23, 42, 0.18);
-  --shadow-card: 0 24px 60px -40px rgba(15, 23, 42, 0.22);
-  --gradient-start: #f8fafc;
-  --gradient-mid: #eef2ff;
-  --gradient-end: #e0e7ff;
-  --glow-primary: rgba(var(--color-primary-rgb), 0.16);
-  --glow-secondary: rgba(244, 114, 182, 0.2);
-  --chart-line: #2563eb;
-  --chart-fill: rgba(37, 99, 235, 0.18);
-  --chart-grid: rgba(148, 163, 184, 0.36);
-  --chart-text: rgba(31, 41, 55, 0.68);
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-soft: 0 18px 42px rgba(15, 23, 42, 0.12);
+  --shadow-card: 0 10px 28px rgba(15, 23, 42, 0.08);
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(
-    160deg,
-    var(--gradient-start) 0%,
-    var(--gradient-mid) 45%,
-    var(--gradient-end) 100%
-  );
+  background: linear-gradient(180deg, var(--color-background) 0%, #eef1f9 100%);
   color: var(--color-text);
   display: flex;
   flex-direction: column;
-  position: relative;
-}
-
-body::before,
-body::after {
-  content: '';
-  position: fixed;
-  width: 420px;
-  height: 420px;
-  border-radius: 50%;
-  filter: blur(120px);
-  z-index: -2;
-  opacity: 0.7;
-}
-
-body::before {
-  background: var(--glow-primary);
-  top: -140px;
-  right: -120px;
-}
-
-body::after {
-  background: var(--glow-secondary);
-  bottom: -160px;
-  left: -120px;
 }
 
 main {
   flex: 1;
-  width: min(1120px, calc(100% - 32px));
-  margin: 0 auto 48px;
-  padding-top: 32px;
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 64px;
   display: flex;
   flex-direction: column;
   gap: 32px;
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-accent);
   text-decoration: none;
-  transition: color 0.2s ease;
 }
 
 a:hover,
-a:focus {
-  color: var(--color-primary-dark);
-}
-
 a:focus-visible {
-  outline: 3px solid rgba(var(--color-primary-rgb), 0.35);
-  outline-offset: 4px;
-  border-radius: 12px;
+  text-decoration: underline;
 }
 
 img {
-  display: block;
   max-width: 100%;
   height: auto;
+  display: block;
 }
 
 [hidden] {
@@ -155,561 +66,743 @@ img {
 }
 
 .app-header {
-  position: sticky;
-  top: 16px;
-  width: min(1120px, calc(100% - 32px));
-  margin: 16px auto 0;
+  width: min(1080px, calc(100% - 32px));
+  margin: 24px auto 0;
   padding: 16px 24px;
-  border-radius: var(--radius-lg);
   background: var(--color-surface);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--color-border-strong);
-  backdrop-filter: blur(18px);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
   display: grid;
   grid-template-columns: auto 1fr auto;
-  align-items: center;
   gap: 24px;
-  z-index: 5;
-  transform: translateY(0);
-  opacity: 1;
-  transition: transform 0.35s ease, opacity 0.25s ease;
-  will-change: transform, opacity;
-}
-
-.app-header[data-header-visible='false'] {
-  transform: translateY(calc(-100% - 32px));
-  opacity: 0;
-  pointer-events: none;
-}
-
-.app-header[data-header-visible='true'] {
-  transform: translateY(0);
-  opacity: 1;
+  align-items: center;
 }
 
 .brand {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
 }
 
 .brand img {
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  box-shadow: 0 12px 24px -16px rgba(17, 22, 63, 0.6);
-}
-
-.brand-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  line-height: 1.1;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-card);
 }
 
 .brand-title {
   font-size: 1.2rem;
-  font-weight: 700;
-  color: var(--color-primary);
+  font-weight: 600;
 }
 
 .brand-subtitle {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+}
+
+.nav-toggle span {
+  width: 22px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 999px;
 }
 
 .app-nav {
   display: flex;
   gap: 16px;
   align-items: center;
-  justify-content: flex-end;
 }
 
 .app-nav a {
-  font-size: 0.95rem;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  color: var(--color-muted);
   font-weight: 500;
-  padding: 10px 16px;
-  border-radius: 999px;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
+.app-nav a.active,
 .app-nav a:hover,
 .app-nav a:focus-visible {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  color: var(--color-primary);
-}
-
-.app-nav a.active {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  box-shadow: 0 12px 20px -16px rgba(30, 30, 72, 0.8);
-}
-
-.nav-toggle {
-  display: none;
-  background: rgba(var(--color-primary-rgb), 0.08);
-  border: none;
-  border-radius: 14px;
-  padding: 10px;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  cursor: pointer;
-  transition: transform 0.2s ease;
-}
-
-.nav-toggle span {
-  width: 20px;
-  height: 2px;
-  border-radius: 999px;
-  background: var(--color-primary);
-  display: block;
-}
-
-.nav-toggle:active {
-  transform: scale(0.94);
+  color: var(--color-accent-dark);
+  background: var(--color-accent-soft);
 }
 
 .header-actions {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
   gap: 12px;
-  flex-wrap: wrap;
+  align-items: center;
 }
 
-.user-profile {
+.user-pill {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 14px;
+  padding: 6px 12px;
   border-radius: 999px;
-  color: var(--color-text);
-  text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  background: var(--color-surface-alt);
+  color: var(--color-muted);
+  font-size: 0.85rem;
 }
 
-.user-profile[data-state="anonymous"] {
-  opacity: 0.65;
-  pointer-events: none;
-}
-
-.user-profile:hover,
-.user-profile:focus-visible {
-  background: rgba(var(--color-primary-rgb), 0.12);
-  color: var(--color-text);
-  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.18);
-  outline: none;
-}
-
-body[data-theme="dark"] .user-profile:hover,
-body[data-theme="dark"] .user-profile:focus-visible {
-  background: rgba(var(--color-primary-rgb), 0.18);
-  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.22);
-}
-
-.user-name {
-  font-weight: 600;
-  color: inherit;
-  min-width: 0;
-}
-
-.user-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--color-primary), rgba(var(--color-primary-rgb), 0.5));
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  color: #fff;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.6);
-  overflow: hidden;
-}
-
-body[data-theme="dark"] .user-avatar {
-  color: #0f1424;
-  background: linear-gradient(
-    135deg,
-    rgba(var(--color-primary-rgb), 0.85),
-    rgba(var(--color-primary-rgb), 0.55)
-  );
-  box-shadow: 0 12px 24px -18px rgba(0, 0, 0, 0.5);
-}
-
-.theme-toggle {
-  width: 40px;
-  height: 40px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(var(--color-primary-rgb), 0.12);
-  color: var(--color-primary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1rem;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
-}
-
-.theme-toggle:hover {
-  background: rgba(var(--color-primary-rgb), 0.18);
-}
-
-.theme-toggle:active {
-  transform: scale(0.95);
-}
-
-body[data-theme="dark"] .theme-toggle {
-  background: rgba(var(--color-primary-rgb), 0.14);
-  color: var(--color-primary);
-}
-
-body[data-theme="dark"] .theme-toggle:hover {
-  background: rgba(var(--color-primary-rgb), 0.2);
-}
-
-#login-button,
-#logout-button {
-  padding: 8px 18px;
-  border-radius: 999px;
-}
-
-.button,
-button {
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border-radius: 16px;
-  border: none;
-  font-family: inherit;
-  font-size: 0.95rem;
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
   font-weight: 600;
-  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.button:disabled,
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  transform: none;
-  box-shadow: none;
-}
-
-.button.primary,
-button.primary {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+.button.primary {
+  background: var(--color-accent);
   color: #fff;
-  box-shadow: 0 22px 46px -24px rgba(8, 16, 36, 0.75);
+  border-color: var(--color-accent);
 }
 
 .button.primary:hover,
-button.primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 26px 52px -24px rgba(8, 16, 36, 0.72);
+.button.primary:focus-visible {
+  background: var(--color-accent-dark);
+  border-color: var(--color-accent-dark);
 }
 
-.button.secondary,
-button.secondary {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  color: var(--color-primary);
+.button.secondary {
+  background: var(--color-surface);
+  color: var(--color-accent-dark);
+  border-color: var(--color-accent);
 }
 
 .button.secondary:hover,
-button.secondary:hover {
-  transform: translateY(-1px);
-  background: rgba(var(--color-primary-rgb), 0.16);
+.button.secondary:focus-visible {
+  background: var(--color-accent-soft);
 }
 
-.button.ghost,
-button.ghost {
-  background: transparent;
-  color: var(--color-primary);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.22);
+.button.inline {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  border-radius: var(--radius-sm);
 }
 
-.button.ghost:hover,
-button.ghost:hover {
-  background: rgba(var(--color-primary-rgb), 0.1);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.32);
-}
-
-body[data-theme="light"] .button.ghost,
-body[data-theme="light"] button.ghost {
-  color: var(--color-primary);
-}
-
-body[data-theme="light"] .button.ghost:hover,
-body[data-theme="light"] button.ghost:hover {
-  background: rgba(var(--color-primary-rgb), 0.12);
-}
-
-.button.danger,
-button.danger {
-  background: rgba(248, 113, 113, 0.18);
+.button.inline.danger {
   color: var(--color-danger);
+  border-color: var(--color-danger);
+  background: transparent;
 }
 
-.button.danger:hover,
-button.danger:hover {
-  background: rgba(248, 113, 113, 0.25);
+.button.inline.danger:hover,
+.button.inline.danger:focus-visible {
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.button.link {
+  background: transparent;
+  color: var(--color-accent-dark);
+  border-color: transparent;
+  padding: 0;
+}
+
+.ghost {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.ghost:hover,
+.ghost:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent-dark);
 }
 
 .page-hero {
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  color: #fff;
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
-  padding: 40px clamp(24px, 5vw, 56px);
-  box-shadow: var(--shadow-card), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 32px;
-  align-items: center;
-  background-image: linear-gradient(
-      135deg,
-      rgba(12, 15, 24, 0.82),
-      rgba(var(--color-primary-rgb), 0.72)
-    ),
-    url("/static/background.jpg");
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-}
-
-body[data-theme="light"] .page-hero {
-  background-image: linear-gradient(
-      135deg,
-      rgba(248, 250, 252, 0.88),
-      rgba(var(--color-primary-rgb), 0.6)
-    ),
-    url("/static/background.jpg");
+  box-shadow: var(--shadow-soft);
+  padding: 32px;
 }
 
 .page-hero h1 {
-  font-size: clamp(2rem, 4vw, 2.8rem);
   margin: 0 0 12px;
-  font-weight: 700;
+  font-size: clamp(1.8rem, 2.4vw, 2.4rem);
 }
 
 .page-hero p {
-  margin: 0 0 24px;
-  color: rgba(255, 255, 255, 0.86);
-  max-width: 520px;
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 680px;
   line-height: 1.6;
 }
 
 .hero-actions {
+  margin-top: 24px;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.home-hero {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  background: linear-gradient(135deg, rgba(12, 20, 39, 0.92), rgba(21, 32, 58, 0.82));
-  border-radius: var(--radius-lg);
-  padding: clamp(24px, 4vw, 40px);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline-strong);
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--color-accent-dark);
+  font-weight: 600;
+  margin-bottom: 8px;
 }
 
-body[data-theme="light"] .home-hero {
-  background: linear-gradient(135deg, rgba(var(--color-primary-rgb), 0.08), rgba(248, 214, 109, 0.12));
+.panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.panel-header p {
+  margin: 4px 0 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.collection-followup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--color-muted);
+}
+
+.collection-followup p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.empty-state {
+  margin: 16px 0 0;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  color: var(--color-muted);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.alert {
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+.alert[data-variant="success"] {
+  border-color: rgba(22, 163, 74, 0.35);
+  background: rgba(22, 163, 74, 0.08);
+  color: var(--color-success);
+}
+
+.alert[data-variant="error"] {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--color-danger);
+}
+
+.table-responsive {
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+}
+
+.collection-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.collection-table th,
+.collection-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.95rem;
+}
+
+.collection-table th {
+  font-weight: 600;
+  color: var(--color-muted);
+  background: var(--color-surface-alt);
+}
+
+.collection-table input[type="number"] {
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: #fff;
+  font-size: 0.9rem;
+}
+
+.table-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.table-checkbox {
+  text-align: center;
+}
+
+.table-checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.portfolio-list {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.portfolio-card {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.portfolio-card header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.portfolio-card header p {
+  margin: 4px 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.portfolio-card dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 16px;
+  font-size: 0.9rem;
+}
+
+.portfolio-card dt {
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.portfolio-card dd {
+  margin: 0;
+}
+
+.portfolio-card footer {
+  margin-top: auto;
+}
+
+.add-card-form {
+  display: grid;
+  gap: 16px;
+  max-width: 540px;
+}
+
+.add-card-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.add-card-form input[type="text"],
+.add-card-form input[type="number"],
+.add-card-form input[type="password"],
+.add-card-form input[type="email"],
+.add-card-form input[type="url"] {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+}
+
+.search-summary {
+  margin: 16px 0 0;
+  color: var(--color-muted);
+}
+
+.card-search-results {
+  margin-top: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.card-search-item {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+}
+
+.card-search-info h3 {
+  margin: 0 0 6px;
+}
+
+.card-search-info p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.card-search-meta {
+  margin-top: 4px;
+  font-size: 0.85rem;
+}
+
+.card-search-form {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  align-items: end;
+}
+
+.card-search-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.card-search-form input[type="number"] {
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: #fff;
+}
+
+.checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 8px !important;
+  font-weight: 500;
+}
+
+.card-detail-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card-detail-main {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+}
+
+.card-detail-image {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  aspect-ratio: 3 / 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-detail-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-detail-placeholder {
+  font-size: 3rem;
+  color: var(--color-muted);
+}
+
+.card-detail-info h1 {
+  margin: 0 0 12px;
+}
+
+.card-detail-set {
+  font-size: 1rem;
+  color: var(--color-muted);
+  margin-bottom: 16px;
+}
+
+.card-detail-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin: 0 0 16px;
+}
+
+.card-detail-meta dt {
+  font-weight: 600;
+  color: var(--color-muted);
+  margin-bottom: 4px;
+}
+
+.card-detail-meta dd {
+  margin: 0;
+}
+
+.card-detail-actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.card-detail-related .panel-header p {
+  max-width: 520px;
+}
+
+.related-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.related-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: inherit;
+}
+
+.related-card:hover,
+.related-card:focus-visible {
+  border-color: var(--color-accent);
+}
+
+.related-card-name {
+  font-weight: 600;
+}
+
+.related-card-meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.related-empty {
+  margin-top: 12px;
+  color: var(--color-muted);
+}
+
+.auth-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.auth-copy h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.8rem, 2.6vw, 2.5rem);
+}
+
+.auth-copy p {
+  margin: 0 0 12px;
+  color: var(--color-muted);
+}
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 24px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.feature-list li {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  color: var(--color-muted);
+}
+
+.feature-list span {
+  font-weight: 600;
+  color: var(--color-accent-dark);
+}
+
+.form-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.form-card h2 {
+  margin: 0;
+}
+
+.form-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.form-card label {
+  display: grid;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.form-card input {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+}
+
+.form-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.inline-link {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.home-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.home-hero-copy h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.9rem, 2.6vw, 2.6rem);
 }
 
 .home-hero-copy p {
-  color: var(--color-text-muted);
+  margin: 0 0 20px;
+  color: var(--color-muted);
   line-height: 1.6;
 }
 
 .home-hero-cards {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .home-hero-cards article {
-  background: var(--color-surface-strong);
+  background: var(--color-surface);
   border-radius: var(--radius-md);
-  padding: 20px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  padding: 18px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
 }
 
 .home-hero-cards h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--color-primary);
-}
-
-.home-hero-cards p {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-  line-height: 1.6;
+  margin: 0 0 8px;
 }
 
 .home-panel {
-  gap: 28px;
-}
-
-.home-news-grid {
   display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
 }
 
-.home-news-card {
-  background: var(--color-surface-strong);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.home-news-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(var(--color-primary-rgb), 0.12);
-  color: var(--color-primary);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-body[data-theme="dark"] .home-news-tag {
-  background: rgba(var(--color-primary-rgb), 0.22);
-  color: var(--color-primary);
-}
-
-.home-news-tag[data-category="turnieje"] {
-  background: rgba(45, 212, 191, 0.16);
-  color: #0f766e;
-}
-
-body[data-theme="dark"] .home-news-tag[data-category="turnieje"] {
-  background: rgba(45, 212, 191, 0.28);
-  color: #5df2df;
-}
-
-.home-news-tag[data-category="kolekcjonerstwo"] {
-  background: rgba(250, 204, 21, 0.2);
-  color: #92400e;
-}
-
-body[data-theme="dark"] .home-news-tag[data-category="kolekcjonerstwo"] {
-  background: rgba(250, 204, 21, 0.32);
-  color: #facc15;
-}
-
-.home-news-tag[data-category="rynek"] {
-  background: rgba(248, 113, 113, 0.2);
-  color: #b91c1c;
-}
-
-body[data-theme="dark"] .home-news-tag[data-category="rynek"] {
-  background: rgba(248, 113, 113, 0.32);
-  color: #fca5a5;
-}
-
-.home-news-card h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--color-primary);
-}
-
-.home-news-card p {
-  margin: 0;
-  color: var(--color-text-muted);
-  line-height: 1.6;
-}
-
-.home-news-card time {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-}
-
-.home-sets-grid {
+.home-news-grid,
+.home-sets-grid,
+.home-legal {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.home-sets-grid article {
-  padding: 20px;
+.home-news-card,
+.home-legal article {
   border-radius: var(--radius-md);
-  background: var(--color-surface-strong);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  border: 1px solid var(--color-border);
+  padding: 16px;
+  background: var(--color-surface-alt);
 }
 
-.home-sets-grid h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--color-primary);
-}
-
-.home-sets-grid p {
-  margin: 0;
-  color: var(--color-text-muted);
-  line-height: 1.6;
+.home-news-tag {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-dark);
+  margin-bottom: 12px;
 }
 
 .home-trends {
   display: grid;
-  gap: 24px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
 }
 
 .home-trends-column h3 {
-  margin: 0 0 12px;
-  color: var(--color-primary);
-  font-size: 1rem;
+  margin: 0 0 8px;
 }
 
 .home-trends-column ul {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  gap: 8px;
 }
 
 .home-trends-column li {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  background: var(--color-surface-strong);
-  border-radius: var(--radius-md);
-  padding: 14px 18px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
+  gap: 12px;
   font-size: 0.9rem;
-  color: var(--color-text);
+  color: var(--color-muted);
 }
 
 .trend-up {
@@ -722,1994 +815,175 @@ body[data-theme="dark"] .home-news-tag[data-category="rynek"] {
   font-weight: 600;
 }
 
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.72);
-  margin-bottom: 12px;
+.legal-content h2 {
+  margin-top: 24px;
+  font-size: 1.1rem;
 }
 
-.panel {
-  background: var(--color-surface);
+.legal-content p {
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.settings-panel {
+  display: grid;
+  gap: 24px;
+}
+
+.settings-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.settings-card {
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  padding: clamp(20px, 4vw, 32px);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline-strong);
-  backdrop-filter: blur(18px);
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.add-card-cta {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.add-card-cta p {
-  margin: 0;
-  color: var(--color-text-muted);
-  line-height: 1.6;
-}
-
-.add-card-cta .button {
-  align-self: flex-start;
-}
-
-.panel-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.panel-header > div {
-  flex: 1 1 240px;
-}
-
-.panel-header .button,
-.panel-header button {
-  flex-shrink: 0;
-}
-
-.panel-header h2 {
-  margin: 0 0 8px;
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: var(--color-primary);
-}
-
-.panel-header p {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-.stat-grid {
-  display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.stat-card {
-  background: var(--color-surface-strong);
-  border-radius: var(--radius-md);
-  padding: 24px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  backdrop-filter: blur(10px);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 160px;
-}
-
-.stat-card h3 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.stat-card p {
-  margin: 0;
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.stat-card p[data-direction='up'] {
-  color: var(--color-success);
-}
-
-.stat-card p[data-direction='down'] {
-  color: var(--color-danger);
-}
-
-.stat-card span {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-#portfolio-value[data-direction='up'],
-#portfolio-chart-latest[data-direction='up'] {
-  color: var(--color-success);
-}
-
-#portfolio-value[data-direction='down'],
-#portfolio-chart-latest[data-direction='down'] {
-  color: var(--color-danger);
-}
-
-#portfolio-value[data-direction='flat'],
-#portfolio-chart-latest[data-direction='flat'] {
-  color: var(--color-text);
-}
-
-.quick-actions {
-  display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-}
-
-.action-card {
-  background: var(--color-surface-strong);
-  border-radius: var(--radius-md);
-  padding: 22px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.action-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 26px 48px -32px rgba(17, 22, 63, 0.55);
-}
-
-.action-emoji {
-  font-size: 1.8rem;
-}
-
-.action-card strong {
-  font-size: 1.1rem;
-  color: var(--color-primary);
-}
-
-.action-card span {
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  line-height: 1.5;
-}
-
-.form-grid {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.form-grid label {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 0.9rem;
-  color: var(--color-primary);
-  font-weight: 500;
-}
-
-.search-hint {
-  margin: -6px 0 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-  transition: opacity 0.2s ease;
-}
-
-#add-card-query[data-hint-active='true']::placeholder {
-  opacity: 0.3;
-}
-
-.card-search-results-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.card-search-results-header {
-  align-items: flex-start;
-  gap: 18px;
-}
-
-.card-search-controls {
-  display: flex;
-  align-items: flex-end;
-  gap: 12px;
-}
-
-.card-search-sort {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.85rem;
-  color: var(--color-primary);
-  font-weight: 500;
-}
-
-.card-search-sort select {
-  min-width: 180px;
-}
-
-.card-search-summary {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--color-text-muted);
-}
-
-.card-search-results {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 18px;
-}
-
-.card-search-empty {
-  margin: 0;
-  padding: 16px 20px;
-  border-radius: 16px;
-  background: rgba(var(--color-primary-rgb), 0.06);
-  color: var(--color-text-muted);
-  font-size: 0.95rem;
-  text-align: center;
-}
-
-.card-search-empty[data-state='loading'] {
-  color: var(--color-primary);
-}
-
-.card-search-empty[data-state='error'] {
-  color: var(--color-danger);
-  background: rgba(244, 67, 54, 0.08);
-}
-
-.card-search-item {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 18px;
-  border-radius: 18px;
-  background: var(--color-surface);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.card-search-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 52px -30px rgba(8, 16, 36, 0.6), inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.2);
-}
-
-.card-search-item.is-selected {
-  box-shadow:
-    var(--shadow-soft),
-    inset 0 0 0 2px rgba(var(--color-primary-rgb), 0.5),
-    0 0 0 10px rgba(var(--color-primary-rgb), 0.12);
-}
-
-.card-search-link {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  text-decoration: none;
-  color: inherit;
-  flex: 1;
-}
-
-.card-search-thumb-wrapper {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  border-radius: 16px;
-  overflow: hidden;
-  position: relative;
-  background: rgba(var(--color-primary-rgb), 0.08);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 12px 28px -20px rgba(17, 22, 63, 0.55);
-}
-
-.card-search-thumb {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: inherit;
-}
-
-.card-search-thumb.placeholder {
-  font-size: 1.6rem;
-  color: var(--color-primary);
-}
-
-.card-search-info {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.card-search-title {
-  margin: 0;
-  font-size: 1.05rem;
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
-.card-search-number,
-.card-search-set {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-}
-
-.card-search-number {
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-.card-search-set {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 500;
-}
-
-.card-search-set img {
-  width: 20px;
-  height: 20px;
-  object-fit: contain;
-  filter: drop-shadow(0 2px 6px rgba(17, 22, 63, 0.25));
-}
-
-.card-search-actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.card-search-add-button {
-  width: 34px;
-  height: 34px;
-  border-radius: 9999px;
-  border: none;
-  background: var(--color-danger);
-  color: #fff;
-  font-size: 1.1rem;
-  font-weight: 600;
-  font-family: inherit;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 2;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-  box-shadow: 0 18px 32px -26px rgba(17, 22, 63, 0.5);
-}
-
-.card-search-add-button:hover:not(:disabled),
-.card-search-add-button:focus-visible:not(:disabled) {
-  transform: translateY(-1px) scale(1.03);
-  box-shadow: 0 22px 40px -24px rgba(17, 22, 63, 0.55);
-  background-color: #b02a37;
-}
-
-.card-search-add-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-  transform: none;
-  box-shadow: none;
-}
-
-.card-search-pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 4px;
-}
-
-.card-search-page-button {
-  border: none;
-  border-radius: 999px;
-  padding: 0.6rem 1.4rem;
-  background: rgba(var(--color-primary-rgb), 0.12);
-  color: var(--color-primary);
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.card-search-page-button:hover:not(:disabled),
-.card-search-page-button:focus-visible:not(:disabled) {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  transform: translateY(-1px);
-  box-shadow: 0 16px 28px -22px rgba(17, 22, 63, 0.45);
-}
-
-.card-search-page-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.card-search-page-list {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.card-search-page-number {
-  border: none;
-  border-radius: 8px;
-  min-width: 38px;
-  padding: 0.45rem 0.75rem;
-  background: rgba(var(--color-primary-rgb), 0.08);
-  color: var(--color-primary);
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.card-search-page-number:hover:not(:disabled),
-.card-search-page-number:focus-visible:not(:disabled) {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  transform: translateY(-1px);
-  box-shadow: 0 16px 28px -22px rgba(17, 22, 63, 0.45);
-}
-
-.card-search-page-number.is-active {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-  cursor: default;
-  box-shadow: 0 16px 28px -24px rgba(17, 22, 63, 0.4);
-}
-
-.card-search-page-number.is-active:disabled {
-  opacity: 1;
-}
-
-.card-search-page-info {
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  font-weight: 600;
-}
-
-@media (max-width: 720px) {
-  .card-search-results-header {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 16px;
-  }
-
-  .card-search-controls {
-    width: 100%;
-    justify-content: stretch;
-  }
-
-  .card-search-sort {
-    width: 100%;
-  }
-
-  .card-search-sort select {
-    width: 100%;
-  }
-
-  .card-search-results {
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: 14px;
-  }
-
-  .card-search-item {
-    padding: 16px;
-  }
-
-  .card-search-thumb-wrapper {
-    aspect-ratio: 2 / 3;
-  }
-}
-
-input,
-select,
-textarea {
-  width: 100%;
-  border-radius: 14px;
-  background: var(--color-surface);
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-  font-family: inherit;
-  color: var(--color-text);
-  box-shadow:
-    inset 0 0 0 1px var(--surface-outline),
-    inset 0 8px 20px -18px rgba(8, 16, 36, 0.65);
-  transition: box-shadow 0.2s ease, background 0.2s ease;
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  box-shadow:
-    inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.5),
-    0 0 0 6px rgba(var(--color-primary-rgb), 0.16);
-  outline: none;
-}
-
-body[data-theme="light"] input,
-body[data-theme="light"] select,
-body[data-theme="light"] textarea {
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--color-text);
-  box-shadow:
-    inset 0 0 0 1px var(--surface-outline),
-    inset 0 2px 6px rgba(148, 163, 184, 0.24);
-}
-
-body[data-theme="light"] input:focus,
-body[data-theme="light"] select:focus,
-body[data-theme="light"] textarea:focus {
-  box-shadow:
-    inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.55),
-    0 0 0 6px rgba(var(--color-primary-rgb), 0.18);
-}
-
-input[type="checkbox"] {
-  width: auto;
-  height: 20px;
-  border-radius: 6px;
-  box-shadow: none;
-}
-
-.form-checkbox {
-  display: flex !important;
-  align-items: center;
-  gap: 10px;
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  background: var(--color-surface);
-  box-shadow: inset 0 0 0 1px var(--surface-outline);
-}
-
-body[data-theme="light"] .form-checkbox {
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: inset 0 0 0 1px var(--surface-outline);
-}
-
-.form-footer {
-  grid-column: 1 / -1;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: center;
-}
-
-.form-footer .alert {
-  flex: 1 1 260px;
-  margin: 0;
-}
-
-.alert {
-  padding: 0.85rem 1rem;
-  border-radius: 14px;
-  font-weight: 500;
-  width: 100%;
-  box-shadow: inset 0 0 0 1px rgba(244, 67, 54, 0.08);
-}
-
-.alert[data-variant="error"],
-.alert:not([data-variant]) {
-  border: 1px solid rgba(244, 67, 54, 0.25);
-  background: rgba(244, 67, 54, 0.12);
-  color: var(--color-danger);
-}
-
-.alert[data-variant="success"] {
-  border: 1px solid rgba(76, 175, 80, 0.28);
-  background: rgba(76, 175, 80, 0.12);
-  color: var(--color-success);
-  box-shadow: inset 0 0 0 1px rgba(76, 175, 80, 0.1);
-}
-
-.toast-container {
-  position: fixed;
-  top: var(--spacing);
-  right: var(--spacing);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: auto;
-  max-width: min(420px, calc(100vw - 2 * var(--spacing)));
-  z-index: 20;
-  pointer-events: none;
-}
-
-#add-card-alert {
-  width: auto;
-  min-width: min(360px, calc(100vw - 2 * var(--spacing)));
-  max-width: min(420px, calc(100vw - 2 * var(--spacing)));
-  padding: 1rem 1.25rem;
-  border-radius: 18px;
-  border: 1px solid var(--surface-outline-strong);
-  background: var(--color-surface);
-  color: var(--color-text);
-  box-shadow: var(--shadow-soft), 0 24px 48px -28px rgba(5, 10, 28, 0.75);
-  opacity: 0;
-  transform: translateY(-12px);
-  transition: opacity 0.3s ease, transform 0.3s ease;
-  pointer-events: auto;
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-}
-
-#add-card-alert[data-visible="true"] {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-#add-card-alert[data-variant="success"] {
-  border-color: rgba(34, 197, 94, 0.45);
-  box-shadow: var(--shadow-soft), 0 0 0 1px rgba(34, 197, 94, 0.25);
-  color: var(--color-success);
-}
-
-#add-card-alert[data-variant="error"] {
-  border-color: rgba(239, 68, 68, 0.45);
-  box-shadow: var(--shadow-soft), 0 0 0 1px rgba(239, 68, 68, 0.25);
-  color: var(--color-danger);
-}
-
-.table-responsive {
-  width: 100%;
-  overflow-x: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  background: var(--color-surface-strong);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-}
-
-thead {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-  color: #fff;
-}
-
-thead th {
-  padding: 16px 18px;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-align: left;
-}
-
-tbody td {
-  padding: 16px 18px;
-  border-bottom: 1px solid var(--color-border);
-  font-size: 0.95rem;
-  color: var(--color-text);
-}
-
-tbody tr:last-child td {
-  border-bottom: none;
-}
-
-tbody tr:hover {
-  background: rgba(var(--color-primary-rgb), 0.06);
-}
-
-body[data-theme="light"] table {
-  background: rgba(255, 255, 255, 0.92);
-}
-
-body[data-theme="light"] tbody td {
-  border-bottom-color: rgba(148, 163, 184, 0.3);
-}
-
-body[data-theme="light"] tbody tr:hover {
-  background: rgba(var(--color-primary-rgb), 0.1);
-}
-
-.table-actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.portfolio-grid {
-  display: grid;
-  gap: 24px;
-  margin-top: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.portfolio-empty {
-  margin-top: 16px;
-  text-align: center;
-  color: var(--color-text-muted);
-}
-
-.portfolio-performance-panel .panel-header {
-  align-items: center;
-}
-
-.portfolio-change {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: rgba(var(--color-primary-rgb), 0.08);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.22);
-  transition: background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.portfolio-change strong {
-  display: block;
-  font-size: 1rem;
-  color: var(--color-primary);
-}
-
-.portfolio-change div span {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.portfolio-change[data-direction='up'] {
-  background: rgba(74, 222, 128, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.32);
-}
-
-.portfolio-change[data-direction='up'] strong {
-  color: var(--color-success);
-}
-
-.portfolio-change[data-direction='down'] {
-  background: rgba(248, 113, 113, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.32);
-}
-
-.portfolio-change[data-direction='down'] strong {
-  color: var(--color-danger);
-}
-
-.portfolio-change-icon {
-  font-size: 1.1rem;
-}
-
-body[data-theme="light"] .portfolio-change {
-  background: rgba(var(--color-primary-rgb), 0.1);
-}
-
-body[data-theme="light"] .portfolio-change[data-direction='up'] {
-  background: rgba(34, 197, 94, 0.2);
-}
-
-body[data-theme="light"] .portfolio-change[data-direction='down'] {
-  background: rgba(248, 113, 113, 0.22);
-}
-
-.portfolio-chart-wrapper {
-  margin-top: 16px;
-}
-
-.portfolio-chart {
-  position: relative;
-  width: 100%;
-  min-height: 240px;
-  border-radius: 18px;
-  background: linear-gradient(
-    160deg,
-    rgba(var(--color-primary-rgb), 0.08) 0%,
-    var(--color-surface) 55%,
-    var(--color-surface-strong) 100%
-  );
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   padding: 20px;
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.portfolio-chart-meta {
-  margin-top: 18px;
-  display: flex;
-  flex-wrap: wrap;
+  background: var(--color-surface-alt);
+  display: grid;
   gap: 16px;
-  align-items: stretch;
-  background: var(--color-surface);
-  border-radius: 16px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  padding: 16px 20px;
 }
 
-.portfolio-chart-stats {
-  display: flex;
+.settings-card h2 {
+  margin: 0;
+}
+
+.settings-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.settings-form {
+  display: grid;
   gap: 16px;
-  flex-wrap: wrap;
-  flex: 1 1 220px;
 }
 
-.portfolio-chart-stats > div {
-  min-width: 140px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.portfolio-chart-stats span,
-.portfolio-chart-range span {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-muted);
-}
-
-.portfolio-chart-stats strong,
-.portfolio-chart-range strong {
-  font-size: 1.15rem;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.portfolio-chart-range {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 180px;
-}
-
-.portfolio-chart-svg {
-  width: 100%;
-  height: 220px;
-  display: block;
-}
-
-.portfolio-chart-area {
-  fill: rgba(var(--color-primary-rgb), 0.16);
-  fill: color-mix(in srgb, var(--color-primary) 22%, transparent);
-  transition: fill 0.3s ease;
-}
-
-.portfolio-chart-line {
-  fill: none;
-  stroke: var(--color-primary);
-  stroke: color-mix(in srgb, var(--color-primary) 78%, var(--color-text) 22%);
-  stroke-width: 2.6;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  transition: stroke 0.3s ease;
-}
-
-.portfolio-chart-grid {
-  pointer-events: none;
-}
-
-.portfolio-chart-grid-line {
-  stroke: rgba(var(--color-primary-rgb), 0.22);
-  stroke-width: 0.35;
-  shape-rendering: geometricPrecision;
-}
-
-.portfolio-chart-grid-line--vertical {
-  stroke-dasharray: 1 2;
-}
-
-.portfolio-chart-axis line {
-  stroke: var(--color-border-strong);
-  stroke-width: 0.6;
-}
-
-.portfolio-chart-axis-label {
-  fill: var(--color-text-muted);
-  font-size: 12px;
-  letter-spacing: 0.02em;
-  font-weight: 500;
-  pointer-events: none;
-}
-
-.portfolio-chart-axis-label--x {
-  font-size: 11px;
-}
-
-.portfolio-chart-point {
-  fill: var(--color-primary);
-  stroke: var(--color-surface);
-  stroke-width: 0.6;
-  transition: transform 0.2s ease, stroke-width 0.2s ease, stroke 0.2s ease;
-}
-
-.portfolio-chart-point:hover,
-.portfolio-chart-point:focus-visible {
-  transform: scale(1.35);
-  stroke-width: 0.9;
-  stroke: rgba(var(--color-primary-rgb), 0.35);
-}
-
-.portfolio-chart-tooltip {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translate(-50%, -110%);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border-radius: 12px;
-  padding: 8px 12px;
-  box-shadow: var(--shadow-card), inset 0 0 0 1px var(--surface-outline);
-  pointer-events: none;
-  font-size: 0.78rem;
-  line-height: 1.25;
-  opacity: 0;
-  transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 10;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.portfolio-chart-tooltip[data-visible="true"] {
-  opacity: 1;
-  transform: translate(-50%, -140%);
-}
-
-.portfolio-chart-tooltip-date {
-  font-weight: 600;
-}
-
-.portfolio-chart-tooltip-value {
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-}
-
-.portfolio-chart[data-direction='up'] .portfolio-chart-line {
-  stroke: var(--color-success);
-  stroke: color-mix(in srgb, var(--color-success) 78%, var(--color-text) 22%);
-}
-
-.portfolio-chart[data-direction='up'] .portfolio-chart-area {
-  fill: rgba(76, 175, 80, 0.2);
-  fill: color-mix(in srgb, var(--color-success) 26%, transparent);
-}
-
-.portfolio-chart[data-direction='down'] .portfolio-chart-line {
-  stroke: var(--color-danger);
-  stroke: color-mix(in srgb, var(--color-danger) 80%, var(--color-text) 20%);
-}
-
-.portfolio-chart[data-direction='down'] .portfolio-chart-area {
-  fill: rgba(244, 67, 54, 0.2);
-  fill: color-mix(in srgb, var(--color-danger) 28%, transparent);
-}
-
-body[data-theme="light"] .portfolio-chart-line {
-  stroke: color-mix(in srgb, var(--color-primary) 82%, #0b101d 18%);
-}
-
-body[data-theme="light"] .portfolio-chart-area {
-  fill: color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
-body[data-theme="light"] .portfolio-chart[data-direction='up'] .portfolio-chart-line {
-  stroke: color-mix(in srgb, var(--color-success) 82%, rgba(9, 12, 21, 0.35) 18%);
-}
-
-body[data-theme="light"] .portfolio-chart[data-direction='up'] .portfolio-chart-area {
-  fill: color-mix(in srgb, var(--color-success) 32%, transparent);
-}
-
-body[data-theme="light"] .portfolio-chart[data-direction='down'] .portfolio-chart-line {
-  stroke: color-mix(in srgb, var(--color-danger) 84%, rgba(9, 12, 21, 0.45) 16%);
-}
-
-body[data-theme="light"] .portfolio-chart[data-direction='down'] .portfolio-chart-area {
-  fill: color-mix(in srgb, var(--color-danger) 34%, transparent);
-}
-
-body[data-theme="light"] .portfolio-chart-point {
-  fill: rgba(var(--color-primary-rgb), 0.9);
-  stroke: rgba(9, 12, 21, 0.65);
-}
-
-body[data-theme="light"] .portfolio-chart {
-  background: linear-gradient(
-    160deg,
-    rgba(var(--color-primary-rgb), 0.12) 0%,
-    rgba(248, 250, 252, 0.92) 48%,
-    rgba(241, 245, 249, 0.96) 100%
-  );
-}
-
-body[data-theme="light"] .portfolio-chart-grid-line {
-  stroke: rgba(var(--color-primary-rgb), 0.18);
-}
-
-body[data-theme="light"] .portfolio-chart-axis line {
-  stroke: rgba(var(--color-primary-rgb), 0.38);
-}
-
-body[data-theme="light"] .portfolio-chart-axis-label {
-  fill: rgba(222, 223, 231, 0.7);
-}
-
-body[data-theme="light"] .portfolio-chart-tooltip {
-  background: rgba(248, 250, 252, 0.95);
-  box-shadow: 0 18px 38px -24px rgba(15, 23, 42, 0.28), inset 0 0 0 1px var(--surface-outline);
-}
-
-.portfolio-chart-empty,
-.portfolio-chart-error,
-.portfolio-chart-loading {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--color-text-muted);
-  text-align: center;
-}
-
-.portfolio-chart-error {
-  color: var(--color-danger);
-}
-
-.portfolio-card {
-  border-radius: 18px;
-  background: var(--color-surface);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline-strong);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.portfolio-card:hover,
-.portfolio-card:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 32px 60px -32px rgba(8, 16, 36, 0.65), inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.22);
-}
-
-body[data-theme="light"] .portfolio-card:hover,
-body[data-theme="light"] .portfolio-card:focus-within {
-  box-shadow: 0 30px 56px -32px rgba(15, 23, 42, 0.4), inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.24);
-}
-
-.portfolio-card-link {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  height: 100%;
-  color: inherit;
-  text-decoration: none;
-}
-
-.portfolio-card-media {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  background: rgba(var(--color-primary-rgb), 0.08);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-body[data-theme="dark"] .portfolio-card-media {
-  background: rgba(var(--color-primary-rgb), 0.12);
-}
-
-.portfolio-card-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.portfolio-card-placeholder {
-  font-size: 2.8rem;
-  color: rgba(var(--color-primary-rgb), 0.28);
-}
-
-body[data-theme="dark"] .portfolio-card-placeholder {
-  color: rgba(var(--color-primary-rgb), 0.32);
-}
-
-.portfolio-card-body {
-  padding: 16px 20px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  flex: 1;
-}
-
-.portfolio-card-set {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.78rem;
-  color: var(--color-text-muted);
-}
-
-.portfolio-card-set img {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: var(--color-surface-strong);
-  box-shadow: inset 0 0 0 1px var(--surface-outline);
-  object-fit: contain;
-  padding: 3px;
-}
-
-body[data-theme="light"] .portfolio-card-set img {
-  box-shadow: inset 0 0 0 1px var(--surface-outline);
-}
-
-.portfolio-card-title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-.portfolio-card-meta {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.portfolio-card-value {
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: var(--color-text);
-}
-
-.portfolio-card-value[data-direction='up'] {
-  color: var(--color-success);
-}
-
-.portfolio-card-value[data-direction='down'] {
-  color: var(--color-danger);
-}
-
-.portfolio-card-trend {
-  margin: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.portfolio-card-trend-icon {
+.settings-form label,
+.settings-form fieldset {
+  display: grid;
+  gap: 8px;
   font-size: 0.9rem;
 }
 
-.portfolio-card-trend[data-direction='up'] {
-  color: var(--color-success);
+.settings-form input {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: #fff;
 }
 
-.portfolio-card-trend[data-direction='down'] {
-  color: var(--color-danger);
+.avatar-selector {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  background: #fff;
 }
 
-.portfolio-card-trend[data-direction='flat'] {
-  color: var(--color-text-muted);
-}
-
-.portfolio-card-update {
-  margin: 0;
-  font-size: 0.75rem;
-  color: rgba(31, 31, 61, 0.6);
-}
-
-body[data-theme="dark"] .portfolio-card-update {
-  color: rgba(231, 234, 240, 0.55);
-}
-
-.table-responsive a.table-link {
-  color: var(--color-primary);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.table-responsive a.table-link:hover,
-.table-responsive a.table-link:focus-visible {
-  text-decoration: underline;
-}
-
-.table-empty {
-  text-align: center;
-  padding: 32px 16px;
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--color-text-muted);
-}
-
-.auth-layout {
+.avatar-options {
   display: grid;
-  gap: clamp(24px, 5vw, 60px);
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  align-items: center;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
 
-.auth-copy {
+.avatar-option {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.auth-copy h1 {
-  margin: 0;
-  font-size: clamp(2.2rem, 5vw, 3rem);
-  color: var(--color-primary);
-}
-
-.auth-copy p {
-  margin: 0;
-  color: var(--color-text-muted);
-  line-height: 1.7;
-}
-
-.feature-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 12px;
-}
-
-.feature-list li {
-  display: flex;
-  gap: 12px;
+  gap: 8px;
   align-items: center;
-  color: var(--color-text-muted);
+  text-align: center;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
 }
 
-.feature-list span {
-  width: 32px;
-  height: 32px;
+.avatar-option input {
+  margin: 0;
+}
+
+.avatar-option-visual {
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
-  background: rgba(var(--color-primary-rgb), 0.1);
+  background-size: cover;
+  background-position: center;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-primary);
   font-weight: 600;
-}
-
-.form-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: clamp(24px, 4vw, 36px);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline-strong);
-  backdrop-filter: blur(16px);
-  display: grid;
-  gap: 18px;
-}
-
-.form-card h2 {
-  margin: 0;
-  font-size: 1.8rem;
-  color: var(--color-primary);
-}
-
-.form-card p {
-  margin: 0;
-  color: var(--color-text-muted);
-}
-
-.form-card .alert {
-  margin-top: -4px;
-}
-
-.form-card .form-footer {
-  margin-top: 12px;
-}
-
-.inline-link {
-  color: var(--color-primary);
-  font-weight: 600;
-  text-decoration: underline;
+  color: var(--color-muted);
+  background-color: var(--color-surface-alt);
 }
 
 .app-footer {
-  width: min(1120px, calc(100% - 32px));
-  margin: 0 auto 32px;
-  padding: 24px;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, rgba(12, 20, 38, 0.92), rgba(9, 13, 24, 0.88));
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline-strong);
+  margin: 48px 0 32px;
   text-align: center;
+  color: var(--color-muted);
   font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-body[data-theme="light"] .app-footer {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.92));
-}
-
-.card-detail-hero,
-.card-detail-chart-panel,
-.card-detail-related {
-  padding: clamp(24px, 4vw, 36px);
-}
-
-.card-detail-main {
-  display: grid;
-  grid-template-columns: minmax(220px, 320px) 1fr;
-  gap: clamp(24px, 5vw, 48px);
-  align-items: center;
-}
-
-.card-detail-media {
-  display: flex;
-  justify-content: center;
-}
-
-.card-detail-image {
-  position: relative;
-  width: min(100%, 320px);
-  aspect-ratio: 3 / 4;
-  border-radius: 24px;
-  background: linear-gradient(135deg, rgba(var(--color-primary-rgb), 0.14), rgba(255, 204, 0, 0.18));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--shadow-card);
-  overflow: hidden;
-}
-
-.card-detail-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 20px;
-  box-shadow: 0 28px 40px -32px rgba(17, 22, 63, 0.65);
-}
-
-.card-detail-placeholder {
-  font-size: clamp(3rem, 8vw, 4.5rem);
-  color: rgba(var(--color-primary-rgb), 0.3);
-}
-
-.card-detail-info {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.card-detail-era {
-  align-self: flex-start;
-  background: rgba(var(--color-primary-rgb), 0.12);
-  color: var(--color-primary);
-  padding: 4px 14px;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-.card-detail-set {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 1rem;
-  color: var(--color-text-muted);
-}
-
-#card-detail-set-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
-  border: 1px solid rgba(var(--color-primary-rgb), 0.12);
-  background: #fff;
-  object-fit: contain;
-  padding: 4px;
-  box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.65);
-}
-
-.card-detail-artist {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.92rem;
-}
-
-.card-detail-meta {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  margin: 16px 0 12px;
 }
 
-.card-detail-meta div {
-  background: rgba(var(--color-primary-rgb), 0.05);
-  border-radius: 16px;
-  padding: 12px 16px;
+.footer-links {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.card-detail-meta dt {
-  margin: 0;
-  font-size: 0.72rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.card-detail-meta dd {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-.card-detail-actions {
-  display: flex;
+  justify-content: center;
+  gap: 16px;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 8px;
 }
 
-.card-detail-chart-panel .panel-header {
-  align-items: center;
+.footer-links a {
+  color: var(--color-accent);
 }
 
-.chart-range {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.chart-range .secondary {
-  border-radius: 999px;
-  padding: 6px 16px;
-  font-size: 0.85rem;
-}
-
-.chart-range .secondary.active {
-  background: var(--color-primary);
-  color: #fff;
-  box-shadow: 0 12px 24px -18px rgba(17, 22, 63, 0.6);
-}
-
-.card-chart-wrapper {
-  margin-top: 24px;
-  background: var(--color-surface);
-  border-radius: 24px;
-  padding: clamp(18px, 4vw, 28px);
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-}
-
-.chart-empty {
-  text-align: center;
-  margin: 16px 0 0;
-  color: var(--color-text-muted);
-}
-
-.related-grid {
-  display: grid;
-  gap: 18px;
-  margin-top: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.related-card {
-  border-radius: 20px;
-  background: var(--color-surface);
-  box-shadow: var(--shadow-card);
-  overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.related-card:hover,
-.related-card:focus-within {
-  transform: translateY(-4px);
-  box-shadow: 0 28px 48px -32px rgba(17, 22, 63, 0.45);
-}
-
-.related-card a {
-  display: flex;
-  flex-direction: column;
-  color: inherit;
-  text-decoration: none;
-  height: 100%;
-}
-
-.related-card-image {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  object-fit: cover;
-}
-
-.related-card-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 2.4rem;
-  color: rgba(var(--color-primary-rgb), 0.28);
-  background: rgba(var(--color-primary-rgb), 0.08);
-}
-
-.related-card-body {
-  padding: 14px 18px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.related-card-set {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--color-text-muted);
-  font-size: 0.78rem;
-}
-
-.related-card-set img {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  background: #fff;
-  border: 1px solid rgba(var(--color-primary-rgb), 0.12);
-  object-fit: contain;
-  padding: 3px;
-}
-
-.related-card-title {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
-.related-card-meta {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.85rem;
-}
-
-.related-empty {
-  margin-top: 12px;
-  text-align: center;
-  color: var(--color-text-muted);
-}
-
-@media (max-width: 920px) {
+@media (max-width: 900px) {
   .app-header {
     grid-template-columns: auto auto;
-    grid-template-rows: auto auto;
-    gap: 16px;
+    grid-template-areas: "brand actions" "nav nav";
   }
 
-  .app-nav {
-    grid-column: 1 / -1;
+  .brand {
+    grid-area: brand;
   }
 
   .header-actions {
-    justify-content: flex-start;
+    grid-area: actions;
+  }
+
+  .app-nav {
+    grid-area: nav;
+    flex-direction: column;
+    align-items: stretch;
+    background: var(--color-surface-alt);
+    padding: 12px;
+    border-radius: var(--radius-md);
+    display: none;
+  }
+
+  .app-nav[data-open="true"] {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 720px) {
+  main {
+    gap: 24px;
+    padding-top: 24px;
+  }
+
+  .page-hero,
+  .panel {
+    padding: 20px;
   }
 
   .card-detail-main {
     grid-template-columns: 1fr;
   }
 
-  .card-detail-info {
-    align-items: center;
-    text-align: center;
-  }
-
-  .card-detail-set {
-    justify-content: center;
-  }
-
-  .card-detail-meta {
-    justify-items: center;
+  .collection-table {
+    min-width: 600px;
   }
 }
-
-@media (max-width: 760px) {
-  main {
-    width: calc(100% - 24px);
-    padding-top: 24px;
-    gap: 24px;
-  }
-
-  .app-header {
-    width: calc(100% - 24px);
-    margin-top: 12px;
-    grid-template-columns: auto auto;
-    grid-template-rows: auto auto;
-    align-items: center;
-  }
-
-  .nav-toggle {
-    display: inline-flex;
-  }
-
-  .app-nav {
-    position: absolute;
-    top: calc(100% + 12px);
-    right: 16px;
-    left: 16px;
-    flex-direction: column;
-    background: var(--color-surface);
-    border-radius: var(--radius-md);
-    padding: 16px;
-    box-shadow: var(--shadow-soft);
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(-10px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
-  }
-
-  .app-nav[data-open='true'] {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
-
-  .app-nav a {
-    width: 100%;
-    text-align: center;
-  }
-
-  .header-actions {
-    grid-column: 1 / -1;
-    justify-content: space-between;
-  }
-
-  .user-chip {
-    flex: 1;
-    justify-content: flex-start;
-  }
-
-  .page-hero {
-    padding: 28px 24px;
-  }
-
-  .card-detail-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .chart-range {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 520px) {
-  .app-header {
-    grid-template-columns: 1fr auto;
-  }
-
-  .header-actions {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
-  .form-grid {
-    grid-template-columns: 1fr;
-  }
-
-  thead {
-    display: none;
-  }
-
-  table,
-  tbody,
-  tr,
-  td {
-    display: block;
-    width: 100%;
-  }
-
-  tbody tr {
-    margin-bottom: 16px;
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-soft);
-    background: var(--color-surface);
-  }
-
-  tbody td {
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  tbody td::before {
-    content: attr(data-label);
-    display: block;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-muted);
-    margin-bottom: 4px;
-  }
-
-  .table-actions {
-    justify-content: flex-start;
-  }
-
-  .table-empty {
-    padding: 24px 16px;
-  }
-
-  .table-empty::before {
-    display: none;
-  }
-
-  .card-chart-wrapper {
-    padding: 18px 16px;
-  }
-}
-
-.settings-panel {
-  gap: 32px;
-}
-
-.settings-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 24px;
-}
-
-.settings-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.settings-form {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.settings-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.settings-form input {
-  border-radius: var(--radius-md);
-  padding: 10px 12px;
-  font-size: 0.95rem;
-  background: var(--color-background-alt);
-  color: var(--color-text);
-  box-shadow: inset 0 0 0 1px var(--surface-outline);
-}
-
-.settings-form input:focus {
-  outline: 2px solid rgba(var(--color-primary-rgb), 0.35);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.45);
-}
-
-.avatar-selector {
-  border-radius: var(--radius-md);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  background: var(--color-surface-strong);
-  margin: 0;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-}
-
-.avatar-selector legend {
-  font-size: 0.9rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-muted);
-  padding: 0 6px;
-}
-
-.avatar-selector p {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.avatar-options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
-}
-
-.avatar-option {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  background: rgba(var(--color-primary-rgb), 0.1);
-  cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.14);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.avatar-option input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.avatar-option-visual {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  color: var(--color-text);
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
-}
-
-.avatar-option input:checked + .avatar-option-visual {
-  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.35);
-}
-
-.avatar-option input:checked + .avatar-option-visual + .avatar-option-label,
-.avatar-option:focus-within .avatar-option-label {
-  color: var(--color-primary-dark);
-}
-
-.avatar-option:focus-within,
-.avatar-option:hover {
-  transform: translateY(-1px);
-  border-color: rgba(var(--color-primary-rgb), 0.45);
-  box-shadow: 0 12px 28px -18px rgba(8, 16, 36, 0.55);
-}
-
-.avatar-option-label {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.avatar-option[data-custom="true"] {
-  background: rgba(var(--color-primary-rgb), 0.06);
-  border-style: dashed;
-}
-
-.avatar-option[data-custom="true"] .avatar-option-visual {
-  background: linear-gradient(135deg, rgba(var(--color-primary-rgb), 0.28), rgba(255, 209, 102, 0.45));
-  color: #fff;
-  box-shadow: none;
-}
-
-body[data-theme="light"] .avatar-selector {
-  background: rgba(255, 255, 255, 0.96);
-}
-
-body[data-theme="light"] .avatar-option {
-  background: rgba(var(--color-primary-rgb), 0.05);
-  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.12);
-}
-
-body[data-theme="light"] .avatar-option:hover,
-body[data-theme="light"] .avatar-option:focus-within {
-  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.38);
-}
-
-body[data-theme="light"] .avatar-option-visual {
-  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.65);
-}
-
-body[data-theme="light"] .avatar-option[data-custom="true"] .avatar-option-visual {
-  color: #0f172a;
-}
-
-.settings-form .alert {
-  margin-top: 4px;
-}
-
-.legal-panel {
-  gap: 24px;
-}
-
-.legal-content {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  line-height: 1.6;
-}
-
-.legal-content h2 {
-  font-size: 1.25rem;
-  color: var(--color-primary);
-}
-
-.legal-content ul {
-  list-style: disc;
-  padding-left: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.footer-links {
-  margin-top: 12px;
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  justify-content: center;
-  font-size: 0.9rem;
-}
-
-.footer-links a {
-  color: inherit;
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-}
-
-.footer-links a:hover,
-.footer-links a:focus-visible {
-  border-bottom-color: currentColor;
-}
-
-.home-legal {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 24px;
-}
-
-.home-legal article {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: 20px;
-  box-shadow: var(--shadow-soft), inset 0 0 0 1px var(--surface-outline);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.home-legal a {
-  align-self: flex-start;
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-@media (max-width: 960px) {
-  .settings-grid,
-  .home-legal {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -1,25 +1,22 @@
 {% extends "base.html" %}
 {% block title %}Dodaj kartę - Kartoteka{% endblock %}
 {% block content %}
-<section class="page-hero">
+<section class="page-hero add-card-hero">
   <div>
     <p class="eyebrow">Rozszerz swoją kolekcję</p>
-    <h1>Wyszukaj kartę w bazie</h1>
-    <p>
-      Aby wyszukać kartę w bazie, wpisz jej nazwę lub nazwę z numerem w polu poniżej, a następnie
-      wybierz interesujący Cię wynik z listy.
-    </p>
+    <h1>Dodaj kartę z katalogu</h1>
+    <p>Wpisz nazwę lub numer karty. Wyniki możesz od razu zapisać w kolekcji, ustawiając ilość i podstawowe oznaczenia.</p>
   </div>
 </section>
 
 <section class="panel" id="add-card-page">
   <div class="panel-header">
     <div>
-      <h2>Znajdź kartę w bazie</h2>
-      <p>Wpisz nazwę karty – możesz dodać numer, aby szybciej odnaleźć konkretny egzemplarz.</p>
+      <h2>Wyszukiwarka kart</h2>
+      <p>Dodaj numer lub kod seta, aby szybciej znaleźć właściwy wariant.</p>
     </div>
   </div>
-  <form id="add-card-form" class="form-grid" autocomplete="off">
+  <form id="add-card-form" class="add-card-form" autocomplete="off" data-card-search-form>
     <label>
       Nazwa lub numer karty
       <input
@@ -27,45 +24,17 @@
         name="query"
         id="add-card-query"
         autocomplete="off"
-        placeholder="np. Giovanni's Charisma 78/132"
+        placeholder="np. Pikachu 25/102"
         required
       />
     </label>
-    <p class="search-hint" id="card-search-hint" aria-live="polite" hidden></p>
-    <input type="hidden" name="rarity" id="add-card-rarity" />
     <div class="form-footer">
-      <button type="submit" class="secondary" id="card-search-trigger">Szukaj</button>
+      <button type="submit" class="button primary" id="card-search-trigger">Szukaj</button>
     </div>
   </form>
-</section>
-
-<section class="panel card-search-results-panel" id="card-search-results-section" hidden>
-  <div class="panel-header card-search-results-header">
-      <div>
-        <h2>Wyniki wyszukiwania</h2>
-        <p>Otwórz kartę z listy, aby zobaczyć jej szczegóły.</p>
-      </div>
-    <div class="card-search-controls">
-      <label class="card-search-sort">
-        Sortuj według
-        <select id="card-search-sort" name="card-search-sort">
-          <option value="relevance">Trafność</option>
-          <option value="name_asc">Nazwa A–Z</option>
-          <option value="name_desc">Nazwa Z–A</option>
-          <option value="number_asc">Numer rosnąco</option>
-          <option value="number_desc">Numer malejąco</option>
-          <option value="set_asc">Set A–Z</option>
-          <option value="set_desc">Set Z–A</option>
-        </select>
-      </label>
-    </div>
-  </div>
-  <p id="card-search-summary" class="card-search-summary" hidden aria-live="polite"></p>
+  <div class="alert" id="add-card-alert" hidden></div>
+  <p id="card-search-summary" class="search-summary" hidden aria-live="polite"></p>
   <div id="card-search-results" class="card-search-results" role="list"></div>
-  <p id="card-search-empty" class="card-search-empty" hidden aria-live="polite"></p>
+  <p id="card-search-empty" class="empty-state" hidden aria-live="polite"></p>
 </section>
-
-<div class="toast-container">
-  <div class="alert" id="add-card-alert" role="status" aria-live="polite" hidden></div>
-</div>
 {% endblock %}

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -31,19 +31,21 @@
     </button>
     <nav class="app-nav" id="primary-navigation" data-nav>
       <a href="/" class="{{ 'active' if current_path == '/' else '' }}">Strona główna</a>
-      <a href="/dashboard" class="{{ 'active' if current_path.startswith('/dashboard') else '' }}">Panel</a>
-      <a href="/portfolio" class="{{ 'active' if current_path.startswith('/portfolio') else '' }}">Portfolio</a>
+      <a
+        href="/collection"
+        class="{{ 'active' if current_path.startswith('/collection') or current_path.startswith('/dashboard') else '' }}"
+      >Kolekcja</a>
+      <a
+        href="/cards/add"
+        class="{{ 'active' if current_path.startswith('/cards/add') else '' }}"
+      >Dodaj kartę</a>
     </nav>
     <div class="header-actions">
-      <button type="button" class="theme-toggle" data-theme-toggle aria-label="Przełącz motyw">
-        <span aria-hidden="true">🌙</span>
-      </button>
-      <a href="/settings" class="user-profile" data-user-profile-link data-state="anonymous" aria-disabled="true">
-        <span class="user-name" data-username-display>Gość</span>
-        <span class="user-avatar" data-user-avatar aria-hidden="true">G</span>
-      </a>
+      <span class="user-pill" data-user-pill>
+        <span class="user-pill-label" data-username-display>Gość</span>
+      </span>
       <a href="/login" class="ghost" id="login-button">Zaloguj</a>
-      <button type="button" class="ghost" id="logout-button" hidden>Wyloguj</button>
+      <button type="button" class="ghost" id="logout-button" data-logout hidden>Wyloguj</button>
     </div>
   </header>
   <main>

--- a/kartoteka_web/templates/dashboard.html
+++ b/kartoteka_web/templates/dashboard.html
@@ -1,108 +1,62 @@
 {% extends "base.html" %}
 {% block title %}Kolekcja - Kartoteka{% endblock %}
 {% block content %}
-<section class="page-hero">
+<section class="page-hero collection-hero">
   <div>
-    <p class="eyebrow">Pokemon TCG Manager</p>
+    <p class="eyebrow">Twoja kolekcja</p>
     <h1>Witaj, {{ username or 'Trenerze' }}!</h1>
-    <p>Z poziomu kokpitu błyskawicznie sprawdzisz stan swojej kolekcji, dodasz nowe karty i zaktualizujesz informacje o swoich wpisach.</p>
-    <div class="hero-actions">
-      <a class="button primary" href="/cards/add">Wyszukaj kartę</a>
-      <a class="button secondary" href="#collection-section">Przeglądaj kolekcję</a>
-    </div>
-  </div>
-</section>
-
-<section class="panel">
-  <div class="panel-header">
-    <div>
-      <h2>Podsumowanie kolekcji</h2>
-      <p>Najważniejsze statystyki Twojego zbioru aktualizowane w czasie rzeczywistym.</p>
-    </div>
-  </div>
-  <div class="stat-grid" id="portfolio-summary">
-    <article class="stat-card">
-      <h3>Liczba wpisów</h3>
-      <p id="summary-count">0</p>
-      <span>Wszystkie pozycje w bazie</span>
-    </article>
-    <article class="stat-card">
-      <h3>Łączna liczba kart</h3>
-      <p id="summary-quantity">0</p>
-      <span>Sumaryczna ilość egzemplarzy</span>
-    </article>
-    <article class="stat-card">
-      <h3>Łączna kwota zakupu [PLN]</h3>
-      <p id="summary-value">0.00</p>
-      <span>Łączny koszt zadeklarowanych kart</span>
-    </article>
-  </div>
-</section>
-
-<section class="panel">
-  <div class="panel-header">
-    <div>
-      <h2>Akcje szybkie</h2>
-      <p>Skróty, które pozwalają przechodzić do najczęściej wykonywanych zadań.</p>
-    </div>
-  </div>
-  <div class="quick-actions">
-    <a class="action-card" href="/cards/add">
-      <span class="action-emoji">➕</span>
-      <strong>Dodaj kartę</strong>
-      <span>Rozszerz swoją kolekcję o nowy wpis.</span>
-    </a>
-    <a class="action-card" href="#collection-section">
-      <span class="action-emoji">📚</span>
-      <strong>Zobacz kolekcję</strong>
-      <span>Przeglądaj karty i zarządzaj wpisami.</span>
-    </a>
-    <a class="action-card" href="/portfolio">
-      <span class="action-emoji">💰</span>
-      <strong>Sprawdź portfel</strong>
-      <span>Analizuj strukturę swojej kolekcji.</span>
-    </a>
-  </div>
-</section>
-
-<section class="panel" id="add-card-panel">
-  <div class="panel-header">
-    <div>
-      <h2>Dodaj kartę</h2>
-      <p>Skorzystaj z wyszukiwarki, aby odnaleźć kartę przed dodaniem jej do kolekcji.</p>
-    </div>
-  </div>
-  <div class="add-card-cta">
     <p>
-      Nowe wpisy dodasz na dedykowanej stronie wyszukiwania kart. Wprowadź nazwę, opcjonalnie
-      numer lub zestaw, wybierz odpowiednią kartę i potwierdź dodanie do kolekcji.
+      Poniżej znajdziesz prostą listę wszystkich kart dodanych do kolekcji. Aktualizuj ilości,
+      oznaczaj wersje reverse lub holo i usuwaj wpisy, gdy przestaną być potrzebne.
     </p>
-    <a class="button primary" href="/cards/add">Szukaj kart</a>
+    <div class="hero-actions">
+      <a class="button primary" href="/cards/add">Dodaj nową kartę</a>
+      <button class="button secondary" id="refresh-collection" type="button">Odśwież listę</button>
+    </div>
   </div>
 </section>
 
 <section class="panel" id="collection-section">
   <div class="panel-header">
     <div>
-      <h2>Aktualna kolekcja</h2>
-      <p>Pełna lista kart z możliwością aktualizacji ilości oraz usuwania wpisów.</p>
+      <h2>Zapisane wpisy</h2>
+      <p>Zarządzaj podstawowymi metadanymi dla każdej karty z kolekcji.</p>
     </div>
-    <button id="refresh-collection" class="secondary" type="button">Odśwież dane</button>
   </div>
+  <div class="alert" id="collection-alert" hidden></div>
   <div class="table-responsive">
-    <table>
+    <table class="collection-table">
       <thead>
         <tr>
-          <th>Nazwa</th>
-          <th>Numer</th>
-          <th>Set</th>
-          <th>Ilość</th>
-          <th>Cena zakupu</th>
-          <th>Akcje</th>
+          <th scope="col">Karta</th>
+          <th scope="col">Set</th>
+          <th scope="col">Numer</th>
+          <th scope="col">Ilość</th>
+          <th scope="col">Reverse</th>
+          <th scope="col">Holo</th>
+          <th scope="col">Cena zakupu</th>
+          <th scope="col">Akcje</th>
         </tr>
       </thead>
       <tbody id="collection-table"></tbody>
     </table>
+    <p class="empty-state" id="collection-empty" hidden>Brak kart w kolekcji. Dodaj pierwszą kartę, aby rozpocząć.</p>
+  </div>
+</section>
+
+<section class="panel">
+  <div class="panel-header">
+    <div>
+      <h2>Porządkuj zbiory krok po kroku</h2>
+      <p>Użyj widoku kart, aby skupić się na pojedynczych wpisach i dodać dodatkowe notatki.</p>
+    </div>
+  </div>
+  <div class="collection-followup">
+    <p>
+      Widok kart prezentuje te same dane w formie kafelków. To dobre miejsce, aby planować wymiany
+      lub zaznaczać priorytetowe pozycje w kolekcji.
+    </p>
+    <a class="button secondary" href="/portfolio">Otwórz widok kart</a>
   </div>
 </section>
 {% endblock %}

--- a/kartoteka_web/templates/portfolio.html
+++ b/kartoteka_web/templates/portfolio.html
@@ -1,45 +1,17 @@
 {% extends "base.html" %}
-{% block title %}Portfel - Kartoteka{% endblock %}
+{% block title %}Zapisane karty - Kartoteka{% endblock %}
 {% block content %}
-<section class="page-hero">
+<section class="page-hero portfolio-hero">
   <div>
-    <p class="eyebrow">Analiza kolekcji</p>
-    <h1>Portfel kolekcjonera</h1>
-    <p>Przeglądaj swoją kolekcję i analizuj liczbę kart oraz zadeklarowane koszty.</p>
+    <p class="eyebrow">Zapisane karty</p>
+    <h1>Przegląd kolekcji</h1>
+    <p>
+      Ten widok przedstawia Twoje wpisy w formie prostych kart. To wygodne miejsce na szybkie
+      sprawdzenie, które pozycje masz już w kolekcji.
+    </p>
     <div class="hero-actions">
-      <a class="button secondary" href="/dashboard">Powrót do kolekcji</a>
-      <button id="refresh-portfolio" class="primary" type="button">Odśwież dane</button>
-    </div>
-  </div>
-</section>
-
-<section class="panel portfolio-performance-panel">
-  <div class="panel-header">
-    <div>
-      <h2 id="portfolio-chart-heading">Historia kolekcji</h2>
-      <p>Podgląd trendów jest obecnie niedostępny w uproszczonym trybie.</p>
-    </div>
-    <div class="portfolio-change" id="portfolio-change" data-direction="flat">
-      <span class="portfolio-change-icon" aria-hidden="true">→</span>
-      <div>
-        <strong id="portfolio-change-value">0.00 PLN</strong>
-        <span>Zmiana w 24h</span>
-      </div>
-    </div>
-  </div>
-  <div class="portfolio-chart-wrapper">
-    <div
-      class="portfolio-chart"
-      id="portfolio-chart"
-      role="group"
-      aria-live="polite"
-      aria-labelledby="portfolio-chart-heading"
-    >
-      <p>Ładuję dane wykresu…</p>
-    </div>
-    <div class="portfolio-chart-meta">
-      <div class="portfolio-chart-stats" hidden></div>
-      <div class="portfolio-chart-range" hidden></div>
+      <a class="button secondary" href="/collection">Przejdź do listy edycji</a>
+      <button id="refresh-portfolio" class="button primary" type="button">Odśwież listę</button>
     </div>
   </div>
 </section>
@@ -47,38 +19,28 @@
 <section class="panel">
   <div class="panel-header">
     <div>
-      <h2>Podsumowanie portfela</h2>
-      <p>Kluczowe wskaźniki obejmujące liczbę wpisów, egzemplarzy i łączny koszt zakupu.</p>
+      <h2>Karty w kolekcji</h2>
+      <p>Podstawowe metadane o każdej karcie i zadeklarowane ilości.</p>
     </div>
-  </div>
-  <div class="stat-grid" id="portfolio-overview">
-    <article class="stat-card">
-      <h3>Wpisy w kolekcji</h3>
-      <p id="portfolio-count">0</p>
-      <span>Unikalne rekordy w bazie</span>
-    </article>
-    <article class="stat-card">
-      <h3>Łączna ilość kart</h3>
-      <p id="portfolio-quantity">0</p>
-      <span>Sumaryczna liczba egzemplarzy</span>
-    </article>
-    <article class="stat-card">
-      <h3>Łączna kwota zakupu [PLN]</h3>
-      <p id="portfolio-value">0.00</p>
-      <span>Suma zadeklarowanych kosztów kart</span>
-    </article>
   </div>
   <div class="alert" id="portfolio-alert" hidden></div>
+  <div class="portfolio-list" id="portfolio-cards"></div>
+  <p class="empty-state" id="portfolio-empty" hidden>Brak kart w kolekcji. Dodaj wpisy, by zobaczyć je tutaj.</p>
 </section>
 
 <section class="panel">
   <div class="panel-header">
     <div>
-      <h2>Karty w portfelu</h2>
-      <p>Przeglądaj zapisane karty wraz z ich szczegółami i cenami zakupu.</p>
+      <h2>Chcesz zaktualizować dane?</h2>
+      <p>Wszystkie zmiany ilości lub cen wykonasz w widoku kolekcji.</p>
     </div>
   </div>
-  <div class="portfolio-grid" id="portfolio-cards"></div>
-  <p class="portfolio-empty" id="portfolio-empty" hidden>Brak kart w portfelu. Dodaj pozycje do kolekcji, aby pojawiły się w tym miejscu.</p>
+  <div class="collection-followup">
+    <p>
+      Kliknij przycisk poniżej, aby przejść do tabeli umożliwiającej edycję wpisów oraz usuwanie
+      niepotrzebnych kart.
+    </p>
+    <a class="button secondary" href="/collection">Otwórz widok edycji</a>
+  </div>
 </section>
 {% endblock %}

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
+from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
@@ -126,56 +127,46 @@ async def _resolve_request_user(request: Request) -> tuple[str, bool, str]:
         return user.username, False, user.avatar_url or ""
 
 
-@app.get("/dashboard", response_class=HTMLResponse)
-async def dashboard_page(request: Request) -> HTMLResponse:
+async def _render_authenticated_page(
+    request: Request, template_name: str, extra_context: dict[str, Any] | None = None
+) -> HTMLResponse:
     username, invalid_credentials, avatar_url = await _resolve_request_user(request)
     if invalid_credentials:
-        return templates.TemplateResponse(
-            "login.html", {"request": request, "username": ""}
-        )
-    return templates.TemplateResponse(
-        "dashboard.html",
-        {"request": request, "username": username, "avatar_url": avatar_url},
-    )
+        return templates.TemplateResponse("login.html", {"request": request, "username": ""})
+
+    context: dict[str, Any] = {
+        "request": request,
+        "username": username,
+        "avatar_url": avatar_url,
+    }
+    if extra_context:
+        context.update(extra_context)
+    return templates.TemplateResponse(template_name, context)
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard_page(request: Request) -> HTMLResponse:
+    return await _render_authenticated_page(request, "dashboard.html")
+
+
+@app.get("/collection", response_class=HTMLResponse)
+async def collection_page(request: Request) -> HTMLResponse:
+    return await _render_authenticated_page(request, "dashboard.html")
 
 
 @app.get("/cards/add", response_class=HTMLResponse)
 async def add_card_page(request: Request) -> HTMLResponse:
-    username, invalid_credentials, avatar_url = await _resolve_request_user(request)
-    if invalid_credentials:
-        return templates.TemplateResponse(
-            "login.html", {"request": request, "username": ""}
-        )
-    return templates.TemplateResponse(
-        "add_card.html",
-        {"request": request, "username": username, "avatar_url": avatar_url},
-    )
+    return await _render_authenticated_page(request, "add_card.html")
 
 
 @app.get("/portfolio", response_class=HTMLResponse)
 async def portfolio_page(request: Request) -> HTMLResponse:
-    username, invalid_credentials, avatar_url = await _resolve_request_user(request)
-    if invalid_credentials:
-        return templates.TemplateResponse(
-            "login.html", {"request": request, "username": ""}
-        )
-    return templates.TemplateResponse(
-        "portfolio.html",
-        {"request": request, "username": username, "avatar_url": avatar_url},
-    )
+    return await _render_authenticated_page(request, "portfolio.html")
 
 
 @app.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request) -> HTMLResponse:
-    username, invalid_credentials, avatar_url = await _resolve_request_user(request)
-    if invalid_credentials:
-        return templates.TemplateResponse(
-            "login.html", {"request": request, "username": ""}
-        )
-    return templates.TemplateResponse(
-        "settings.html",
-        {"request": request, "username": username, "avatar_url": avatar_url},
-    )
+    return await _render_authenticated_page(request, "settings.html")
 
 
 @app.get("/cards/{set_identifier}/{number}", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- streamline the navigation header around the collection workflow and expose a /collection alias for the main builder
- replace the dashboard, portfolio and add-card templates with lean list and card views that focus on quantity, flags and entry management
- rebuild the frontend styling and app.js to cover authentication, collection CRUD and search without the legacy analytics widgets

## Testing
- pytest tests/web/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd1dcdd40832f84b5ba7e9efb31a6