### PR TITLE
Ensure RapidAPI host header always sent

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -252,11 +252,11 @@ def search_cards(
     _apply_default_user_agent(headers, session)
     use_rapidapi = bool(rapidapi_key or rapidapi_host)
     if use_rapidapi:
-        url = _build_cards_endpoint(rapidapi_host)
+        api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+        url = _build_cards_endpoint(api_host)
         if rapidapi_key:
             headers["X-RapidAPI-Key"] = rapidapi_key
-        if rapidapi_host:
-            headers["X-RapidAPI-Host"] = rapidapi_host
+        headers["X-RapidAPI-Host"] = api_host
     else:
         url = POKEMONTCG_API_URL
         if POKEMONTCG_API_KEY:
@@ -423,11 +423,11 @@ def list_set_cards(
     _apply_default_user_agent(headers, session)
     use_rapidapi = bool(rapidapi_key or rapidapi_host)
     if use_rapidapi:
-        url = _build_cards_endpoint(rapidapi_host)
+        api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+        url = _build_cards_endpoint(api_host)
         if rapidapi_key:
             headers["X-RapidAPI-Key"] = rapidapi_key
-        if rapidapi_host:
-            headers["X-RapidAPI-Host"] = rapidapi_host
+        headers["X-RapidAPI-Host"] = api_host
     else:
         url = POKEMONTCG_API_URL
         if POKEMONTCG_API_KEY:

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -51,6 +51,27 @@ def test_search_cards_uses_rapidapi_headers(monkeypatch):
     assert "X-Api-Key" not in headers
 
 
+def test_search_cards_uses_default_host_when_missing(monkeypatch):
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
+
+    session = _DummySession()
+    tcg_api.search_cards(
+        name="Eevee",
+        rapidapi_key="rapid-key",
+        rapidapi_host=None,
+        session=session,
+    )
+
+    assert session.calls, "Expected a single HTTP request"
+    call = session.calls[0]
+    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    headers = call["headers"]
+    assert headers.get("X-RapidAPI-Key") == "rapid-key"
+    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert "X-Api-Key" not in headers
+
+
 def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
     monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
     monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")


### PR DESCRIPTION
## Summary
- ensure RapidAPI requests default to the official host when none is provided
- always include the RapidAPI host header for search and set card listings
- add coverage confirming the default host header is sent with only an API key

## Testing
- pytest tests/test_tcg_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfa749df0832f902daa95b8753085