### PR TITLE
Adjust RapidAPI search query format

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -265,67 +265,72 @@ def search_cards(
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
 
-    def _map_query_field(field: str) -> str:
-        if not use_rapidapi:
-            return field
-        mapping = {
-            "set.id": "setId",
-            "set.ptcgoCode": "setPtcgoCode",
-            "set.name": "setName",
-            "set.total": "setTotal",
-            "set.printedTotal": "setPrintedTotal",
-        }
-        return mapping.get(field, field.replace(".", ""))
-
-    query_parts: list[str] = []
-    if name_api:
-        query_parts.append(f'name:"*{_escape_query(name_api)}*"')
-    if number_clean:
-        query_parts.append(f'number:"{_escape_query(number_clean)}"')
-    if set_name:
-        set_query = text.normalize(set_name, keep_spaces=True)
-        if set_query:
-            escaped = _escape_query(set_query)
-            set_fields = (
-                _map_query_field("set.id"),
-                _map_query_field("set.ptcgoCode"),
-                _map_query_field("set.name"),
+    if use_rapidapi:
+        rapid_search_parts: list[str] = []
+        if name_api:
+            rapid_search_parts.append(name_api)
+        if number_clean:
+            rapid_search_parts.append(number_clean)
+        if set_name:
+            set_query = text.normalize(set_name, keep_spaces=True)
+            if set_query:
+                rapid_search_parts.append(set_query)
+        if total_clean:
+            rapid_search_parts.append(total_clean)
+        query_value = " ".join(part for part in rapid_search_parts if part)
+        if not query_value:
+            return []
+    else:
+        query_parts: list[str] = []
+        if name_api:
+            query_parts.append(f'name:"*{_escape_query(name_api)}*"')
+        if number_clean:
+            query_parts.append(f'number:"{_escape_query(number_clean)}"')
+        if set_name:
+            set_query = text.normalize(set_name, keep_spaces=True)
+            if set_query:
+                escaped = _escape_query(set_query)
+                set_fields = (
+                    "set.id",
+                    "set.ptcgoCode",
+                    "set.name",
+                )
+                query_parts.append(
+                    "(" +
+                    " OR ".join(
+                        (
+                            f'{set_fields[0]}:"{escaped}"',
+                            f'{set_fields[1]}:"{escaped}"',
+                            f'{set_fields[2]}:"*{escaped}*"',
+                        )
+                    ) +
+                    ")"
+                )
+        if total_clean:
+            escaped_total = _escape_query(total_clean)
+            total_fields = (
+                "set.total",
+                "set.printedTotal",
             )
             query_parts.append(
-                "(" +
-                " OR ".join(
+                "(" 
+                + " OR ".join(
                     (
-                        f'{set_fields[0]}:"{escaped}"',
-                        f'{set_fields[1]}:"{escaped}"',
-                        f'{set_fields[2]}:"*{escaped}*"',
+                        f"{total_fields[0]}:{escaped_total}",
+                        f"{total_fields[1]}:{escaped_total}",
                     )
-                ) +
-                ")"
-            )
-    if total_clean:
-        escaped_total = _escape_query(total_clean)
-        total_fields = (
-            _map_query_field("set.total"),
-            _map_query_field("set.printedTotal"),
-        )
-        query_parts.append(
-            "("
-            + " OR ".join(
-                (
-                    f"{total_fields[0]}:{escaped_total}",
-                    f"{total_fields[1]}:{escaped_total}",
                 )
+                + ")"
             )
-            + ")"
-        )
 
-    if not query_parts:
-        return []
+        if not query_parts:
+            return []
+        query_value = " and ".join(query_parts)
 
     page_size = max(limit * 5, 50)
     page_size = min(page_size, 250)
     params = {
-        ("search" if use_rapidapi else "q"): " and ".join(query_parts),
+        ("search" if use_rapidapi else "q"): query_value,
         "page": "1",
         "pageSize": str(page_size),
     }

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -52,7 +52,7 @@ def test_search_cards_uses_rapidapi_headers(monkeypatch):
     params = call["params"] or {}
     assert "search" in params
     assert "q" not in params
-    assert 'name:"*pikachu*"' in params["search"]
+    assert params["search"] == "pikachu"
 
 
 def test_search_cards_uses_default_host_when_missing(monkeypatch):
@@ -77,6 +77,7 @@ def test_search_cards_uses_default_host_when_missing(monkeypatch):
     params = call["params"] or {}
     assert "search" in params
     assert "q" not in params
+    assert params["search"] == "eevee"
 
 
 def test_list_set_cards_uses_rapidapi_headers(monkeypatch):


### PR DESCRIPTION
## Summary
- switch RapidAPI search query generation to a normalized plain-text string while keeping the official API DSL intact
- ensure RapidAPI requests pass the rebuilt string to the `search` parameter and drop unused field mappings
- update unit tests to cover the new RapidAPI query format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd06694bfc832faa7ff718ce492bd9