### PR TITLE
Add pagination to card search

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -316,6 +316,8 @@ def search_cards_endpoint(
     limit: int | None = None,
     sort: str | None = None,
     order: str | None = None,
+    page: int = 1,
+    per_page: int = 20,
     current_user: models.User = Depends(get_current_user),
     session: Session = Depends(get_session),
 ):
@@ -331,31 +333,49 @@ def search_cards_endpoint(
     result_cap = MAX_SEARCH_RESULTS
     if limit is not None and limit > 0:
         result_cap = max(1, min(limit, MAX_SEARCH_RESULTS))
+    overall_cap = 100
+    result_cap = min(result_cap, overall_cap)
     search_query = query or _compose_query(name_value, number_value, set_name)
     if not (search_query or name_value):
-        return schemas.CardSearchResponse(items=[], total=0)
+        return schemas.CardSearchResponse(items=[], total=0, page=1, per_page=20, total_count=0)
     if not name_value:
         name_value = search_query
 
     del session  # Database access unused when delegating to external API.
 
-    records = tcg_api.search_cards(
+    per_page_value = max(1, min(per_page or 1, 20))
+    max_pages = max(1, (overall_cap + per_page_value - 1) // per_page_value)
+    try:
+        page_value = int(page)
+    except (TypeError, ValueError):
+        page_value = 1
+    page_value = max(1, min(page_value, max_pages))
+
+    limit_value = min(result_cap, per_page_value)
+
+    records, total_count = tcg_api.search_cards(
         name=name_value or search_query,
         number=number_value,
         set_name=set_name,
         total=total,
-        limit=result_cap,
+        limit=limit_value,
         sort=sort,
         order=order,
+        page=page_value,
+        per_page=per_page_value,
         rapidapi_key=RAPIDAPI_KEY,
         rapidapi_host=RAPIDAPI_HOST,
     )
 
     items = [_payload_to_search_schema(record) for record in records]
     suggestion = records[0].get("name") if records else None
+    capped_total = min(overall_cap, max(len(records), total_count))
     return schemas.CardSearchResponse(
         items=items,
         total=len(records),
+        total_count=capped_total,
+        page=page_value,
+        per_page=per_page_value,
         suggested_query=suggestion,
     )
 

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -74,6 +74,9 @@ class CardSearchResult(SQLModel):
 class CardSearchResponse(SQLModel):
     items: List[CardSearchResult] = Field(default_factory=list)
     total: int = 0
+    total_count: int = 0
+    page: int = 1
+    per_page: int = 20
     suggested_query: Optional[str] = None
 
 

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -413,15 +413,29 @@ def search_cards(
     limit: int = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
+    page: int = 1,
+    per_page: int = 20,
     rapidapi_key: Optional[str] = None,
     rapidapi_host: Optional[str] = None,
     session: Optional[requests.sessions.Session] = None,
     timeout: float = 10.0,
-) -> list[dict]:
+) -> tuple[list[dict], int]:
     if not name:
-        return []
+        return [], 0
 
     http = session or requests
+
+    try:
+        page_value = int(page)
+    except (TypeError, ValueError):
+        page_value = 1
+    page_value = max(1, page_value)
+
+    try:
+        per_page_value = int(per_page)
+    except (TypeError, ValueError):
+        per_page_value = limit if limit and limit > 0 else 20
+    per_page_value = max(1, min(per_page_value, 250))
 
     number_part = ""
     number_total = ""
@@ -458,14 +472,12 @@ def search_cards(
         rapid_search_parts.append(total_clean)
     query_value = " ".join(part for part in rapid_search_parts if part)
     if not query_value:
-        return []
+        return [], 0
 
-    page_size = max(limit * 5, 50)
-    page_size = min(page_size, 250)
     params = {
         "search": query_value,
-        "page": "1",
-        "pageSize": str(page_size),
+        "page": str(page_value),
+        "pageSize": str(per_page_value),
     }
     if sort:
         params["sort"] = sort
@@ -476,17 +488,21 @@ def search_cards(
         response = http.get(url, params=params, headers=headers, timeout=timeout)
         if response.status_code != 200:
             logger.warning("API error: %s", response.status_code)
-            return []
+            return [], 0
         cards = response.json()
     except requests.Timeout:
         logger.warning("Request timed out")
-        return []
+        return [], 0
     except (requests.RequestException, ValueError) as exc:  # pragma: no cover
         logger.warning("Fetching cards from RapidAPI failed: %s", exc)
-        return []
+        return [], 0
 
+    payload = cards
+    total_count = 0
     if isinstance(cards, dict):
-        cards = cards.get("data") or cards.get("cards") or []
+        total_count = int(cards.get("totalCount") or 0)
+        payload = cards.get("data") or cards.get("cards") or []
+    cards = payload
 
     name_norm = text.normalize(name)
     total_norm = total_clean
@@ -558,6 +574,7 @@ def search_cards(
 
     seen: set[tuple[str | None, str]] = set()
     results: list[dict] = []
+    limit_value = limit if limit and limit > 0 else per_page_value
     for item in suggestions:
         score_value = float(item.get("_score", 0) or 0)
         if score_value <= 0:
@@ -576,10 +593,13 @@ def search_cards(
         if not item.get("image_small") and item.get("image_large"):
             item["image_small"] = item["image_large"]
         results.append(item)
-        if len(results) >= limit:
+        if len(results) >= limit_value:
             break
 
-    return results
+    if not total_count and isinstance(cards, list):
+        total_count = len(cards)
+
+    return results, total_count
 
 
 def list_set_cards(

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -796,6 +796,8 @@
     summaryElement,
     emptyMessage,
     totalCount = 0,
+    page = 1,
+    perPage = 20,
   ) => {
     const container = document.getElementById("card-search-results");
     if (!container) return;
@@ -814,8 +816,17 @@
     if (emptyMessage) emptyMessage.hidden = true;
     if (summaryElement) {
       summaryElement.hidden = false;
-      const totalLabel = totalCount && totalCount > items.length ? ` z ${totalCount}` : "";
-      summaryElement.textContent = `Znaleziono ${items.length}${totalLabel} wyników.`;
+      const effectiveTotal = Number.isFinite(totalCount) && totalCount > 0
+        ? totalCount
+        : items.length;
+      const normalizedPerPage = perPage && perPage > 0 ? perPage : items.length;
+      const normalizedPage = page && page > 0 ? page : 1;
+      const totalPages = Math.max(1, Math.ceil(effectiveTotal / normalizedPerPage));
+      const startIndex = (normalizedPage - 1) * normalizedPerPage + 1;
+      const endIndex = startIndex + items.length - 1;
+      const safeStart = Math.max(1, startIndex);
+      const safeEnd = Math.max(safeStart, endIndex);
+      summaryElement.textContent = `Znaleziono ${effectiveTotal} wyników. Wyświetlam ${safeStart}–${safeEnd}. Strona ${normalizedPage} z ${totalPages}.`;
     }
     for (const item of items) {
       const article = document.createElement("article");
@@ -934,8 +945,29 @@
     const viewButtons = Array.from(document.querySelectorAll("[data-card-view]") || []);
     const sortSelect = document.querySelector("[data-card-sort]");
     const results = document.getElementById("card-search-results");
+    const pagination = document.getElementById("card-search-pagination");
+    const paginationStatus = pagination?.querySelector("[data-page-status]");
+    const paginationPrev = pagination?.querySelector("[data-page-action='prev']");
+    const paginationNext = pagination?.querySelector("[data-page-action='next']");
     let latestItems = [];
-    let latestTotal = 0;
+    let latestTotalCount = 0;
+    let latestQuery = "";
+    let latestPage = 1;
+    let latestPerPage = 20;
+    let isFetching = false;
+
+    const toPositiveInteger = (value, fallback) => {
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+        return Math.floor(value);
+      }
+      if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number.parseInt(value, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          return parsed;
+        }
+      }
+      return fallback;
+    };
 
     const updateViewButtons = (mode) => {
       viewButtons.forEach((button) => {
@@ -965,10 +997,42 @@
       }
     };
 
+    const updatePaginationControls = () => {
+      if (!pagination) return;
+      const totalAvailable = latestTotalCount > 0 ? latestTotalCount : latestItems.length;
+      if (!latestItems.length || !totalAvailable) {
+        pagination.hidden = true;
+        if (paginationStatus) paginationStatus.textContent = "";
+        if (paginationPrev) paginationPrev.disabled = true;
+        if (paginationNext) paginationNext.disabled = true;
+        return;
+      }
+      const perPage = latestPerPage > 0 ? latestPerPage : latestItems.length;
+      const totalPages = Math.max(1, Math.ceil(totalAvailable / perPage));
+      pagination.hidden = totalPages <= 1 && latestPage <= 1;
+      if (paginationStatus) {
+        paginationStatus.textContent = `Strona ${latestPage} z ${totalPages}`;
+      }
+      if (paginationPrev) {
+        paginationPrev.disabled = latestPage <= 1;
+      }
+      if (paginationNext) {
+        paginationNext.disabled = latestPage >= totalPages;
+      }
+    };
+
     const renderLatestResults = () => {
       const sortedItems = sortCardSearchItems(latestItems, currentCardSortOrder);
-      renderSearchResults(sortedItems, summary, emptyMessage, latestTotal);
+      renderSearchResults(
+        sortedItems,
+        summary,
+        emptyMessage,
+        latestTotalCount,
+        latestPage,
+        latestPerPage,
+      );
       applyViewMode(currentCardViewMode, { persist: false });
+      updatePaginationControls();
     };
 
     const storedView = readStoredCardViewMode();
@@ -995,6 +1059,55 @@
       });
     }
 
+    const fetchResults = async ({ query, page = 1, message } = {}) => {
+      const queryValue = typeof query === "string" ? query.trim() : latestQuery;
+      if (!queryValue) {
+        return;
+      }
+      const targetPage = page && page > 0 ? page : 1;
+      const params = new URLSearchParams({
+        query: queryValue,
+        page: String(targetPage),
+        per_page: String(latestPerPage),
+      });
+      const requestSort = mapSortOrderToRequest(currentCardSortOrder);
+      if (requestSort.sort) {
+        params.set("sort", requestSort.sort);
+      }
+      if (requestSort.order) {
+        params.set("order", requestSort.order);
+      }
+
+      if (message) {
+        showAlert(alertBox, message);
+      }
+
+      if (isFetching) return;
+      isFetching = true;
+
+      try {
+        const data = await apiFetch(`/cards/search?${params.toString()}`);
+        latestQuery = queryValue;
+        latestItems = Array.isArray(data?.items) ? [...data.items] : [];
+        const totalCountValue = toPositiveInteger(
+          data?.total_count,
+          toPositiveInteger(data?.total, latestItems.length),
+        );
+        latestTotalCount = Math.max(latestItems.length, totalCountValue ?? 0);
+        latestTotalCount = Math.min(100, latestTotalCount);
+        let receivedPerPage = toPositiveInteger(data?.per_page, latestPerPage);
+        receivedPerPage = Math.max(1, Math.min(receivedPerPage, 20));
+        latestPerPage = receivedPerPage;
+        latestPage = toPositiveInteger(data?.page, targetPage);
+        renderLatestResults();
+        showAlert(alertBox, "");
+      } catch (error) {
+        showAlert(alertBox, error.message || "Nie udało się pobrać wyników.", "error");
+      } finally {
+        isFetching = false;
+      }
+    };
+
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
       const queryInput = form.querySelector("input[name='query']");
@@ -1004,25 +1117,27 @@
         queryInput?.focus();
         return;
       }
-      showAlert(alertBox, "Szukam kart…");
-      try {
-        const params = new URLSearchParams({ query });
-        const requestSort = mapSortOrderToRequest(currentCardSortOrder);
-        if (requestSort.sort) {
-          params.set("sort", requestSort.sort);
-        }
-        if (requestSort.order) {
-          params.set("order", requestSort.order);
-        }
-        const data = await apiFetch(`/cards/search?${params.toString()}`);
-        latestItems = Array.isArray(data?.items) ? [...data.items] : [];
-        latestTotal = data?.total || 0;
-        renderLatestResults();
-        showAlert(alertBox, "");
-      } catch (error) {
-        showAlert(alertBox, error.message || "Nie udało się pobrać wyników.", "error");
-      }
+      latestPerPage = 20;
+      latestPage = 1;
+      await fetchResults({ query, page: 1, message: "Szukam kart…" });
     });
+
+    if (paginationPrev) {
+      paginationPrev.addEventListener("click", async () => {
+        if (paginationPrev.disabled || isFetching) return;
+        const targetPage = Math.max(1, latestPage - 1);
+        if (targetPage === latestPage) return;
+        await fetchResults({ page: targetPage, message: "Ładuję poprzednią stronę…" });
+      });
+    }
+
+    if (paginationNext) {
+      paginationNext.addEventListener("click", async () => {
+        if (paginationNext.disabled || isFetching) return;
+        const targetPage = latestPage + 1;
+        await fetchResults({ page: targetPage, message: "Ładuję kolejną stronę…" });
+      });
+    }
 
     const handleCardFormSubmission = async (target, trigger) => {
       const alertTarget = document.getElementById("add-card-alert");

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -56,6 +56,16 @@
     </div>
   </div>
   <p id="card-search-summary" class="search-summary" hidden aria-live="polite"></p>
+  <nav
+    id="card-search-pagination"
+    class="pagination"
+    hidden
+    aria-label="Stronicowanie wyników wyszukiwania"
+  >
+    <button type="button" data-page-action="prev">Poprzednia</button>
+    <span data-page-status class="pagination-status" aria-live="polite"></span>
+    <button type="button" data-page-action="next">Następna</button>
+  </nav>
   <div
     id="card-search-results"
     class="card-search-results card-search-results--grid"

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -145,6 +145,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
         limit,
         sort=None,
         order=None,
+        page=None,
+        per_page=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -157,11 +159,13 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "limit": limit,
                 "sort": sort,
                 "order": order,
+                "page": page,
+                "per_page": per_page,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return search_results
+        return search_results, 84
 
     monkeypatch.setattr(
         "kartoteka_web.routes.cards.tcg_api.search_cards",
@@ -183,7 +187,12 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert captured["limit"] == 5
     assert captured["sort"] is None
     assert captured["order"] is None
+    assert captured["page"] == 1
+    assert captured["per_page"] == 20
     assert payload["total"] == len(search_results)
+    assert payload["total_count"] == 84
+    assert payload["page"] == 1
+    assert payload["per_page"] == 20
     assert payload["suggested_query"] == "Eevee"
     assert {item["set_code"] for item in payload["items"]} == {"jng", "fsl"}
     assert sorted(item["price"] for item in payload["items"]) == [8.5, 12.34]
@@ -254,6 +263,8 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
         limit,
         sort=None,
         order=None,
+        page=None,
+        per_page=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -266,11 +277,13 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
                 "limit": limit,
                 "sort": sort,
                 "order": order,
+                "page": page,
+                "per_page": per_page,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return []
+        return [], 0
 
     monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
     monkeypatch.setattr(cards_routes, "RAPIDAPI_KEY", "rapid-key")
@@ -288,6 +301,8 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
     assert captured["name"].startswith("Starmie")
     assert captured["sort"] == "price"
     assert captured["order"] == "desc"
+    assert captured["page"] == 1
+    assert captured["per_page"] == 20
 
 
 def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
@@ -315,6 +330,8 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
         limit,
         sort=None,
         order=None,
+        page=None,
+        per_page=None,
         rapidapi_key=None,
         rapidapi_host=None,
     ):
@@ -327,11 +344,13 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
                 "limit": limit,
                 "sort": sort,
                 "order": order,
+                "page": page,
+                "per_page": per_page,
                 "rapidapi_key": rapidapi_key,
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return []
+        return [], 0
 
     monkeypatch.setattr(reloaded_cards.tcg_api, "search_cards", fake_search_cards)
 
@@ -345,5 +364,62 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
     )
 
     assert response.total == 0
+    assert response.total_count == 0
     assert captured["rapidapi_key"] == "generic-rapid-key"
     assert captured["rapidapi_host"] == "generic-rapid.example.com"
+    assert captured["page"] == 1
+    assert captured["per_page"] == 20
+
+
+def test_card_search_pagination_clamping(api_client, monkeypatch):
+    headers = _auth_headers(api_client, username="brock", password="onix")
+
+    captured: dict[str, object] = {}
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit=None,
+        sort=None,
+        order=None,
+        page=None,
+        per_page=None,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        captured.update(
+            {
+                "name": name,
+                "number": number,
+                "set_name": set_name,
+                "total": total,
+                "limit": limit,
+                "sort": sort,
+                "order": order,
+                "page": page,
+                "per_page": per_page,
+                "rapidapi_key": rapidapi_key,
+                "rapidapi_host": rapidapi_host,
+            }
+        )
+        return [], 150
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+
+    response = api_client.get(
+        "/cards/search",
+        params={"query": "Onix", "page": 9, "per_page": 50},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert captured["page"] == 5
+    assert captured["per_page"] == 20
+    assert captured["limit"] == 20
+    assert payload["page"] == 5
+    assert payload["per_page"] == 20
+    assert payload["total_count"] == 100

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -46,7 +46,7 @@ DEFAULT_HOST = tcg_api.RAPIDAPI_DEFAULT_HOST
 
 def test_search_cards_uses_rapidapi_headers():
     session = _DummySession()
-    tcg_api.search_cards(
+    results, total_count = tcg_api.search_cards(
         name="Pikachu",
         rapidapi_key="rapid-key",
         rapidapi_host=DEFAULT_HOST,
@@ -55,6 +55,8 @@ def test_search_cards_uses_rapidapi_headers():
         order="asc",
     )
 
+    assert results == []
+    assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/search"
@@ -64,19 +66,23 @@ def test_search_cards_uses_rapidapi_headers():
     params = call["params"] or {}
     assert "search" in params
     assert params["search"] == "pikachu"
+    assert params.get("page") == "1"
+    assert params.get("pageSize") == "20"
     assert params.get("sort") == "name"
     assert params.get("order") == "asc"
 
 
 def test_search_cards_uses_default_host_when_missing():
     session = _DummySession()
-    tcg_api.search_cards(
+    results, total_count = tcg_api.search_cards(
         name="Eevee",
         rapidapi_key="rapid-key",
         rapidapi_host=None,
         session=session,
     )
 
+    assert results == []
+    assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/search"
@@ -90,8 +96,12 @@ def test_search_cards_uses_default_host_when_missing():
 
 def test_search_cards_without_key_omits_auth_header():
     session = _DummySession()
-    tcg_api.search_cards(name="Ditto", rapidapi_host=DEFAULT_HOST, session=session)
+    results, total_count = tcg_api.search_cards(
+        name="Ditto", rapidapi_host=DEFAULT_HOST, session=session
+    )
 
+    assert results == []
+    assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
     headers = call["headers"]
@@ -143,6 +153,21 @@ def test_search_cards_builds_compound_query():
     assert params["search"] == "pikachu base 102"
 
 
+def test_search_cards_forwards_pagination_params():
+    session = _DummySession()
+    tcg_api.search_cards(
+        name="Pikachu",
+        page=3,
+        per_page=15,
+        session=session,
+    )
+
+    call = session.calls[0]
+    params = call["params"] or {}
+    assert params.get("page") == "3"
+    assert params.get("pageSize") == "15"
+
+
 def test_search_cards_matches_uppercase_collector_number():
     card_payload = {
         "name": "Pikachu",
@@ -151,7 +176,7 @@ def test_search_cards_matches_uppercase_collector_number():
     }
     session = _DummySession(response_data={"data": [card_payload]})
 
-    results = tcg_api.search_cards(
+    results, total_count = tcg_api.search_cards(
         name="Pikachu",
         number="RC5A",
         session=session,
@@ -159,6 +184,7 @@ def test_search_cards_matches_uppercase_collector_number():
 
     assert results, "Expected to receive at least one suggestion"
     assert results[0]["number"] == "rc5a"
+    assert total_count == 1
 
 
 def test_list_set_cards_without_key_uses_default_headers():


### PR DESCRIPTION
## Summary
- add pagination support to the RapidAPI card search helper and surface total counts
- expose pagination metadata through the /cards/search endpoint and schema
- render pagination controls on the add card page and update API tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de160410b4832fb927d52bbfb0751d