### PR TITLE
Add card search view toggle and grid quick add support

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -141,6 +141,104 @@
     }
   };
 
+  const CARD_VIEW_STORAGE_KEY = "kartoteka_card_view_mode";
+  const CARD_SORT_STORAGE_KEY = "kartoteka_card_sort_order";
+  let currentCardViewMode = "list";
+  let currentCardSortOrder = "relevance";
+
+  const readStoredCardViewMode = () => {
+    if (!storage) return null;
+    try {
+      const value = storage.getItem(CARD_VIEW_STORAGE_KEY);
+      return value === "grid" || value === "list" ? value : null;
+    } catch (error) {
+      console.warn("Unable to read card view mode", error);
+      return null;
+    }
+  };
+
+  const persistCardViewMode = (mode) => {
+    if (!storage) return;
+    try {
+      storage.setItem(CARD_VIEW_STORAGE_KEY, mode);
+    } catch (error) {
+      console.warn("Unable to persist card view mode", error);
+    }
+  };
+
+  const readStoredCardSortOrder = () => {
+    if (!storage) return null;
+    try {
+      const value = storage.getItem(CARD_SORT_STORAGE_KEY);
+      const allowed = [
+        "relevance",
+        "name-asc",
+        "name-desc",
+        "set-asc",
+        "number-asc",
+        "number-desc",
+      ];
+      return allowed.includes(value) ? value : null;
+    } catch (error) {
+      console.warn("Unable to read card sort order", error);
+      return null;
+    }
+  };
+
+  const persistCardSortOrder = (order) => {
+    if (!storage) return;
+    try {
+      storage.setItem(CARD_SORT_STORAGE_KEY, order);
+    } catch (error) {
+      console.warn("Unable to persist card sort order", error);
+    }
+  };
+
+  const applyCardResultsViewMode = (mode) => {
+    const container = document.getElementById("card-search-results");
+    if (!container) return;
+    const normalized = mode === "grid" ? "grid" : "list";
+    container.classList.toggle("card-search-results--grid", normalized === "grid");
+    container.classList.toggle("card-search-results--list", normalized === "list");
+    container.dataset.viewMode = normalized;
+    currentCardViewMode = normalized;
+  };
+
+  const cardResultsCollator =
+    typeof Intl !== "undefined" && typeof Intl.Collator === "function"
+      ? new Intl.Collator("pl", { numeric: true, sensitivity: "base" })
+      : null;
+
+  const compareText = (a = "", b = "") => {
+    if (cardResultsCollator) {
+      return cardResultsCollator.compare(a, b);
+    }
+    return a.localeCompare(b);
+  };
+
+  const sortCardSearchItems = (items = [], order = "relevance") => {
+    const list = Array.isArray(items) ? [...items] : [];
+    switch (order) {
+      case "name-asc":
+        return list.sort((a, b) => compareText(a.name || "", b.name || ""));
+      case "name-desc":
+        return list.sort((a, b) => compareText(b.name || "", a.name || ""));
+      case "set-asc":
+        return list.sort((a, b) => compareText(a.set_name || "", b.set_name || ""));
+      case "number-asc":
+        return list.sort((a, b) =>
+          compareText(a.number_display || a.number || "", b.number_display || b.number || ""),
+        );
+      case "number-desc":
+        return list.sort((a, b) =>
+          compareText(b.number_display || b.number || "", a.number_display || a.number || ""),
+        );
+      case "relevance":
+      default:
+        return list;
+    }
+  };
+
   const getToken = () => (storage ? storage.getItem(TOKEN_KEY) : null);
   const setToken = (token) => {
     if (!storage) return;
@@ -621,6 +719,7 @@
       const hasSetIcon = Boolean(item.set_icon);
       const cardAlt = `Miniatura karty ${cardName}`;
       const setAlt = `Ikona dodatku ${setName}`;
+      const quickAddLabel = `Dodaj kartę ${cardName} do kolekcji`;
       article.innerHTML = `
         <div class="card-search-media">
           <div class="card-search-thumbnail">
@@ -632,6 +731,15 @@
             <div class="card-search-thumbnail-fallback"${hasThumbnail ? " hidden" : ""} data-card-thumbnail-fallback>
               Brak miniatury
             </div>
+            <button
+              type="button"
+              class="card-quick-add"
+              data-card-quick-add
+              aria-label="${escapeHtml(quickAddLabel)}"
+              title="Dodaj do kolekcji"
+            >
+              <span aria-hidden="true">+</span>
+            </button>
           </div>
           <div class="card-search-set">
             <div class="card-search-set-icon">
@@ -708,6 +816,79 @@
     const alertBox = document.getElementById("add-card-alert");
     const summary = document.getElementById("card-search-summary");
     const emptyMessage = document.getElementById("card-search-empty");
+    const viewButtons = Array.from(document.querySelectorAll("[data-card-view]") || []);
+    const sortSelect = document.querySelector("[data-card-sort]");
+    const results = document.getElementById("card-search-results");
+    let latestItems = [];
+    let latestTotal = 0;
+
+    const updateViewButtons = (mode) => {
+      viewButtons.forEach((button) => {
+        const isActive = button.dataset.cardView === mode;
+        button.classList.toggle("is-active", isActive);
+        button.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+    };
+
+    const applyViewMode = (mode, options = {}) => {
+      const normalized = mode === "grid" ? "grid" : "list";
+      applyCardResultsViewMode(normalized);
+      updateViewButtons(normalized);
+      if (options.persist !== false) {
+        persistCardViewMode(normalized);
+      }
+    };
+
+    const applySortOrder = (order, options = {}) => {
+      const allowed = new Set([
+        "relevance",
+        "name-asc",
+        "name-desc",
+        "set-asc",
+        "number-asc",
+        "number-desc",
+      ]);
+      const normalized = allowed.has(order) ? order : "relevance";
+      currentCardSortOrder = normalized;
+      if (sortSelect && sortSelect.value !== normalized) {
+        sortSelect.value = normalized;
+      }
+      if (options.persist !== false) {
+        persistCardSortOrder(normalized);
+      }
+    };
+
+    const renderLatestResults = () => {
+      const sortedItems = sortCardSearchItems(latestItems, currentCardSortOrder);
+      renderSearchResults(sortedItems, summary, emptyMessage, latestTotal);
+      applyViewMode(currentCardViewMode, { persist: false });
+    };
+
+    const storedView = readStoredCardViewMode();
+    const storedSort = readStoredCardSortOrder();
+    if (storedView) {
+      currentCardViewMode = storedView;
+    }
+    if (storedSort) {
+      currentCardSortOrder = storedSort;
+    }
+    if (sortSelect) {
+      sortSelect.value = currentCardSortOrder;
+    }
+    applyViewMode(currentCardViewMode, { persist: false });
+
+    viewButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        applyViewMode(button.dataset.cardView || "list");
+      });
+    });
+
+    if (sortSelect) {
+      sortSelect.addEventListener("change", (event) => {
+        applySortOrder(event.target.value);
+        renderLatestResults();
+      });
+    }
 
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
@@ -722,47 +903,72 @@
       try {
         const params = new URLSearchParams({ query });
         const data = await apiFetch(`/cards/search?${params.toString()}`);
-        renderSearchResults(data?.items || [], summary, emptyMessage, data?.total || 0);
+        latestItems = Array.isArray(data?.items) ? [...data.items] : [];
+        latestTotal = data?.total || 0;
+        renderLatestResults();
         showAlert(alertBox, "");
       } catch (error) {
         showAlert(alertBox, error.message || "Nie udało się pobrać wyników.", "error");
       }
     });
 
-    const results = document.getElementById("card-search-results");
+    const handleCardFormSubmission = async (target, trigger) => {
+      const alertTarget = document.getElementById("add-card-alert");
+      const quantity = Number.parseInt(target.elements.quantity?.value || "1", 10);
+      const priceRaw = target.elements.purchase_price?.value?.trim() || "";
+      const price = priceRaw ? Number.parseFloat(priceRaw.replace(",", ".")) : null;
+      const payload = {
+        quantity: Number.isFinite(quantity) && quantity >= 0 ? quantity : 0,
+        purchase_price:
+          priceRaw && Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : null,
+        is_reverse: Boolean(target.elements.is_reverse?.checked),
+        is_holo: Boolean(target.elements.is_holo?.checked),
+        card: buildCardPayload(target),
+      };
+      if (!payload.card.name || !payload.card.number || !payload.card.set_name) {
+        showAlert(alertTarget, "Brakuje danych karty.", "error");
+        return;
+      }
+      showAlert(alertTarget, "Dodaję kartę do kolekcji…");
+      try {
+        await apiFetch("/cards/", {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        showAlert(alertTarget, "Karta została dodana do kolekcji.", "success");
+        target.reset();
+        if (trigger && typeof trigger.focus === "function") {
+          trigger.focus();
+        } else {
+          target.querySelector('button[type="submit"]')?.focus();
+        }
+        loadCollection();
+      } catch (error) {
+        showAlert(alertTarget, error.message || "Nie udało się dodać karty.", "error");
+        if (trigger && typeof trigger.focus === "function") {
+          trigger.focus();
+        }
+      }
+    };
+
     if (results) {
       results.addEventListener("submit", async (event) => {
         const target = event.target;
         if (!(target instanceof HTMLFormElement)) return;
         event.preventDefault();
-        const alertTarget = document.getElementById("add-card-alert");
-        const quantity = Number.parseInt(target.elements.quantity?.value || "1", 10);
-        const priceRaw = target.elements.purchase_price?.value?.trim() || "";
-        const price = priceRaw ? Number.parseFloat(priceRaw.replace(",", ".")) : null;
-        const payload = {
-          quantity: Number.isFinite(quantity) && quantity >= 0 ? quantity : 0,
-          purchase_price:
-            priceRaw && Number.isFinite(price) && price >= 0 ? Number(price.toFixed(2)) : null,
-          is_reverse: Boolean(target.elements.is_reverse?.checked),
-          is_holo: Boolean(target.elements.is_holo?.checked),
-          card: buildCardPayload(target),
-        };
-        if (!payload.card.name || !payload.card.number || !payload.card.set_name) {
-          showAlert(alertTarget, "Brakuje danych karty.", "error");
-          return;
-        }
-        showAlert(alertTarget, "Dodaję kartę do kolekcji…");
-        try {
-          await apiFetch("/cards/", {
-            method: "POST",
-            body: JSON.stringify(payload),
-          });
-          showAlert(alertTarget, "Karta została dodana do kolekcji.", "success");
-          target.reset();
-          loadCollection();
-        } catch (error) {
-          showAlert(alertTarget, error.message || "Nie udało się dodać karty.", "error");
-        }
+        const trigger = event.submitter || target.querySelector('button[type="submit"]');
+        await handleCardFormSubmission(target, trigger);
+      });
+
+      results.addEventListener("click", async (event) => {
+        const button = event.target instanceof Element
+          ? event.target.closest("[data-card-quick-add]")
+          : null;
+        if (!button) return;
+        const formTarget = button.closest("form[data-card-form]");
+        if (!(formTarget instanceof HTMLFormElement)) return;
+        event.preventDefault();
+        await handleCardFormSubmission(formTarget, button);
       });
     }
   };

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -530,19 +530,128 @@ img {
   color: var(--color-muted);
 }
 
+
+.card-search-toolbar {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.card-search-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.card-search-toolbar-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.card-search-view-toggle {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+}
+
+.card-search-view-toggle button {
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-sm) - 2px);
+  padding: 6px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: none;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-search-view-toggle button:hover,
+.card-search-view-toggle button:focus-visible {
+  color: var(--color-accent);
+}
+
+.card-search-view-toggle button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.card-search-view-toggle button[aria-pressed="true"],
+.card-search-view-toggle button.is-active {
+  background: var(--color-surface);
+  color: var(--color-accent);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+  border-color: var(--color-border);
+}
+
+.card-search-toolbar-group--sort label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.card-search-toolbar-group--sort select {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.card-search-toolbar-group--sort select:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .card-search-results {
   margin-top: 24px;
+}
+
+.card-search-results--list {
   display: grid;
   gap: 16px;
 }
 
-.card-search-item {
+.card-search-results--grid {
   display: grid;
   gap: 20px;
-  padding: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card-search-item {
+  position: relative;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-search-results--grid .card-search-item {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  min-height: 100%;
+}
+
+.card-search-results--list .card-search-item {
+  display: grid;
+  gap: 20px;
+  padding: 20px;
   grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
   grid-template-areas:
     "media info"
@@ -550,11 +659,17 @@ img {
   align-items: start;
 }
 
-.card-search-media {
+.card-search-results--list .card-search-media {
   grid-area: media;
   display: grid;
   gap: 12px;
   align-content: start;
+}
+
+.card-search-results--grid .card-search-media {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .card-search-thumbnail {
@@ -586,6 +701,52 @@ img {
   color: var(--color-muted);
   width: 100%;
   height: 100%;
+}
+
+.card-quick-add {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-accent);
+  cursor: pointer;
+  box-shadow: var(--shadow-card);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.card-quick-add span {
+  font-size: 1.6rem;
+  line-height: 1;
+  font-weight: 500;
+}
+
+.card-quick-add:hover,
+.card-quick-add:focus-visible {
+  background: var(--color-accent);
+  color: #fff;
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.28);
+}
+
+.card-quick-add:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.card-search-results--grid .card-quick-add {
+  display: inline-flex;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.card-search-results--grid .card-quick-add:active {
+  transform: translateY(0) scale(0.95);
 }
 
 .card-search-set {
@@ -624,6 +785,10 @@ img {
   letter-spacing: 0.08em;
 }
 
+.card-search-results--grid .card-search-set {
+  padding: 8px 10px;
+}
+
 .card-search-set-text {
   display: flex;
   flex-direction: column;
@@ -644,6 +809,10 @@ img {
   gap: 8px;
 }
 
+.card-search-results--grid .card-search-info {
+  gap: 6px;
+}
+
 .card-search-info h3 {
   margin: 0 0 6px;
 }
@@ -659,7 +828,12 @@ img {
   font-size: 0.85rem;
 }
 
+
 .card-search-form {
+  display: none;
+}
+
+.card-search-results--list .card-search-form {
   grid-area: form;
   display: grid;
   gap: 12px;
@@ -667,27 +841,48 @@ img {
   align-items: end;
 }
 
-.card-search-form label {
+.card-search-results--list .card-search-form label {
   display: flex;
   flex-direction: column;
   gap: 6px;
   font-size: 0.9rem;
 }
 
-.card-search-form input[type="number"] {
+.card-search-results--list .card-search-form input[type="number"] {
   padding: 8px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
 }
 
+
 .card-search-set-value {
   font-weight: 600;
   font-size: 0.95rem;
 }
 
+@media (max-width: 860px) {
+  .card-search-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .card-search-toolbar-group {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .card-search-toolbar-group--sort {
+    gap: 8px;
+  }
+
+  .card-search-toolbar-group--sort select {
+    flex: 1;
+  }
+}
+
 @media (max-width: 720px) {
-  .card-search-item {
+  .card-search-results--list .card-search-item {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
       "media"
@@ -695,11 +890,11 @@ img {
       "form";
   }
 
-  .card-search-media {
+  .card-search-results--list .card-search-media {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .card-search-set {
+  .card-search-results--list .card-search-set {
     justify-content: flex-start;
   }
 }

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -33,8 +33,33 @@
     </div>
   </form>
   <div class="alert" id="add-card-alert" hidden></div>
+  <div class="card-search-toolbar" data-card-search-toolbar>
+    <div class="card-search-toolbar-group" role="group" aria-label="Przełącz widok wyników wyszukiwania">
+      <span class="card-search-toolbar-label">Widok</span>
+      <div class="card-search-view-toggle">
+        <button type="button" data-card-view="grid" aria-pressed="false">Kratka</button>
+        <button type="button" data-card-view="list" aria-pressed="true">Lista</button>
+      </div>
+    </div>
+    <div class="card-search-toolbar-group card-search-toolbar-group--sort">
+      <label for="card-sort-select">Sortowanie</label>
+      <select id="card-sort-select" data-card-sort>
+        <option value="relevance">Domyślne</option>
+        <option value="name-asc">Nazwa (A–Z)</option>
+        <option value="name-desc">Nazwa (Z–A)</option>
+        <option value="set-asc">Dodatek (A–Z)</option>
+        <option value="number-asc">Numer rosnąco</option>
+        <option value="number-desc">Numer malejąco</option>
+      </select>
+    </div>
+  </div>
   <p id="card-search-summary" class="search-summary" hidden aria-live="polite"></p>
-  <div id="card-search-results" class="card-search-results" role="list"></div>
+  <div
+    id="card-search-results"
+    class="card-search-results card-search-results--list"
+    role="list"
+    data-view-mode="list"
+  ></div>
   <p id="card-search-empty" class="empty-state" hidden aria-live="polite"></p>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add toolbar to the add-card page with grid/list view toggle and sorting select
- persist view/sort preferences, render grid cards with quick-add button, and reuse add workflow with focus handling
- style new toolbar and provide dedicated grid/list layouts including animated quick-add control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd917d5bd8832fb1e91efe69380047