### PR TITLE
Add RapidAPI support to TCG service requests

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -6,6 +6,7 @@ import logging
 import os
 from difflib import SequenceMatcher
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 POKEMONTCG_API_URL = os.getenv("POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
 POKEMONTCG_API_KEY = os.getenv("POKEMONTCG_API_KEY")
+RAPIDAPI_DEFAULT_HOST = "pokemon-tcg.p.rapidapi.com"
 
 
 def _apply_default_user_agent(
@@ -85,6 +87,18 @@ def _extract_images(card: dict[str, Any]) -> tuple[Optional[str], Optional[str]]
     if image_large and isinstance(image_large, dict):
         image_large = image_large.get("url")
     return image_small, image_large
+
+
+def _build_cards_endpoint(rapidapi_host: Optional[str]) -> str:
+    """Return an absolute API endpoint for the Pokémon TCG cards resource."""
+
+    parsed = urlparse(POKEMONTCG_API_URL)
+    host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+    path = parsed.path or "/v2/cards"
+    if not path.startswith("/"):
+        path = "/" + path
+    query = f"?{parsed.query}" if parsed.query else ""
+    return f"https://{host}{path}{query}"
 
 
 def _normalize_text_field(value: Any) -> Optional[str]:
@@ -234,12 +248,19 @@ def search_cards(
     total_clean = text.sanitize_number(number_total) if number_total else ""
 
     name_api = text.normalize(name, keep_spaces=True)
-    api_key = rapidapi_key if rapidapi_key is not None else POKEMONTCG_API_KEY
-    url = POKEMONTCG_API_URL
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    if api_key:
-        headers["X-Api-Key"] = api_key
+    use_rapidapi = bool(rapidapi_key or rapidapi_host)
+    if use_rapidapi:
+        url = _build_cards_endpoint(rapidapi_host)
+        if rapidapi_key:
+            headers["X-RapidAPI-Key"] = rapidapi_key
+        if rapidapi_host:
+            headers["X-RapidAPI-Host"] = rapidapi_host
+    else:
+        url = POKEMONTCG_API_URL
+        if POKEMONTCG_API_KEY:
+            headers["X-Api-Key"] = POKEMONTCG_API_KEY
 
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
@@ -398,11 +419,19 @@ def list_set_cards(
         return [], 0
 
     http = session or requests
-    api_key = rapidapi_key if rapidapi_key is not None else POKEMONTCG_API_KEY
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    if api_key:
-        headers["X-Api-Key"] = api_key
+    use_rapidapi = bool(rapidapi_key or rapidapi_host)
+    if use_rapidapi:
+        url = _build_cards_endpoint(rapidapi_host)
+        if rapidapi_key:
+            headers["X-RapidAPI-Key"] = rapidapi_key
+        if rapidapi_host:
+            headers["X-RapidAPI-Host"] = rapidapi_host
+    else:
+        url = POKEMONTCG_API_URL
+        if POKEMONTCG_API_KEY:
+            headers["X-Api-Key"] = POKEMONTCG_API_KEY
 
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
@@ -436,7 +465,7 @@ def list_set_cards(
         }
         try:
             response = http.get(
-                POKEMONTCG_API_URL,
+                url,
                 params=params,
                 headers=headers,
                 timeout=timeout,

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -1,0 +1,75 @@
+"""Tests for Pokémon TCG API helper utilities."""
+
+from __future__ import annotations
+
+from kartoteka_web.services import tcg_api
+
+
+class _DummySession:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.headers = {"User-Agent": "pytest-agent"}
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers or {},
+                "timeout": timeout,
+            }
+        )
+
+        class _Response:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"data": []}
+
+        return _Response()
+
+
+def test_search_cards_uses_rapidapi_headers(monkeypatch):
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
+
+    session = _DummySession()
+    tcg_api.search_cards(
+        name="Pikachu",
+        rapidapi_key="rapid-key",
+        rapidapi_host="pokemon-tcg.p.rapidapi.com",
+        session=session,
+    )
+
+    assert session.calls, "Expected a single HTTP request"
+    call = session.calls[0]
+    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    headers = call["headers"]
+    assert headers.get("X-RapidAPI-Key") == "rapid-key"
+    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert "X-Api-Key" not in headers
+
+
+def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
+
+    session = _DummySession()
+    cards, request_count = tcg_api.list_set_cards(
+        "base",
+        limit=1,
+        rapidapi_key="rapid-key",
+        rapidapi_host="pokemon-tcg.p.rapidapi.com",
+        session=session,
+    )
+
+    assert cards == []
+    assert request_count == 1
+    assert session.calls, "Expected at least one HTTP request"
+    call = session.calls[0]
+    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    headers = call["headers"]
+    assert headers.get("X-RapidAPI-Key") == "rapid-key"
+    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert "X-Api-Key" not in headers


### PR DESCRIPTION
## Summary
- add RapidAPI header handling and endpoint resolution for card search and listing helpers
- retain original API key usage when RapidAPI credentials are not supplied
- cover RapidAPI scenarios with dedicated unit tests for card search and set listing

## Testing
- pytest tests/test_tcg_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf70b9734832f9b2eaf38a27b9502