### PR TITLE
Default add-card results to grid view

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -154,7 +154,7 @@
     "price-desc",
   ];
   const CARD_SORT_ALLOWED = new Set(CARD_SORT_OPTIONS);
-  let currentCardViewMode = "list";
+  let currentCardViewMode = "grid";
   let currentCardSortOrder = "relevance";
 
   const readStoredCardViewMode = () => {
@@ -973,9 +973,7 @@
 
     const storedView = readStoredCardViewMode();
     const storedSort = readStoredCardSortOrder();
-    if (storedView) {
-      currentCardViewMode = storedView;
-    }
+    currentCardViewMode = storedView ?? "grid";
     if (storedSort) {
       currentCardSortOrder = storedSort;
     }

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -37,8 +37,8 @@
     <div class="card-search-toolbar-group" role="group" aria-label="Przełącz widok wyników wyszukiwania">
       <span class="card-search-toolbar-label">Widok</span>
       <div class="card-search-view-toggle">
-        <button type="button" data-card-view="grid" aria-pressed="false">Kratka</button>
-        <button type="button" data-card-view="list" aria-pressed="true">Lista</button>
+        <button type="button" data-card-view="grid" aria-pressed="true" class="is-active">Kratka</button>
+        <button type="button" data-card-view="list" aria-pressed="false">Lista</button>
       </div>
     </div>
     <div class="card-search-toolbar-group card-search-toolbar-group--sort">
@@ -58,9 +58,9 @@
   <p id="card-search-summary" class="search-summary" hidden aria-live="polite"></p>
   <div
     id="card-search-results"
-    class="card-search-results card-search-results--list"
+    class="card-search-results card-search-results--grid"
     role="list"
-    data-view-mode="list"
+    data-view-mode="grid"
   ></div>
   <p id="card-search-empty" class="empty-state" hidden aria-live="polite"></p>
 </section>


### PR DESCRIPTION
## Summary
- default the add-card results view mode to the grid layout when no preference is stored
- update the add-card template so the initial view button state and container classes reflect the grid view

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd9a49fcac832f89acffa26ec17ee1