### PR TITLE
Propagate RapidAPI credentials in card search

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Any, Iterable
 
@@ -18,6 +19,9 @@ from ..utils import images as image_utils, text
 router = APIRouter(prefix="/cards", tags=["cards"])
 
 MAX_SEARCH_RESULTS = 200
+
+RAPIDAPI_KEY = os.getenv("KARTOTEKA_RAPIDAPI_KEY") or os.getenv("POKEMONTCG_RAPIDAPI_KEY")
+RAPIDAPI_HOST = os.getenv("KARTOTEKA_RAPIDAPI_HOST") or os.getenv("POKEMONTCG_RAPIDAPI_HOST")
 
 CARD_NUMBER_PATTERN = re.compile(
     r"(?i)([a-z]{0,5}\d+[a-z0-9]*)(?:\s*/\s*([a-z]{0,5}\d+[a-z0-9]*))?"
@@ -329,6 +333,8 @@ def search_cards_endpoint(
         set_name=set_name,
         total=total,
         limit=result_cap,
+        rapidapi_key=RAPIDAPI_KEY,
+        rapidapi_host=RAPIDAPI_HOST,
     )
 
     items = [_payload_to_search_schema(record) for record in records]

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlmodel import select
 
 from kartoteka_web import database, models
+from kartoteka_web.routes import cards as cards_routes
 
 
 def _auth_headers(client, username: str = "ash", password: str = "pikachu") -> dict[str, str]:
@@ -131,7 +132,16 @@ def test_card_search_and_detail(api_client, monkeypatch):
 
     captured: dict[str, object] = {}
 
-    def fake_search_cards(*, name, number=None, set_name=None, total=None, limit):
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
         captured.update(
             {
                 "name": name,
@@ -139,6 +149,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "set_name": set_name,
                 "total": total,
                 "limit": limit,
+                "rapidapi_key": rapidapi_key,
+                "rapidapi_host": rapidapi_host,
             }
         )
         return search_results
@@ -215,3 +227,47 @@ def test_card_search_and_detail(api_client, monkeypatch):
 
     unauthenticated_search = api_client.get("/cards/search", params={"query": "Eevee"})
     assert unauthenticated_search.status_code == 401
+
+
+def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
+    headers = _auth_headers(api_client, username="misty", password="starmie")
+
+    captured: dict[str, object] = {}
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        captured.update(
+            {
+                "name": name,
+                "number": number,
+                "set_name": set_name,
+                "total": total,
+                "limit": limit,
+                "rapidapi_key": rapidapi_key,
+                "rapidapi_host": rapidapi_host,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+    monkeypatch.setattr(cards_routes, "RAPIDAPI_KEY", "rapid-key")
+    monkeypatch.setattr(cards_routes, "RAPIDAPI_HOST", "rapid.example.com")
+
+    response = api_client.get(
+        "/cards/search",
+        params={"query": "Starmie"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["rapidapi_key"] == "rapid-key"
+    assert captured["rapidapi_host"] == "rapid.example.com"
+    assert captured["name"].startswith("Starmie")


### PR DESCRIPTION
## Summary
- load optional RapidAPI key and host for the card routes module
- forward the credentials to the tcg_api search helper
- add an API test that asserts the endpoint provides configured RapidAPI credentials

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfdfc47fc832fb520375366fb51ec