### PR TITLE
Trim dependencies to FastAPI stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ Kartoteka is a FastAPI service and JavaScript dashboard for organising a private
 JWT-secured endpoints for synchronising cards, storage locations and valuations with the hosted single-page application.
 
 ## Python Compatibility
-Kartoteka supports Python 3.9 through 3.13. The default requirements use `Pillow>=10.4`, which ships pre-built wheels for Python
-3.13.
-
-If you must stay on an older Python release that cannot install Pillow 10.4 or later, pin `Pillow<10.4` in `requirements.txt` and
-use a compatible Python version (for example, Python 3.12).
+Kartoteka supports Python 3.9 through 3.13. The dependency stack now focuses on the FastAPI/SQLModel backend and supporting tooling (authentication, templating and HTTP clients). All listed requirements ship pre-built wheels for current CPython releases, so no system compilation should be required on the supported versions.
 
 ## Running the web API and dashboard
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,6 @@
-Pillow>=10.4
 requests==2.31.0
 python-dotenv==1.0.1
-customtkinter==5.2.2
-openai>=1.12
-imagehash==4.3.1
 httpx==0.27.2
-pytesseract==0.3.10
-numpy>=2.0,<2.3
-opencv-python-headless==4.12.0.88
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
 sqlmodel==0.0.16
@@ -17,4 +10,3 @@ bcrypt>=3.2,<4
 python-jose[cryptography]==3.3.0
 aiofiles==23.2.1
 jinja2==3.1.4
-rapidfuzz==3.6.1

--- a/tests/test_pytesseract_whitelist.py
+++ b/tests/test_pytesseract_whitelist.py
@@ -1,7 +1,10 @@
 import shutil
+
 import pytest
-from PIL import Image, ImageDraw, ImageFont
-import pytesseract
+
+pytesseract = pytest.importorskip("pytesseract")
+pytest.importorskip("PIL")
+from PIL import Image, ImageDraw, ImageFont  # type: ignore # noqa: E402
 
 @pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
 def test_pytesseract_recognizes_fraction():


### PR DESCRIPTION
## Summary
- remove GUI, OCR and CV libraries from the Python requirements to focus on the FastAPI/SQLModel backend stack
- update the README to reflect the streamlined dependency set
- make the pytesseract whitelist test optional when OCR tooling is not installed

## Testing
- pip install -r requirements.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcbac48868832fab2cd864db9f0c71