### PR TITLE
Enhance card search results presentation

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -614,12 +614,44 @@
     for (const item of items) {
       const article = document.createElement("article");
       article.className = "card-search-item";
-      const numberLabel = item.number_display || item.number;
+      const numberLabel = item.number_display || item.number || "";
+      const cardName = (item.name || "").trim() || "Bez nazwy";
+      const setName = (item.set_name || "").trim() || "Nieznany dodatek";
+      const hasThumbnail = Boolean(item.image_small);
+      const hasSetIcon = Boolean(item.set_icon);
+      const cardAlt = `Miniatura karty ${cardName}`;
+      const setAlt = `Ikona dodatku ${setName}`;
       article.innerHTML = `
+        <div class="card-search-media">
+          <div class="card-search-thumbnail">
+            ${
+              hasThumbnail
+                ? `<img src="${escapeHtml(item.image_small)}" alt="${escapeHtml(cardAlt)}" loading="lazy" decoding="async" data-card-thumbnail />`
+                : ""
+            }
+            <div class="card-search-thumbnail-fallback"${hasThumbnail ? " hidden" : ""} data-card-thumbnail-fallback>
+              Brak miniatury
+            </div>
+          </div>
+          <div class="card-search-set">
+            <div class="card-search-set-icon">
+              ${
+                hasSetIcon
+                  ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+                  : ""
+              }
+              <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
+            </div>
+            <div class="card-search-set-text">
+              <span class="card-search-set-label">Dodatek</span>
+              <span class="card-search-set-value">${escapeHtml(setName)}</span>
+            </div>
+          </div>
+        </div>
         <div class="card-search-info">
-          <h3>${escapeHtml(item.name)}</h3>
-          <p>${escapeHtml(item.set_name || "")}</p>
-          <p class="card-search-meta">${escapeHtml(numberLabel || "")}</p>
+          <h3>${escapeHtml(cardName)}</h3>
+          <p>${escapeHtml(setName)}</p>
+          <p class="card-search-meta">${escapeHtml(numberLabel)}</p>
         </div>
         <form class="card-search-form" data-card-form>
           <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
@@ -648,6 +680,24 @@
           </div>
         </form>
       `;
+      const thumbnail = article.querySelector("[data-card-thumbnail]");
+      const thumbnailFallback = article.querySelector("[data-card-thumbnail-fallback]");
+      if (thumbnail && thumbnailFallback) {
+        const handleThumbnailError = () => {
+          thumbnail.remove();
+          thumbnailFallback.hidden = false;
+        };
+        thumbnail.addEventListener("error", handleThumbnailError, { once: true });
+      }
+      const setIcon = article.querySelector("[data-card-set-icon]");
+      const setIconFallback = article.querySelector("[data-card-set-icon-fallback]");
+      if (setIcon && setIconFallback) {
+        const handleSetIconError = () => {
+          setIcon.remove();
+          setIconFallback.hidden = false;
+        };
+        setIcon.addEventListener("error", handleSetIconError, { once: true });
+      }
       container.appendChild(article);
     }
   };

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -538,11 +538,110 @@ img {
 
 .card-search-item {
   display: grid;
-  gap: 16px;
+  gap: 20px;
   padding: 20px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
+  grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
+  grid-template-areas:
+    "media info"
+    "form form";
+  align-items: start;
+}
+
+.card-search-media {
+  grid-area: media;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.card-search-thumbnail {
+  position: relative;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, var(--color-background-alt), var(--color-surface));
+  aspect-ratio: 3 / 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-search-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.card-search-thumbnail-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  width: 100%;
+  height: 100%;
+}
+
+.card-search-set {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.card-search-set-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-search-set-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.card-search-set-icon-fallback {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-muted);
+  letter-spacing: 0.08em;
+}
+
+.card-search-set-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.card-search-set-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.card-search-info {
+  grid-area: info;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .card-search-info h3 {
@@ -561,6 +660,7 @@ img {
 }
 
 .card-search-form {
+  grid-area: form;
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -578,7 +678,30 @@ img {
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
-  background: #fff;
+  background: var(--color-surface);
+}
+
+.card-search-set-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .card-search-item {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "media"
+      "info"
+      "form";
+  }
+
+  .card-search-media {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .card-search-set {
+    justify-content: flex-start;
+  }
 }
 
 .checkbox {


### PR DESCRIPTION
## Summary
- add card thumbnails and set icons to search results with appropriate accessibility text and fallbacks
- refresh card search layout styles for responsive presentation in light and dark themes
- hide failed thumbnails and set icons to keep the layout stable when assets are missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8f285f84832faaecc39c79dbffaa