### PR TITLE
Add dark theme toggle with persistence

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -14,6 +14,133 @@
     }
   })();
 
+  const THEME_KEY = "kartoteka_theme";
+  const themeMediaQuery =
+    typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-color-scheme: dark)")
+      : null;
+  let currentThemePreference = "auto";
+
+  const readStoredTheme = () => {
+    if (!storage) return null;
+    try {
+      return storage.getItem(THEME_KEY);
+    } catch (error) {
+      console.warn("Unable to read theme preference", error);
+      return null;
+    }
+  };
+
+  const persistThemePreference = (preference) => {
+    if (!storage) return;
+    try {
+      if (preference === "auto") {
+        storage.removeItem(THEME_KEY);
+      } else {
+        storage.setItem(THEME_KEY, preference);
+      }
+    } catch (error) {
+      console.warn("Unable to persist theme preference", error);
+    }
+  };
+
+  const resolveEffectiveTheme = (preference) => {
+    if (preference === "dark" || preference === "light") {
+      return preference;
+    }
+    if (themeMediaQuery && typeof themeMediaQuery.matches === "boolean") {
+      return themeMediaQuery.matches ? "dark" : "light";
+    }
+    return "light";
+  };
+
+  const updateThemeMetaTag = () => {
+    const meta = document.querySelector("meta[data-theme-color]");
+    const root = document.body || document.documentElement;
+    if (!meta || !root) return;
+    const styles = getComputedStyle(root);
+    const fallback = resolveEffectiveTheme(currentThemePreference) === "dark"
+      ? "#0b1220"
+      : "#ffffff";
+    const surface =
+      styles.getPropertyValue("--color-surface").trim() ||
+      styles.getPropertyValue("--color-background").trim() ||
+      fallback;
+    meta.setAttribute("content", surface || fallback);
+  };
+
+  const updateThemeToggleDisplay = (preference) => {
+    const toggle = document.querySelector("[data-theme-toggle]");
+    if (!toggle) return;
+    const icon = toggle.querySelector("[data-theme-toggle-icon]");
+    const effective = resolveEffectiveTheme(preference);
+    let label = "Motyw systemowy";
+    let iconSymbol = "🌓";
+    if (preference === "dark") {
+      label = "Motyw ciemny";
+      iconSymbol = "🌙";
+    } else if (preference === "light") {
+      label = "Motyw jasny";
+      iconSymbol = "☀️";
+    } else {
+      label =
+        effective === "dark" ? "Motyw systemowy (ciemny)" : "Motyw systemowy (jasny)";
+      iconSymbol = "🌓";
+    }
+    toggle.dataset.mode = preference;
+    toggle.setAttribute("aria-label", `${label}. Kliknij, aby zmienić motyw.`);
+    toggle.setAttribute("title", `${label} – kliknij, aby zmienić motyw`);
+    if (icon) {
+      icon.textContent = iconSymbol;
+    }
+  };
+
+  const applyThemePreference = (preference, options = {}) => {
+    const target = document.body;
+    if (!target) return;
+    const normalized = preference === "dark" || preference === "light" ? preference : "auto";
+    target.setAttribute("data-theme", normalized);
+    if (options.persist !== false) {
+      persistThemePreference(normalized);
+    }
+    currentThemePreference = normalized;
+    updateThemeToggleDisplay(normalized);
+    updateThemeMetaTag();
+  };
+
+  const initializeTheme = () => {
+    const stored = readStoredTheme();
+    const initial = stored === "dark" || stored === "light" ? stored : "auto";
+    applyThemePreference(initial, { persist: false });
+
+    const toggle = document.querySelector("[data-theme-toggle]");
+    if (toggle) {
+      toggle.addEventListener("click", () => {
+        const next =
+          currentThemePreference === "light"
+            ? "dark"
+            : currentThemePreference === "dark"
+              ? "auto"
+              : "light";
+        applyThemePreference(next);
+      });
+    }
+
+    if (themeMediaQuery) {
+      const handleChange = () => {
+        if (currentThemePreference === "auto") {
+          applyThemePreference("auto", { persist: false });
+        }
+      };
+      if (typeof themeMediaQuery.addEventListener === "function") {
+        themeMediaQuery.addEventListener("change", handleChange);
+      } else if (typeof themeMediaQuery.addListener === "function") {
+        themeMediaQuery.addListener(handleChange);
+      }
+      handleChange();
+    }
+  };
+
   const getToken = () => (storage ? storage.getItem(TOKEN_KEY) : null);
   const setToken = (token) => {
     if (!storage) return;
@@ -802,6 +929,8 @@
       });
     }
   };
