### PR TITLE
Remove PokémonTCG official API fallback from RapidAPI client

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -1,9 +1,8 @@
-"""Minimal Pokémon TCG API helpers for catalogue operations."""
+"""Minimal RapidAPI Pokémon TCG helpers for catalogue operations."""
 
 from __future__ import annotations
 
 import logging
-import os
 from difflib import SequenceMatcher
 from typing import Any, Optional
 from urllib.parse import urlparse
@@ -14,8 +13,6 @@ from ..utils import text
 
 logger = logging.getLogger(__name__)
 
-POKEMONTCG_API_URL = os.getenv("POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-POKEMONTCG_API_KEY = os.getenv("POKEMONTCG_API_KEY")
 RAPIDAPI_DEFAULT_HOST = "pokemon-tcg.p.rapidapi.com"
 
 
@@ -90,15 +87,12 @@ def _extract_images(card: dict[str, Any]) -> tuple[Optional[str], Optional[str]]
 
 
 def _build_cards_endpoint(rapidapi_host: Optional[str]) -> str:
-    """Return an absolute API endpoint for the Pokémon TCG cards resource."""
+    """Return an absolute RapidAPI endpoint for the cards resource."""
 
-    parsed = urlparse(POKEMONTCG_API_URL)
     host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-    path = parsed.path or "/v2/cards"
-    if not path.startswith("/"):
-        path = "/" + path
-    query = f"?{parsed.query}" if parsed.query else ""
-    return f"https://{host}{path}{query}"
+    parsed = urlparse(f"https://{host}")
+    path = "/v2/cards"
+    return f"https://{parsed.netloc or host}{path}"
 
 
 def _normalize_text_field(value: Any) -> Optional[str]:
@@ -250,87 +244,31 @@ def search_cards(
     name_api = text.normalize(name, keep_spaces=True)
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    use_rapidapi = bool(rapidapi_key or rapidapi_host)
-    if use_rapidapi:
-        api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-        url = _build_cards_endpoint(api_host)
-        if rapidapi_key:
-            headers["X-RapidAPI-Key"] = rapidapi_key
-        headers["X-RapidAPI-Host"] = api_host
-    else:
-        url = POKEMONTCG_API_URL
-        if POKEMONTCG_API_KEY:
-            headers["X-Api-Key"] = POKEMONTCG_API_KEY
+    api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+    url = _build_cards_endpoint(api_host)
+    if rapidapi_key:
+        headers["X-RapidAPI-Key"] = rapidapi_key
+    headers["X-RapidAPI-Host"] = api_host
 
-    def _escape_query(value: str) -> str:
-        return value.replace("\\", "\\\\").replace('"', r"\"")
-
-    if use_rapidapi:
-        rapid_search_parts: list[str] = []
-        if name_api:
-            rapid_search_parts.append(name_api)
-        if number_clean:
-            rapid_search_parts.append(number_clean)
-        if set_name:
-            set_query = text.normalize(set_name, keep_spaces=True)
-            if set_query:
-                rapid_search_parts.append(set_query)
-        if total_clean:
-            rapid_search_parts.append(total_clean)
-        query_value = " ".join(part for part in rapid_search_parts if part)
-        if not query_value:
-            return []
-    else:
-        query_parts: list[str] = []
-        if name_api:
-            query_parts.append(f'name:"*{_escape_query(name_api)}*"')
-        if number_clean:
-            query_parts.append(f'number:"{_escape_query(number_clean)}"')
-        if set_name:
-            set_query = text.normalize(set_name, keep_spaces=True)
-            if set_query:
-                escaped = _escape_query(set_query)
-                set_fields = (
-                    "set.id",
-                    "set.ptcgoCode",
-                    "set.name",
-                )
-                query_parts.append(
-                    "(" +
-                    " OR ".join(
-                        (
-                            f'{set_fields[0]}:"{escaped}"',
-                            f'{set_fields[1]}:"{escaped}"',
-                            f'{set_fields[2]}:"*{escaped}*"',
-                        )
-                    ) +
-                    ")"
-                )
-        if total_clean:
-            escaped_total = _escape_query(total_clean)
-            total_fields = (
-                "set.total",
-                "set.printedTotal",
-            )
-            query_parts.append(
-                "(" 
-                + " OR ".join(
-                    (
-                        f"{total_fields[0]}:{escaped_total}",
-                        f"{total_fields[1]}:{escaped_total}",
-                    )
-                )
-                + ")"
-            )
-
-        if not query_parts:
-            return []
-        query_value = " and ".join(query_parts)
+    rapid_search_parts: list[str] = []
+    if name_api:
+        rapid_search_parts.append(name_api)
+    if number_clean:
+        rapid_search_parts.append(number_clean)
+    if set_name:
+        set_query = text.normalize(set_name, keep_spaces=True)
+        if set_query:
+            rapid_search_parts.append(set_query)
+    if total_clean:
+        rapid_search_parts.append(total_clean)
+    query_value = " ".join(part for part in rapid_search_parts if part)
+    if not query_value:
+        return []
 
     page_size = max(limit * 5, 50)
     page_size = min(page_size, 250)
     params = {
-        ("search" if use_rapidapi else "q"): query_value,
+        "search": query_value,
         "page": "1",
         "pageSize": str(page_size),
     }
@@ -345,7 +283,7 @@ def search_cards(
         logger.warning("Request timed out")
         return []
     except (requests.RequestException, ValueError) as exc:  # pragma: no cover
-        logger.warning("Fetching cards from the Pokémon TCG API failed: %s", exc)
+        logger.warning("Fetching cards from RapidAPI failed: %s", exc)
         return []
 
     if isinstance(cards, dict):
@@ -454,17 +392,11 @@ def list_set_cards(
     http = session or requests
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    use_rapidapi = bool(rapidapi_key or rapidapi_host)
-    if use_rapidapi:
-        api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-        url = _build_cards_endpoint(api_host)
-        if rapidapi_key:
-            headers["X-RapidAPI-Key"] = rapidapi_key
-        headers["X-RapidAPI-Host"] = api_host
-    else:
-        url = POKEMONTCG_API_URL
-        if POKEMONTCG_API_KEY:
-            headers["X-Api-Key"] = POKEMONTCG_API_KEY
+    api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+    url = _build_cards_endpoint(api_host)
+    if rapidapi_key:
+        headers["X-RapidAPI-Key"] = rapidapi_key
+    headers["X-RapidAPI-Host"] = api_host
 
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
@@ -473,8 +405,6 @@ def list_set_cards(
     normalized = text.normalize(set_code, keep_spaces=True)
     escaped_value = _escape_query(set_value)
     def _map_query_field(field: str) -> str:
-        if not use_rapidapi:
-            return field
         mapping = {
             "set.id": "setId",
             "set.ptcgoCode": "setPtcgoCode",
@@ -502,7 +432,7 @@ def list_set_cards(
 
     while True:
         params = {
-            ("search" if use_rapidapi else "q"): query,
+            "search": query,
             "page": str(page),
             "pageSize": str(page_size),
         }

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -1,4 +1,4 @@
-"""Tests for Pokémon TCG API helper utilities."""
+"""Tests for RapidAPI Pokémon TCG helper utilities."""
 
 from __future__ import annotations
 
@@ -30,10 +30,7 @@ class _DummySession:
         return _Response()
 
 
-def test_search_cards_uses_rapidapi_headers(monkeypatch):
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
-
+def test_search_cards_uses_rapidapi_headers():
     session = _DummySession()
     tcg_api.search_cards(
         name="Pikachu",
@@ -48,17 +45,12 @@ def test_search_cards_uses_rapidapi_headers(monkeypatch):
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
-    assert "X-Api-Key" not in headers
     params = call["params"] or {}
     assert "search" in params
-    assert "q" not in params
     assert params["search"] == "pikachu"
 
 
-def test_search_cards_uses_default_host_when_missing(monkeypatch):
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
-
+def test_search_cards_uses_default_host_when_missing():
     session = _DummySession()
     tcg_api.search_cards(
         name="Eevee",
@@ -73,17 +65,12 @@ def test_search_cards_uses_default_host_when_missing(monkeypatch):
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
-    assert "X-Api-Key" not in headers
     params = call["params"] or {}
     assert "search" in params
-    assert "q" not in params
     assert params["search"] == "eevee"
 
 
-def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
-
+def test_list_set_cards_uses_rapidapi_headers():
     session = _DummySession()
     cards, request_count = tcg_api.list_set_cards(
         "base",
@@ -101,20 +88,15 @@ def test_list_set_cards_uses_rapidapi_headers(monkeypatch):
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
-    assert "X-Api-Key" not in headers
     params = call["params"] or {}
     assert "search" in params
-    assert "q" not in params
     query = params["search"]
     assert 'setId:"base"' in query
     assert 'setPtcgoCode:"base"' in query
     assert 'setName:"*base*"' in query
 
 
-def test_search_cards_uses_official_query_params(monkeypatch):
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
-
+def test_search_cards_builds_compound_query():
     session = _DummySession()
     tcg_api.search_cards(
         name="Pikachu",
@@ -126,30 +108,20 @@ def test_search_cards_uses_official_query_params(monkeypatch):
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     params = call["params"] or {}
-    assert "q" in params
-    assert "search" not in params
-    query = params["q"]
-    assert 'name:"*pikachu*"' in query
-    assert 'set.id:"base"' in query
-    assert 'set.ptcgoCode:"base"' in query
-    assert 'set.name:"*base*"' in query
-    assert "set.total:102" in query
-    assert "set.printedTotal:102" in query
+    assert params["search"] == "pikachu base 102"
 
 
-def test_list_set_cards_uses_official_query_params(monkeypatch):
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_URL", "https://api.pokemontcg.io/v2/cards")
-    monkeypatch.setattr(tcg_api, "POKEMONTCG_API_KEY", "official-key")
-
+def test_list_set_cards_without_key_uses_default_headers():
     session = _DummySession()
     tcg_api.list_set_cards("base", limit=1, session=session)
 
     assert session.calls, "Expected at least one HTTP request"
     call = session.calls[0]
+    headers = call["headers"]
+    assert "X-RapidAPI-Key" not in headers
+    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
     params = call["params"] or {}
-    assert "q" in params
-    assert "search" not in params
-    query = params["q"]
-    assert 'set.id:"base"' in query
-    assert 'set.ptcgoCode:"base"' in query
-    assert 'set.name:"*base*"' in query
+    query = params["search"]
+    assert 'setId:"base"' in query
+    assert 'setPtcgoCode:"base"' in query
+    assert 'setName:"*base*"' in query


### PR DESCRIPTION
## Summary
- remove the legacy PokémonTCG API constants and rely exclusively on RapidAPI hosts
- simplify endpoint construction, search parameters, and logging for the RapidAPI flow
- update tcg API helper tests to cover the RapidAPI-only behaviour

## Testing
- pytest tests/test_tcg_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0c931d1c832f82f63d42173036c6