### PR TITLE
Adjust TCG API queries for RapidAPI compatibility

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -265,6 +265,18 @@ def search_cards(
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
 
+    def _map_query_field(field: str) -> str:
+        if not use_rapidapi:
+            return field
+        mapping = {
+            "set.id": "setId",
+            "set.ptcgoCode": "setPtcgoCode",
+            "set.name": "setName",
+            "set.total": "setTotal",
+            "set.printedTotal": "setPrintedTotal",
+        }
+        return mapping.get(field, field.replace(".", ""))
+
     query_parts: list[str] = []
     if name_api:
         query_parts.append(f'name:"*{_escape_query(name_api)}*"')
@@ -274,21 +286,37 @@ def search_cards(
         set_query = text.normalize(set_name, keep_spaces=True)
         if set_query:
             escaped = _escape_query(set_query)
+            set_fields = (
+                _map_query_field("set.id"),
+                _map_query_field("set.ptcgoCode"),
+                _map_query_field("set.name"),
+            )
             query_parts.append(
                 "(" +
                 " OR ".join(
                     (
-                        f'set.id:"{escaped}"',
-                        f'set.ptcgoCode:"{escaped}"',
-                        f'set.name:"*{escaped}*"',
+                        f'{set_fields[0]}:"{escaped}"',
+                        f'{set_fields[1]}:"{escaped}"',
+                        f'{set_fields[2]}:"*{escaped}*"',
                     )
                 ) +
                 ")"
             )
     if total_clean:
         escaped_total = _escape_query(total_clean)
+        total_fields = (
+            _map_query_field("set.total"),
+            _map_query_field("set.printedTotal"),
+        )
         query_parts.append(
-            f"(set.total:{escaped_total} OR set.printedTotal:{escaped_total})"
+            "("
+            + " OR ".join(
+                (
+                    f"{total_fields[0]}:{escaped_total}",
+                    f"{total_fields[1]}:{escaped_total}",
+                )
+            )
+            + ")"
         )
 
     if not query_parts:
@@ -297,7 +325,7 @@ def search_cards(
     page_size = max(limit * 5, 50)
     page_size = min(page_size, 250)
     params = {
-        "q": " and ".join(query_parts),
+        ("search" if use_rapidapi else "q"): " and ".join(query_parts),
         "page": "1",
         "pageSize": str(page_size),
     }
@@ -439,16 +467,26 @@ def list_set_cards(
     set_value = set_code.strip()
     normalized = text.normalize(set_code, keep_spaces=True)
     escaped_value = _escape_query(set_value)
+    def _map_query_field(field: str) -> str:
+        if not use_rapidapi:
+            return field
+        mapping = {
+            "set.id": "setId",
+            "set.ptcgoCode": "setPtcgoCode",
+            "set.name": "setName",
+        }
+        return mapping.get(field, field.replace(".", ""))
+
     set_filters = {
-        f'set.id:"{escaped_value}"',
-        f'set.ptcgoCode:"{escaped_value}"',
-        f'set.name:"*{escaped_value}*"',
+        f'{_map_query_field("set.id")}:"{escaped_value}"',
+        f'{_map_query_field("set.ptcgoCode")}:"{escaped_value}"',
+        f'{_map_query_field("set.name")}:"*{escaped_value}*"',
     }
     if normalized and normalized != set_value:
         escaped_normalized = _escape_query(normalized)
-        set_filters.add(f'set.id:"{escaped_normalized}"')
-        set_filters.add(f'set.ptcgoCode:"{escaped_normalized}"')
-        set_filters.add(f'set.name:"*{escaped_normalized}*"')
+        set_filters.add(f'{_map_query_field("set.id")}:"{escaped_normalized}"')
+        set_filters.add(f'{_map_query_field("set.ptcgoCode")}:"{escaped_normalized}"')
+        set_filters.add(f'{_map_query_field("set.name")}:"*{escaped_normalized}*"')
 
     query = "(" + " OR ".join(sorted(set_filters)) + ")"
     page = 1
@@ -459,7 +497,7 @@ def list_set_cards(
 
     while True:
         params = {
-            "q": query,
+            ("search" if use_rapidapi else "q"): query,
             "page": str(page),
             "pageSize": str(page_size),
         }

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -49,6 +49,10 @@ def test_search_cards_uses_rapidapi_headers(monkeypatch):
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
     assert "X-Api-Key" not in headers
+    params = call["params"] or {}
+    assert "search" in params
+    assert "q" not in params
+    assert 'name:"*pikachu*"' in params["search"]
 
 
 def test_search_cards_uses_default_host_when_missing(monkeypatch):
@@ -70,6 +74,9 @@ def test_search_cards_uses_default_host_when_missing(monkeypatch):
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
     assert "X-Api-Key" not in headers
+    params = call["params"] or {}
+    assert "search" in params
+    assert "q" not in params
 
 
 def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
@@ -94,3 +101,54 @@ def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
     assert "X-Api-Key" not in headers
+    params = call["params"] or {}
+    assert "search" in params
+    assert "q" not in params
+    query = params["search"]
+    assert 'setId:"base"' in query
+    assert 'setPtcgoCode:"base"' in query
+    assert 'setName:"*base*"' in query
+
+
+def test_search_cards_uses_official_query_params(monkeypatch):
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
+
+    session = _DummySession()
+    tcg_api.search_cards(
+        name="Pikachu",
+        set_name="Base",
+        total="102/102",
+        session=session,
+    )
+
+    assert session.calls, "Expected a single HTTP request"
+    call = session.calls[0]
+    params = call["params"] or {}
+    assert "q" in params
+    assert "search" not in params
+    query = params["q"]
+    assert 'name:"*pikachu*"' in query
+    assert 'set.id:"base"' in query
+    assert 'set.ptcgoCode:"base"' in query
+    assert 'set.name:"*base*"' in query
+    assert "set.total:102" in query
+    assert "set.printedTotal:102" in query
+
+
+def test_list_set_cards_uses_official_query_params(monkeypatch):
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
+    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
+
+    session = _DummySession()
+    tcg_api.list_set_cards("base", limit=1, session=session)
+
+    assert session.calls, "Expected at least one HTTP request"
+    call = session.calls[0]
+    params = call["params"] or {}
+    assert "q" in params
+    assert "search" not in params
+    query = params["q"]
+    assert 'set.id:"base"' in query
+    assert 'set.ptcgoCode:"base"' in query
+    assert 'set.name:"*base*"' in query


### PR DESCRIPTION
## Summary
- switch RapidAPI requests to use the `search` query parameter and translate set-related filters
- keep official API requests on the `q` parameter while updating helper logic to map field names per backend
- add regression tests that verify query construction for both RapidAPI and official API flows

## Testing
- pytest tests/test_tcg_api.py


------
https://chatgpt.com/codex/tasks/task_e_68dd00687ae4832f9d251d397cf9cd5f