+
+  initializeTheme();
 
   const init = async () => {
     setupNavigation();

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: light;
   --color-background: #f5f6fb;
+  --color-background-alt: #eef1f9;
   --color-surface: #ffffff;
   --color-surface-alt: #f0f3fa;
   --color-border: #d9deeb;
@@ -29,10 +30,63 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, var(--color-background) 0%, #eef1f9 100%);
+  background: linear-gradient(
+    180deg,
+    var(--color-background) 0%,
+    var(--color-background-alt, var(--color-background)) 100%
+  );
   color: var(--color-text);
   display: flex;
   flex-direction: column;
+}
+
+body[data-theme="light"] {
+  color-scheme: light;
+}
+
+body[data-theme="dark"] {
+  color-scheme: dark;
+  --color-background: #0b1220;
+  --color-background-alt: #111a2c;
+  --color-surface: #111a2c;
+  --color-surface-alt: #1a2742;
+  --color-border: #253556;
+  --color-border-strong: #314469;
+  --color-text: #f8fbff;
+  --color-muted: #9fb3d9;
+  --color-accent: #60a5fa;
+  --color-accent-dark: #3b82f6;
+  --color-accent-soft: rgba(59, 130, 246, 0.22);
+  --color-success: #22c55e;
+  --color-danger: #f87171;
+  --shadow-soft: 0 18px 48px rgba(8, 14, 26, 0.65);
+  --shadow-card: 0 10px 32px rgba(8, 14, 26, 0.45);
+}
+
+body[data-theme="auto"] {
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  body[data-theme="auto"],
+  body:not([data-theme]) {
+    color-scheme: dark;
+    --color-background: #0b1220;
+    --color-background-alt: #111a2c;
+    --color-surface: #111a2c;
+    --color-surface-alt: #1a2742;
+    --color-border: #253556;
+    --color-border-strong: #314469;
+    --color-text: #f8fbff;
+    --color-muted: #9fb3d9;
+    --color-accent: #60a5fa;
+    --color-accent-dark: #3b82f6;
+    --color-accent-soft: rgba(59, 130, 246, 0.22);
+    --color-success: #22c55e;
+    --color-danger: #f87171;
+    --shadow-soft: 0 18px 48px rgba(8, 14, 26, 0.65);
+    --shadow-card: 0 10px 32px rgba(8, 14, 26, 0.45);
+  }
 }
 
 main {
@@ -229,6 +283,20 @@ img {
 .ghost:focus-visible {
   border-color: var(--color-accent);
   color: var(--color-accent-dark);
+}
+
+.theme-toggle {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+}
+
+.theme-toggle span {
+  line-height: 1;
 }
 
 .page-hero {

--- a/kartoteka_web/templates/base.html
+++ b/kartoteka_web/templates/base.html
@@ -14,7 +14,11 @@
   <script defer src="{{ url_for('static', path='/js/app.js') }}"></script>
   {% block head_extra %}{% endblock %}
 </head>
-<body data-username="{{ username | default('') }}" data-avatar="{{ avatar_url | default('') }}">
+<body
+  data-theme="auto"
+  data-username="{{ username | default('') }}"
+  data-avatar="{{ avatar_url | default('') }}"
+>
   {% set current_path = request.url.path %}
   <header class="app-header">
     <div class="brand">
@@ -41,6 +45,15 @@
       >Dodaj kartę</a>
     </nav>
     <div class="header-actions">
+      <button
+        type="button"
+        class="ghost theme-toggle"
+        data-theme-toggle
+        aria-label="Przełącz motyw"
+        title="Przełącz motyw"
+      >
+        <span aria-hidden="true" data-theme-toggle-icon>🌓</span>
+      </button>
       <span class="user-pill" data-user-pill>
         <span class="user-pill-label" data-username-display>Gość</span>
       </span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ bcrypt>=3.2,<4
 python-jose[cryptography]==3.3.0
 aiofiles==23.2.1
 jinja2==3.1.4
+beautifulsoup4==4.12.3

--- a/tests/test_frontend_theme.py
+++ b/tests/test_frontend_theme.py
@@ -1,0 +1,25 @@
+"""Frontend integration checks for base template theming."""
+
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def test_base_template_contains_theme_toggle(api_client):
+    response = api_client.get("/")
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    body = soup.body
+    assert body is not None
+    assert body.get("data-theme") == "auto"
+
+    toggle = soup.select_one("[data-theme-toggle]")
+    assert toggle is not None
+    icon = toggle.select_one("[data-theme-toggle-icon]")
+    assert icon is not None
+
+    theme_meta = soup.select_one('meta[data-theme-color]')
+    assert theme_meta is not None
+    assert theme_meta.get("content")


### PR DESCRIPTION
## Summary
- add a dark theme variable palette with a header toggle and automatic fallback
- persist the selected theme in localStorage while syncing the meta theme color
- cover the base template with a BeautifulSoup test to ensure the toggle renders

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcecba4a38832f8de74ecb998e2a7f