### PR TITLE
Handle substring name matches in TCG search results

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -507,7 +507,13 @@ def search_cards(
 
         name_similarity = 0.0
         if name_norm and card_name_norm:
+            strong_name_match = False
             if card_name_norm == name_norm:
+                strong_name_match = True
+            elif name_norm in card_name_norm or card_name_norm in name_norm:
+                strong_name_match = True
+
+            if strong_name_match:
                 name_similarity = 1.0
             else:
                 name_similarity = SequenceMatcher(None, name_norm, card_name_norm).ratio()


### PR DESCRIPTION
## Summary
- treat substring matches between the query and card names as strong matches in `search_cards`
- retain similarity safeguard for unrelated results while allowing relevant substrings through

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68de123d3fbc832fb31f074bde1cc2f9