### PR TITLE
Switch TCG API queries to new search parameter names

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -245,6 +245,7 @@ def search_cards(
     set_name: Optional[str] = None,
     total: Optional[str] = None,
     limit: int = 10,
+    sort: Optional[str] = None,
     rapidapi_key: Optional[str] = None,
     rapidapi_host: Optional[str] = None,
     session: Optional[requests.sessions.Session] = None,
@@ -295,10 +296,12 @@ def search_cards(
     page_size = max(limit * 5, 50)
     page_size = min(page_size, 250)
     params = {
-        "q": query_value,
+        "search": query_value,
         "page": "1",
         "pageSize": str(page_size),
     }
+    if sort:
+        params["sort"] = sort
 
     try:
         response = http.get(url, params=params, headers=headers, timeout=timeout)
@@ -459,10 +462,10 @@ def list_set_cards(
 
     while True:
         params = {
-            "q": query,
+            "search": query,
             "page": str(page),
             "pageSize": str(page_size),
-            "orderBy": "number",
+            "sort": "number",
         }
         try:
             response = http.get(

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -49,6 +49,7 @@ def test_search_cards_uses_rapidapi_headers():
         rapidapi_key="rapid-key",
         rapidapi_host=DEFAULT_HOST,
         session=session,
+        sort="name",
     )
 
     assert session.calls, "Expected a single HTTP request"
@@ -58,8 +59,9 @@ def test_search_cards_uses_rapidapi_headers():
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "q" in params
-    assert params["q"] == "pikachu"
+    assert "search" in params
+    assert params["search"] == "pikachu"
+    assert params.get("sort") == "name"
 
 
 def test_search_cards_uses_default_host_when_missing():
@@ -78,8 +80,8 @@ def test_search_cards_uses_default_host_when_missing():
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "q" in params
-    assert params["q"] == "eevee"
+    assert "search" in params
+    assert params["search"] == "eevee"
 
 
 def test_search_cards_without_key_omits_auth_header():
@@ -92,7 +94,7 @@ def test_search_cards_without_key_omits_auth_header():
     assert "X-RapidAPI-Key" not in headers
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert params.get("q") == "ditto"
+    assert params.get("search") == "ditto"
 
 
 def test_list_set_cards_uses_rapidapi_headers():
@@ -114,12 +116,12 @@ def test_list_set_cards_uses_rapidapi_headers():
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    assert "q" in params
-    query = params["q"]
+    assert "search" in params
+    query = params["search"]
     assert 'setId:"base"' in query
     assert 'setPtcgoCode:"base"' in query
     assert 'setName:"*base*"' in query
-    assert params.get("orderBy") == "number"
+    assert params.get("sort") == "number"
 
 
 def test_search_cards_builds_compound_query():
@@ -134,7 +136,7 @@ def test_search_cards_builds_compound_query():
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     params = call["params"] or {}
-    assert params["q"] == "pikachu base 102"
+    assert params["search"] == "pikachu base 102"
 
 
 def test_search_cards_matches_uppercase_collector_number():
@@ -166,7 +168,7 @@ def test_list_set_cards_without_key_uses_default_headers():
     assert "X-RapidAPI-Key" not in headers
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
-    query = params["q"]
+    query = params["search"]
     assert 'setId:"base"' in query
     assert 'setPtcgoCode:"base"' in query
     assert 'setName:"*base*"' in query


### PR DESCRIPTION
## Summary
- update the search_cards helper to send the new RapidAPI `search` parameter and allow optional sorting
- adjust list_set_cards to use the updated `search`/`sort` keys when fetching set cards
- refresh the tcg_api tests so they assert the new parameter names

## Testing
- pytest tests/test_tcg_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2519e360832fbcb45e5bd542c50d