### PR TITLE
Support generic RapidAPI env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
+# Legacy variable names (also supported):
+# KARTOTEKA_RAPIDAPI_KEY / KARTOTEKA_RAPIDAPI_HOST or
+# POKEMONTCG_RAPIDAPI_KEY / POKEMONTCG_RAPIDAPI_HOST
 # Keep the official Pokémon TCG API key outside of version control (.env only)
 POKEMONTCG_API_KEY=
 SHOPER_API_URL=https://your-store.shop/webapi/rest

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -20,8 +20,16 @@ router = APIRouter(prefix="/cards", tags=["cards"])
 
 MAX_SEARCH_RESULTS = 200
 
-RAPIDAPI_KEY = os.getenv("KARTOTEKA_RAPIDAPI_KEY") or os.getenv("POKEMONTCG_RAPIDAPI_KEY")
-RAPIDAPI_HOST = os.getenv("KARTOTEKA_RAPIDAPI_HOST") or os.getenv("POKEMONTCG_RAPIDAPI_HOST")
+RAPIDAPI_KEY = (
+    os.getenv("KARTOTEKA_RAPIDAPI_KEY")
+    or os.getenv("POKEMONTCG_RAPIDAPI_KEY")
+    or os.getenv("RAPIDAPI_KEY")
+)
+RAPIDAPI_HOST = (
+    os.getenv("KARTOTEKA_RAPIDAPI_HOST")
+    or os.getenv("POKEMONTCG_RAPIDAPI_HOST")
+    or os.getenv("RAPIDAPI_HOST")
+)
 
 CARD_NUMBER_PATTERN = re.compile(
     r"(?i)([a-z]{0,5}\d+[a-z0-9]*)(?:\s*/\s*([a-z]{0,5}\d+[a-z0-9]*))?"

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 from sqlmodel import select
 
 from kartoteka_web import database, models
@@ -271,3 +273,58 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
     assert captured["rapidapi_key"] == "rapid-key"
     assert captured["rapidapi_host"] == "rapid.example.com"
     assert captured["name"].startswith("Starmie")
+
+
+def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
+    for variable in (
+        "KARTOTEKA_RAPIDAPI_KEY",
+        "POKEMONTCG_RAPIDAPI_KEY",
+        "KARTOTEKA_RAPIDAPI_HOST",
+        "POKEMONTCG_RAPIDAPI_HOST",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+    monkeypatch.setenv("RAPIDAPI_KEY", "generic-rapid-key")
+    monkeypatch.setenv("RAPIDAPI_HOST", "generic-rapid.example.com")
+
+    reloaded_cards = importlib.reload(cards_routes)
+
+    captured: dict[str, object] = {}
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        captured.update(
+            {
+                "name": name,
+                "number": number,
+                "set_name": set_name,
+                "total": total,
+                "limit": limit,
+                "rapidapi_key": rapidapi_key,
+                "rapidapi_host": rapidapi_host,
+            }
+        )
+        return []
+
+    monkeypatch.setattr(reloaded_cards.tcg_api, "search_cards", fake_search_cards)
+
+    dummy_user = models.User(id=1, username="misty", hashed_password="hashed:pw")
+
+    response = reloaded_cards.search_cards_endpoint(
+        query="Eevee",
+        limit=5,
+        current_user=dummy_user,
+        session=None,
+    )
+
+    assert response.total == 0
+    assert captured["rapidapi_key"] == "generic-rapid-key"
+    assert captured["rapidapi_host"] == "generic-rapid.example.com"


### PR DESCRIPTION
## Summary
- allow the cards routes to fall back to generic RAPIDAPI_KEY and RAPIDAPI_HOST variables
- document that both the legacy and generic RapidAPI variable names are accepted
- add a regression test covering the new fallback behaviour

## Testing
- pytest tests/api/test_cards.py::test_cards_module_uses_generic_rapidapi_env

------
https://chatgpt.com/codex/tasks/task_e_68dd18d189a0832f96b93c74f4fd6d78