### PR TITLE
Add price-aware card search sorting

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -114,6 +114,7 @@ def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
         artist=None,
         series=None,
         release_date=None,
+        price=None,
     )
 
 
@@ -301,6 +302,7 @@ def _payload_to_search_schema(payload: dict[str, Any]) -> schemas.CardSearchResu
         artist=payload.get("artist"),
         series=payload.get("series"),
         release_date=payload.get("release_date"),
+        price=payload.get("price"),
     )
 
 
@@ -312,6 +314,8 @@ def search_cards_endpoint(
     total: str | None = None,
     set_name: str | None = None,
     limit: int | None = None,
+    sort: str | None = None,
+    order: str | None = None,
     current_user: models.User = Depends(get_current_user),
     session: Session = Depends(get_session),
 ):
@@ -341,6 +345,8 @@ def search_cards_endpoint(
         set_name=set_name,
         total=total,
         limit=result_cap,
+        sort=sort,
+        order=order,
         rapidapi_key=RAPIDAPI_KEY,
         rapidapi_host=RAPIDAPI_HOST,
     )

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -68,6 +68,7 @@ class CardSearchResult(SQLModel):
     artist: Optional[str] = None
     series: Optional[str] = None
     release_date: Optional[str] = None
+    price: Optional[float] = None
 
 
 class CardSearchResponse(SQLModel):

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -95,6 +95,110 @@ def _extract_images(card: dict[str, Any]) -> tuple[Optional[str], Optional[str]]
     return image_small, image_large
 
 
