### PR TITLE
Update RapidAPI Pokémon TCG endpoints and add price history helper

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -13,7 +13,16 @@ from ..utils import text
 
 logger = logging.getLogger(__name__)
 
-RAPIDAPI_DEFAULT_HOST = "pokemon-tcg.p.rapidapi.com"
+RAPIDAPI_DEFAULT_HOST = "pokemon-tcg-api.p.rapidapi.com"
+
+
+def _normalize_host(rapidapi_host: Optional[str]) -> tuple[str, str]:
+    host_value = rapidapi_host or RAPIDAPI_DEFAULT_HOST
+    if "://" not in host_value:
+        return host_value, host_value
+    parsed = urlparse(host_value)
+    netloc = parsed.netloc or parsed.path
+    return host_value, netloc or host_value
 
 
 def _apply_default_user_agent(
@@ -86,13 +95,28 @@ def _extract_images(card: dict[str, Any]) -> tuple[Optional[str], Optional[str]]
     return image_small, image_large
 
 
-def _build_cards_endpoint(rapidapi_host: Optional[str]) -> str:
-    """Return an absolute RapidAPI endpoint for the cards resource."""
+def _build_cards_endpoint(
+    rapidapi_host: Optional[str], *path_parts: str
+) -> str:
+    """Return an absolute RapidAPI endpoint for the given cards resource path."""
 
     host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-    parsed = urlparse(f"https://{host}")
-    path = "/v2/cards"
-    return f"https://{parsed.netloc or host}{path}"
+    if "://" not in host:
+        host = f"https://{host}"
+    parsed = urlparse(host)
+    scheme = parsed.scheme or "https"
+    netloc = parsed.netloc or parsed.path
+    base_path = parsed.path.rstrip("/")
+    extra_path = "/".join(part.strip("/") for part in path_parts if part)
+    if base_path:
+        if extra_path:
+            path = f"{base_path.strip('/')}/{extra_path}"
+        else:
+            path = base_path.strip("/")
+    else:
+        path = extra_path
+    path = path.strip("/")
+    return f"{scheme}://{netloc}/{path}" if path else f"{scheme}://{netloc}"
 
 
 def _normalize_text_field(value: Any) -> Optional[str]:
@@ -247,11 +271,11 @@ def search_cards(
     name_api = text.normalize(name, keep_spaces=True)
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-    url = _build_cards_endpoint(api_host)
+    api_host_value, api_host_header = _normalize_host(rapidapi_host)
+    url = _build_cards_endpoint(api_host_value, "cards", "search")
     if rapidapi_key:
         headers["X-RapidAPI-Key"] = rapidapi_key
-    headers["X-RapidAPI-Host"] = api_host
+    headers["X-RapidAPI-Host"] = api_host_header
 
     rapid_search_parts: list[str] = []
     if name_api:
@@ -271,7 +295,7 @@ def search_cards(
     page_size = max(limit * 5, 50)
     page_size = min(page_size, 250)
     params = {
-        "search": query_value,
+        "q": query_value,
         "page": "1",
         "pageSize": str(page_size),
     }
@@ -395,11 +419,11 @@ def list_set_cards(
     http = session or requests
     headers: dict[str, str] = {}
     _apply_default_user_agent(headers, session)
-    api_host = rapidapi_host or RAPIDAPI_DEFAULT_HOST
-    url = _build_cards_endpoint(api_host)
+    api_host_value, api_host_header = _normalize_host(rapidapi_host)
+    url = _build_cards_endpoint(api_host_value, "cards")
     if rapidapi_key:
         headers["X-RapidAPI-Key"] = rapidapi_key
-    headers["X-RapidAPI-Host"] = api_host
+    headers["X-RapidAPI-Host"] = api_host_header
 
     def _escape_query(value: str) -> str:
         return value.replace("\\", "\\\\").replace('"', r"\"")
@@ -435,9 +459,10 @@ def list_set_cards(
 
     while True:
         params = {
-            "search": query,
+            "q": query,
             "page": str(page),
             "pageSize": str(page_size),
+            "orderBy": "number",
         }
         try:
             response = http.get(
@@ -498,3 +523,71 @@ def list_set_cards(
     if limit and limit > 0:
         results = results[:limit]
     return results, request_count
+
+
+def fetch_card_price_history(
+    card_id: str,
+    *,
+    rapidapi_key: Optional[str] = None,
+    rapidapi_host: Optional[str] = None,
+    session: Optional[requests.sessions.Session] = None,
+    timeout: float = 10.0,
+    market: Optional[str] = None,
+    currency: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Fetch market price history for a Pokémon card via RapidAPI."""
+
+    if not card_id:
+        return []
+
+    http = session or requests
+    headers: dict[str, str] = {}
+    _apply_default_user_agent(headers, session)
+    api_host_value, api_host_header = _normalize_host(rapidapi_host)
+    url = _build_cards_endpoint(api_host_value, "cards", card_id, "history-prices")
+    if rapidapi_key:
+        headers["X-RapidAPI-Key"] = rapidapi_key
+    headers["X-RapidAPI-Host"] = api_host_header
+
+    params: dict[str, str] = {}
+    if market:
+        params["market"] = market
+    if currency:
+        params["currency"] = currency
+
+    try:
+        response = http.get(url, params=params or None, headers=headers, timeout=timeout)
+    except requests.Timeout:
+        logger.warning("Price history request timed out for card %s", card_id)
+        return []
+    except (requests.RequestException, ValueError) as exc:  # pragma: no cover
+        logger.warning("Fetching price history for %s failed: %s", card_id, exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "API error while fetching price history for %s: %s",
+            card_id,
+            response.status_code,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError:
+        logger.warning("Failed to decode price history payload for card %s", card_id)
+        return []
+
+    history: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        candidates = payload.get("data") or payload.get("history") or payload.get("prices")
+        if candidates is None and payload:
+            candidates = payload
+        if isinstance(candidates, dict):
+            candidates = [candidates]
+        if isinstance(candidates, list):
+            history = [item for item in candidates if isinstance(item, dict)]
+    elif isinstance(payload, list):
+        history = [item for item in payload if isinstance(item, dict)]
+
+    return history

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from kartoteka_web.services import tcg_api
 
 
 class _DummySession:
     def __init__(
         self,
-        response_data: dict[str, object] | None = None,
+        response_data: Any | None = None,
         status_code: int = 200,
     ) -> None:
         self.calls: list[dict[str, object]] = []
@@ -27,7 +29,7 @@ class _DummySession:
         )
 
         class _Response:
-            def __init__(self, data: dict[str, object], status_code: int) -> None:
+            def __init__(self, data: Any, status_code: int) -> None:
                 self._data = data
                 self.status_code = status_code
 
@@ -37,24 +39,27 @@ class _DummySession:
         return _Response(self._response_data, self._status_code)
 
 
+DEFAULT_HOST = tcg_api.RAPIDAPI_DEFAULT_HOST
+
+
 def test_search_cards_uses_rapidapi_headers():
     session = _DummySession()
     tcg_api.search_cards(
         name="Pikachu",
         rapidapi_key="rapid-key",
-        rapidapi_host="pokemon-tcg.p.rapidapi.com",
+        rapidapi_host=DEFAULT_HOST,
         session=session,
     )
 
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
-    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/search"
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "search" in params
-    assert params["search"] == "pikachu"
+    assert "q" in params
+    assert params["q"] == "pikachu"
 
 
 def test_search_cards_uses_default_host_when_missing():
@@ -68,26 +73,26 @@ def test_search_cards_uses_default_host_when_missing():
 
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
-    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/search"
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "search" in params
-    assert params["search"] == "eevee"
+    assert "q" in params
+    assert params["q"] == "eevee"
 
 
 def test_search_cards_without_key_omits_auth_header():
     session = _DummySession()
-    tcg_api.search_cards(name="Ditto", rapidapi_host="pokemon-tcg.p.rapidapi.com", session=session)
+    tcg_api.search_cards(name="Ditto", rapidapi_host=DEFAULT_HOST, session=session)
 
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     headers = call["headers"]
     assert "X-RapidAPI-Key" not in headers
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert params.get("search") == "ditto"
+    assert params.get("q") == "ditto"
 
 
 def test_list_set_cards_uses_rapidapi_headers():
@@ -96,7 +101,7 @@ def test_list_set_cards_uses_rapidapi_headers():
         "base",
         limit=1,
         rapidapi_key="rapid-key",
-        rapidapi_host="pokemon-tcg.p.rapidapi.com",
+        rapidapi_host=DEFAULT_HOST,
         session=session,
     )
 
@@ -104,16 +109,17 @@ def test_list_set_cards_uses_rapidapi_headers():
     assert request_count == 1
     assert session.calls, "Expected at least one HTTP request"
     call = session.calls[0]
-    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards"
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "search" in params
-    query = params["search"]
+    assert "q" in params
+    query = params["q"]
     assert 'setId:"base"' in query
     assert 'setPtcgoCode:"base"' in query
     assert 'setName:"*base*"' in query
+    assert params.get("orderBy") == "number"
 
 
 def test_search_cards_builds_compound_query():
@@ -128,7 +134,7 @@ def test_search_cards_builds_compound_query():
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     params = call["params"] or {}
-    assert params["search"] == "pikachu base 102"
+    assert params["q"] == "pikachu base 102"
 
 
 def test_search_cards_matches_uppercase_collector_number():
@@ -155,12 +161,12 @@ def test_list_set_cards_without_key_uses_default_headers():
 
     assert session.calls, "Expected at least one HTTP request"
     call = session.calls[0]
-    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards"
     headers = call["headers"]
     assert "X-RapidAPI-Key" not in headers
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    query = params["search"]
+    query = params["q"]
     assert 'setId:"base"' in query
     assert 'setPtcgoCode:"base"' in query
     assert 'setName:"*base*"' in query
@@ -178,7 +184,61 @@ def test_list_set_cards_uses_default_host_when_missing():
 
     assert session.calls, "Expected at least one HTTP request"
     call = session.calls[0]
-    assert call["url"] == "https://pokemon-tcg.p.rapidapi.com/v2/cards"
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards"
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
-    assert headers.get("X-RapidAPI-Host") == "pokemon-tcg.p.rapidapi.com"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
+
+
+def test_build_cards_endpoint_supports_nested_paths():
+    url = tcg_api._build_cards_endpoint(
+        "https://pokemon-tcg-api.p.rapidapi.com",
+        "cards",
+        "sv1-1",
+        "history-prices",
+    )
+    assert url == "https://pokemon-tcg-api.p.rapidapi.com/cards/sv1-1/history-prices"
+
+
+def test_fetch_card_price_history_uses_endpoint_and_parses_data():
+    history_payload = {
+        "data": [
+            {"date": "2023-01-01", "market": {"price": 9.99}},
+            {"date": "2023-01-02", "market": {"price": 10.5}},
+        ]
+    }
+    session = _DummySession(response_data=history_payload)
+
+    history = tcg_api.fetch_card_price_history(
+        "sv1-1",
+        rapidapi_key="rapid-key",
+        rapidapi_host="https://pokemon-tcg-api.p.rapidapi.com",
+        session=session,
+        market="tcgplayer",
+    )
+
+    assert session.calls, "Expected a price history request"
+    call = session.calls[0]
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/sv1-1/history-prices"
+    headers = call["headers"]
+    assert headers.get("X-RapidAPI-Key") == "rapid-key"
+    assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
+    params = call["params"] or {}
+    assert params.get("market") == "tcgplayer"
+    assert history == history_payload["data"]
+
+
+def test_fetch_card_price_history_handles_non_200_response():
+    session = _DummySession(status_code=404)
+
+    history = tcg_api.fetch_card_price_history(
+        "base1-4",
+        rapidapi_key=None,
+        rapidapi_host=None,
+        session=session,
+    )
+
+    assert session.calls, "Expected a price history request"
+    call = session.calls[0]
+    assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/base1-4/history-prices"
+    assert history == []


### PR DESCRIPTION
## Summary
- update the RapidAPI default host and endpoint builder to target the pokemon-tcg-api host and nested paths such as /cards/search and /cards/{id}/history-prices
- adjust search and set listing helpers to call the new endpoints with q/orderBy parameters and keep response normalisation intact
- add a price history helper and expand the tcg_api test suite for the new endpoints, headers, and parameters

## Testing
- pytest tests/test_tcg_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dd22974328832fbf29aa99a5362713