### PR TITLE
Normalize RapidAPI collector number comparisons

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -152,7 +152,7 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
     )
 
     card_number_part, card_total_from_number = _split_number_total(raw_number)
-    card_number_clean = text.sanitize_number(card_number_part.lower())
+    card_number_clean = text.sanitize_number(card_number_part.casefold())
     if not card_number_clean:
         return None
     card_total_clean = text.sanitize_number(card_total_from_number or raw_total)
@@ -238,7 +238,10 @@ def search_cards(
     if total:
         _, forced_total = _split_number_total(str(total))
         number_total = forced_total or number_total
-    number_clean = text.sanitize_number(number_part) if number_part else ""
+    number_part_normalized = number_part.casefold() if number_part else ""
+    number_clean = (
+        text.sanitize_number(number_part_normalized) if number_part_normalized else ""
+    )
     total_clean = text.sanitize_number(number_total) if number_total else ""
 
     name_api = text.normalize(name, keep_spaces=True)

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -6,9 +6,15 @@ from kartoteka_web.services import tcg_api
 
 
 class _DummySession:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        response_data: dict[str, object] | None = None,
+        status_code: int = 200,
+    ) -> None:
         self.calls: list[dict[str, object]] = []
         self.headers = {"User-Agent": "pytest-agent"}
+        self._response_data = response_data or {"data": []}
+        self._status_code = status_code
 
     def get(self, url, params=None, headers=None, timeout=None):
         self.calls.append(
@@ -21,13 +27,14 @@ class _DummySession:
         )
 
         class _Response:
-            status_code = 200
+            def __init__(self, data: dict[str, object], status_code: int) -> None:
+                self._data = data
+                self.status_code = status_code
 
-            @staticmethod
-            def json():
-                return {"data": []}
+            def json(self):
+                return self._data
 
-        return _Response()
+        return _Response(self._response_data, self._status_code)
 
 
 def test_search_cards_uses_rapidapi_headers():
@@ -122,6 +129,24 @@ def test_search_cards_builds_compound_query():
     call = session.calls[0]
     params = call["params"] or {}
     assert params["search"] == "pikachu base 102"
+
+
+def test_search_cards_matches_uppercase_collector_number():
+    card_payload = {
+        "name": "Pikachu",
+        "number": "RC5a",
+        "set": {"name": "Radiant Collection"},
+    }
+    session = _DummySession(response_data={"data": [card_payload]})
+
+    results = tcg_api.search_cards(
+        name="Pikachu",
+        number="RC5A",
+        session=session,
+    )
+
+    assert results, "Expected to receive at least one suggestion"
+    assert results[0]["number"] == "rc5a"
 
 
 def test_list_set_cards_without_key_uses_default_headers():


### PR DESCRIPTION
## Summary
- normalise collector numbers from RapidAPI payloads with casefold and apply the same to query numbers before comparison
- ensure the cleaned collector number is propagated in card payloads and reuse it in search queries
- extend the RapidAPI test session helper to allow canned responses and cover uppercase collector number lookups

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd1f4777b8832fb9e981a0dad69bc1