+def _normalize_price_value(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        price = float(value)
+    elif isinstance(value, str):
+        text_value = value.strip()
+        if not text_value:
+            return None
+        text_value = text_value.replace(",", ".")
+        try:
+            price = float(text_value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if price != price or price in (float("inf"), float("-inf")) or price < 0:
+        return None
+    return round(price, 2)
+
+
+def _extract_cardmarket_price(card: dict[str, Any]) -> Optional[float]:
+    cardmarket = (
+        card.get("cardmarket")
+        or card.get("cardMarket")
+        or card.get("card_market")
+        or {}
+    )
+    if not isinstance(cardmarket, dict):
+        return None
+    prices = cardmarket.get("prices")
+    if isinstance(prices, dict):
+        for key in (
+            "averageSellPrice",
+            "trendPrice",
+            "avg7",
+            "avg30",
+            "avg1",
+            "lowPrice",
+        ):
+            price = _normalize_price_value(prices.get(key))
+            if price is not None:
+                return price
+    for key in ("price", "marketPrice"):
+        price = _normalize_price_value(cardmarket.get(key))
+        if price is not None:
+            return price
+    return None
+
+
+def _extract_tcgplayer_price(card: dict[str, Any]) -> Optional[float]:
+    tcgplayer = card.get("tcgplayer") or card.get("tcgPlayer") or {}
+    if not isinstance(tcgplayer, dict):
+        return None
+    prices = tcgplayer.get("prices")
+    if isinstance(prices, dict):
+        for variant in prices.values():
+            if not isinstance(variant, dict):
+                continue
+            for key in ("market", "mid", "directLow", "low", "high"):
+                price = _normalize_price_value(variant.get(key))
+                if price is not None:
+                    return price
+    for key in ("market", "mid", "price"):
+        price = _normalize_price_value(tcgplayer.get(key))
+        if price is not None:
+            return price
+    return None
+
+
+def _extract_generic_price(card: dict[str, Any]) -> Optional[float]:
+    for key in ("price", "marketPrice", "current_price", "currentPrice"):
+        price = _normalize_price_value(card.get(key))
+        if price is not None:
+            return price
+    prices = card.get("prices")
+    if isinstance(prices, dict):
+        for value in prices.values():
+            if isinstance(value, dict):
+                for nested in value.values():
+                    price = _normalize_price_value(nested)
+                    if price is not None:
+                        return price
+            else:
+                price = _normalize_price_value(value)
+                if price is not None:
+                    return price
+    return None
+
+
+def _extract_card_price(card: dict[str, Any]) -> Optional[float]:
+    for extractor in (
+        _extract_cardmarket_price,
+        _extract_tcgplayer_price,
+        _extract_generic_price,
+    ):
+        price = extractor(card)
+        if price is not None:
+            return price
+    return None
+
+
 def _build_cards_endpoint(
     rapidapi_host: Optional[str], *path_parts: str
 ) -> str:
@@ -220,6 +324,7 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
     )
 
     image_small, image_large = _extract_images(card)
+    price = _extract_card_price(card)
 
     return {
         "name": card.get("name") or "",
@@ -235,6 +340,7 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         "series": series,
         "release_date": release_date,
         "set_icon": set_icon,
+        "price": price,
     }
 
 
@@ -246,6 +352,7 @@ def search_cards(
     total: Optional[str] = None,
     limit: int = 10,
     sort: Optional[str] = None,
+    order: Optional[str] = None,
     rapidapi_key: Optional[str] = None,
     rapidapi_host: Optional[str] = None,
     session: Optional[requests.sessions.Session] = None,
@@ -302,6 +409,8 @@ def search_cards(
     }
     if sort:
         params["sort"] = sort
+    if order:
+        params["order"] = order
 
     try:
         response = http.get(url, params=params, headers=headers, timeout=timeout)

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -143,6 +143,17 @@
 
   const CARD_VIEW_STORAGE_KEY = "kartoteka_card_view_mode";
   const CARD_SORT_STORAGE_KEY = "kartoteka_card_sort_order";
+  const CARD_SORT_OPTIONS = [
+    "relevance",
+    "name-asc",
+    "name-desc",
+    "set-asc",
+    "number-asc",
+    "number-desc",
+    "price-asc",
+    "price-desc",
+  ];
+  const CARD_SORT_ALLOWED = new Set(CARD_SORT_OPTIONS);
   let currentCardViewMode = "list";
   let currentCardSortOrder = "relevance";
 
@@ -170,15 +181,7 @@
     if (!storage) return null;
     try {
       const value = storage.getItem(CARD_SORT_STORAGE_KEY);
-      const allowed = [
-        "relevance",
-        "name-asc",
-        "name-desc",
-        "set-asc",
-        "number-asc",
-        "number-desc",
-      ];
-      return allowed.includes(value) ? value : null;
+      return CARD_SORT_ALLOWED.has(value) ? value : null;
     } catch (error) {
       console.warn("Unable to read card sort order", error);
       return null;
@@ -209,6 +212,56 @@
       ? new Intl.Collator("pl", { numeric: true, sensitivity: "base" })
       : null;
 
+  const cardPriceFormatter =
+    typeof Intl !== "undefined" && typeof Intl.NumberFormat === "function"
+      ? new Intl.NumberFormat("pl-PL", {
+          style: "currency",
+          currency: "PLN",
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
+      : null;
+
+  const normalizePriceInput = (value) => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return Number(value);
+    }
+    if (typeof value === "string") {
+      const normalized = value.replace(/,/g, ".").trim();
+      if (!normalized) return null;
+      const parsed = Number.parseFloat(normalized);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  };
+
+  const getCardPriceValue = (item) => {
+    if (!item) return null;
+    return normalizePriceInput(item.price);
+  };
+
+  const formatCardPrice = (price) => {
+    if (!Number.isFinite(price)) return "";
+    if (cardPriceFormatter) {
+      try {
+        return cardPriceFormatter.format(price);
+      } catch (error) {
+        console.debug("Unable to format card price", error);
+      }
+    }
+    return `${price.toFixed(2)} zł`;
+  };
+
+  const stableSort = (items, compare) =>
+    items
+      .map((item, index) => ({ item, index }))
+      .sort((a, b) => {
+        const result = compare(a.item, b.item);
+        if (result !== 0) return result;
+        return a.index - b.index;
+      })
+      .map((entry) => entry.item);
+
   const compareText = (a = "", b = "") => {
     if (cardResultsCollator) {
       return cardResultsCollator.compare(a, b);
@@ -216,26 +269,81 @@
     return a.localeCompare(b);
   };
 
+  const comparePriceAsc = (a, b) => {
+    const priceA = getCardPriceValue(a);
+    const priceB = getCardPriceValue(b);
+    if (priceA === null && priceB === null) return 0;
+    if (priceA === null) return 1;
+    if (priceB === null) return -1;
+    if (priceA < priceB) return -1;
+    if (priceA > priceB) return 1;
+    return 0;
+  };
+
+  const comparePriceDesc = (a, b) => {
+    const priceA = getCardPriceValue(a);
+    const priceB = getCardPriceValue(b);
+    if (priceA === null && priceB === null) return 0;
+    if (priceA === null) return 1;
+    if (priceB === null) return -1;
+    if (priceA > priceB) return -1;
+    if (priceA < priceB) return 1;
+    return 0;
+  };
+
   const sortCardSearchItems = (items = [], order = "relevance") => {
     const list = Array.isArray(items) ? [...items] : [];
+    if (list.length <= 1) return list;
     switch (order) {
       case "name-asc":
-        return list.sort((a, b) => compareText(a.name || "", b.name || ""));
+        return stableSort(list, (a, b) => compareText(a.name || "", b.name || ""));
       case "name-desc":
-        return list.sort((a, b) => compareText(b.name || "", a.name || ""));
+        return stableSort(list, (a, b) => compareText(b.name || "", a.name || ""));
       case "set-asc":
-        return list.sort((a, b) => compareText(a.set_name || "", b.set_name || ""));
+        return stableSort(list, (a, b) => compareText(a.set_name || "", b.set_name || ""));
       case "number-asc":
-        return list.sort((a, b) =>
-          compareText(a.number_display || a.number || "", b.number_display || b.number || ""),
+        return stableSort(list, (a, b) =>
+          compareText(
+            a.number_display || a.number || "",
+            b.number_display || b.number || "",
+          ),
         );
       case "number-desc":
-        return list.sort((a, b) =>
-          compareText(b.number_display || b.number || "", a.number_display || a.number || ""),
+        return stableSort(list, (a, b) =>
+          compareText(
+            b.number_display || b.number || "",
+            a.number_display || a.number || "",
+          ),
         );
+      case "price-asc":
+        return stableSort(list, comparePriceAsc);
+      case "price-desc":
+        return stableSort(list, comparePriceDesc);
       case "relevance":
       default:
         return list;
+    }
+  };
+
+  const mapSortOrderToRequest = (order) => {
+    switch (order) {
+      case "name-asc":
+        return { sort: "name", order: "asc" };
+      case "name-desc":
+        return { sort: "name", order: "desc" };
+      case "set-asc":
+        return { sort: "set.name", order: "asc" };
+      case "number-asc":
+        return { sort: "number", order: "asc" };
+      case "number-desc":
+        return { sort: "number", order: "desc" };
+      case "price-asc":
+        return { sort: "price", order: "asc" };
+      case "price-desc":
+        return { sort: "price", order: "desc" };
+      case "relevance":
+      default:
+        return { sort: null, order: null };
     }
   };
 
@@ -720,6 +828,8 @@
       const cardAlt = `Miniatura karty ${cardName}`;
       const setAlt = `Ikona dodatku ${setName}`;
       const quickAddLabel = `Dodaj kartę ${cardName} do kolekcji`;
+      const priceValue = getCardPriceValue(item);
+      const priceText = priceValue === null ? "" : formatCardPrice(priceValue);
       article.innerHTML = `
         <div class="card-search-media">
           <div class="card-search-thumbnail">
@@ -760,6 +870,11 @@
           <h3>${escapeHtml(cardName)}</h3>
           <p>${escapeHtml(setName)}</p>
           <p class="card-search-meta">${escapeHtml(numberLabel)}</p>
+          ${
+            priceText
+              ? `<p class="card-search-price" data-card-price>Cena: ${escapeHtml(priceText)}</p>`
+              : ""
+          }
         </div>
         <form class="card-search-form" data-card-form>
           <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
@@ -840,15 +955,7 @@
     };
 
     const applySortOrder = (order, options = {}) => {
-      const allowed = new Set([
-        "relevance",
-        "name-asc",
-        "name-desc",
-        "set-asc",
-        "number-asc",
-        "number-desc",
-      ]);
-      const normalized = allowed.has(order) ? order : "relevance";
+      const normalized = CARD_SORT_ALLOWED.has(order) ? order : "relevance";
       currentCardSortOrder = normalized;
       if (sortSelect && sortSelect.value !== normalized) {
         sortSelect.value = normalized;
@@ -902,6 +1009,13 @@
       showAlert(alertBox, "Szukam kart…");
       try {
         const params = new URLSearchParams({ query });
+        const requestSort = mapSortOrderToRequest(currentCardSortOrder);
+        if (requestSort.sort) {
+          params.set("sort", requestSort.sort);
+        }
+        if (requestSort.order) {
+          params.set("order", requestSort.order);
+        }
         const data = await apiFetch(`/cards/search?${params.toString()}`);
         latestItems = Array.isArray(data?.items) ? [...data.items] : [];
         latestTotal = data?.total || 0;

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -50,6 +50,8 @@
         <option value="set-asc">Dodatek (A–Z)</option>
         <option value="number-asc">Numer rosnąco</option>
         <option value="number-desc">Numer malejąco</option>
+        <option value="price-asc">Cena rosnąco</option>
+        <option value="price-desc">Cena malejąco</option>
       </select>
     </div>
   </div>

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -114,6 +114,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "artist": "Keiji Kinebuchi",
             "series": "Base",
             "release_date": "1999/06/16",
+            "price": 12.34,
         },
         {
             "name": "Eevee",
@@ -129,6 +130,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "artist": "Mitsuhiro Arita",
             "series": "Base",
             "release_date": "1999/10/10",
+            "price": 8.5,
         },
     ]
 
@@ -141,6 +143,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
         set_name=None,
         total=None,
         limit,
+        sort=None,
+        order=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -151,6 +155,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "set_name": set_name,
                 "total": total,
                 "limit": limit,
+                "sort": sort,
+                "order": order,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }
@@ -175,9 +181,12 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert captured["name"].startswith("Eevee")
     assert captured["number"] == "133"
     assert captured["limit"] == 5
+    assert captured["sort"] is None
+    assert captured["order"] is None
     assert payload["total"] == len(search_results)
     assert payload["suggested_query"] == "Eevee"
     assert {item["set_code"] for item in payload["items"]} == {"jng", "fsl"}
+    assert sorted(item["price"] for item in payload["items"]) == [8.5, 12.34]
 
     with database.session_scope() as session:
         session.add_all(
@@ -243,6 +252,8 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
         set_name=None,
         total=None,
         limit,
+        sort=None,
+        order=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -253,6 +264,8 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
                 "set_name": set_name,
                 "total": total,
                 "limit": limit,
+                "sort": sort,
+                "order": order,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }
@@ -265,7 +278,7 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
 
     response = api_client.get(
         "/cards/search",
-        params={"query": "Starmie"},
+        params={"query": "Starmie", "sort": "price", "order": "desc"},
         headers=headers,
     )
 
@@ -273,6 +286,8 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
     assert captured["rapidapi_key"] == "rapid-key"
     assert captured["rapidapi_host"] == "rapid.example.com"
     assert captured["name"].startswith("Starmie")
+    assert captured["sort"] == "price"
+    assert captured["order"] == "desc"
 
 
 def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
@@ -298,6 +313,8 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
         set_name=None,
         total=None,
         limit,
+        sort=None,
+        order=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -308,6 +325,8 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
                 "set_name": set_name,
                 "total": total,
                 "limit": limit,
+                "sort": sort,
+                "order": order,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -50,6 +50,7 @@ def test_search_cards_uses_rapidapi_headers():
         rapidapi_host=DEFAULT_HOST,
         session=session,
         sort="name",
+        order="asc",
     )
 
     assert session.calls, "Expected a single HTTP request"
@@ -62,6 +63,7 @@ def test_search_cards_uses_rapidapi_headers():
     assert "search" in params
     assert params["search"] == "pikachu"
     assert params.get("sort") == "name"
+    assert params.get("order") == "asc"
 
 
 def test_search_cards_uses_default_host_when_missing():
@@ -190,6 +192,44 @@ def test_list_set_cards_uses_default_host_when_missing():
     headers = call["headers"]
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
+
+
+def test_build_card_payload_extracts_cardmarket_price():
+    card = {
+        "name": "Bulbasaur",
+        "number": "1/102",
+        "set": {"name": "Base Set"},
+        "cardmarket": {
+            "prices": {
+                "averageSellPrice": "9,50",
+            }
+        },
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert payload["price"] == 9.5
+
+
+def test_build_card_payload_prefers_tcgplayer_price_when_available():
+    card = {
+        "name": "Charmander",
+        "number": "4/102",
+        "set": {"name": "Base Set"},
+        "tcgplayer": {
+            "prices": {
+                "normal": {
+                    "market": 3.75,
+                }
+            }
+        },
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert payload["price"] == 3.75
 
 
 def test_build_cards_endpoint_supports_nested_paths():


### PR DESCRIPTION
## Summary
- extract market prices from RapidAPI card payloads and expose them via the card search schema and endpoint
- extend the add-card UI with price sorting options, client-side formatting, and request propagation for sort/order parameters
- cover price support with updated API/TCG service tests and ensure price data is rendered in the search results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9414fcc8832f86336438a6ad17c2