### PR TITLE
Aggregate RapidAPI card search results locally

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -344,36 +344,42 @@ def search_cards_endpoint(
     del session  # Database access unused when delegating to external API.
 
     per_page_value = max(1, min(per_page or 1, 20))
-    max_pages = max(1, (overall_cap + per_page_value - 1) // per_page_value)
     try:
-        page_value = int(page)
+        requested_page = int(page)
     except (TypeError, ValueError):
-        page_value = 1
-    page_value = max(1, min(page_value, max_pages))
-
-    limit_value = min(result_cap, per_page_value)
+        requested_page = 1
+    requested_page = max(1, requested_page)
 
     records, total_count = tcg_api.search_cards(
         name=name_value or search_query,
         number=number_value,
         set_name=set_name,
         total=total,
-        limit=limit_value,
+        limit=overall_cap,
         sort=sort,
         order=order,
-        page=page_value,
+        page=1,
         per_page=per_page_value,
         rapidapi_key=RAPIDAPI_KEY,
         rapidapi_host=RAPIDAPI_HOST,
     )
 
-    items = [_payload_to_search_schema(record) for record in records]
+    effective_total = min(overall_cap, max(len(records), total_count))
+    if result_cap < overall_cap:
+        records = records[:result_cap]
+    max_pages = max(1, (effective_total + per_page_value - 1) // per_page_value)
+    page_value = min(requested_page, max_pages)
+
+    start_index = (page_value - 1) * per_page_value
+    end_index = start_index + per_page_value
+    page_records = records[start_index:end_index]
+
+    items = [_payload_to_search_schema(record) for record in page_records]
     suggestion = records[0].get("name") if records else None
-    capped_total = min(overall_cap, max(len(records), total_count))
     return schemas.CardSearchResponse(
         items=items,
-        total=len(records),
-        total_count=capped_total,
+        total=len(page_records),
+        total_count=effective_total,
         page=page_value,
         per_page=per_page_value,
         suggested_query=suggestion,

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -474,35 +474,76 @@ def search_cards(
     if not query_value:
         return [], 0
 
-    params = {
-        "search": query_value,
-        "page": str(page_value),
-        "pageSize": str(per_page_value),
-    }
-    if sort:
-        params["sort"] = sort
-    if order:
-        params["order"] = order
+    max_results = 100
+    aggregated_cards: list[dict[str, Any]] = []
+    total_count_remote = 0
+    inferred_total = 0
+    current_page = page_value
 
-    try:
-        response = http.get(url, params=params, headers=headers, timeout=timeout)
+    while len(aggregated_cards) < max_results:
+        params = {
+            "search": query_value,
+            "page": str(current_page),
+            "pageSize": str(per_page_value),
+        }
+        if sort:
+            params["sort"] = sort
+        if order:
+            params["order"] = order
+
+        try:
+            response = http.get(url, params=params, headers=headers, timeout=timeout)
+        except requests.Timeout:
+            logger.warning("Request timed out")
+            break
+        except (requests.RequestException, ValueError) as exc:  # pragma: no cover
+            logger.warning("Fetching cards from RapidAPI failed: %s", exc)
+            break
+
         if response.status_code != 200:
             logger.warning("API error: %s", response.status_code)
-            return [], 0
-        cards = response.json()
-    except requests.Timeout:
-        logger.warning("Request timed out")
-        return [], 0
-    except (requests.RequestException, ValueError) as exc:  # pragma: no cover
-        logger.warning("Fetching cards from RapidAPI failed: %s", exc)
-        return [], 0
+            break
 
-    payload = cards
-    total_count = 0
-    if isinstance(cards, dict):
-        total_count = int(cards.get("totalCount") or 0)
-        payload = cards.get("data") or cards.get("cards") or []
-    cards = payload
+        try:
+            cards_payload = response.json()
+        except ValueError:
+            logger.warning("RapidAPI returned invalid JSON payload")
+            break
+
+        cards_page: list[dict[str, Any]] = []
+        page_total_count = 0
+        if isinstance(cards_payload, dict):
+            cards_page = (
+                cards_payload.get("data")
+                or cards_payload.get("cards")
+                or []
+            )
+            page_total_count = int(cards_payload.get("totalCount") or 0)
+        elif isinstance(cards_payload, list):
+            cards_page = cards_payload
+
+        if page_total_count:
+            total_count_remote = page_total_count
+
+        if not isinstance(cards_page, list) or not cards_page:
+            break
+
+        aggregated_cards.extend(cards_page)
+
+        fetched_total = (current_page - page_value) * per_page_value + len(cards_page)
+        inferred_total = max(inferred_total, fetched_total)
+
+        if len(aggregated_cards) >= max_results:
+            break
+        if total_count_remote and fetched_total >= total_count_remote:
+            break
+        if len(cards_page) < per_page_value:
+            break
+
+        current_page += 1
+
+    cards = aggregated_cards
+    total_count = total_count_remote or inferred_total
 
     name_norm = text.normalize(name)
     total_norm = total_clean
@@ -575,6 +616,7 @@ def search_cards(
     seen: set[tuple[str | None, str]] = set()
     results: list[dict] = []
     limit_value = limit if limit and limit > 0 else per_page_value
+    limit_value = min(limit_value, max_results)
     for item in suggestions:
         score_value = float(item.get("_score", 0) or 0)
         if score_value <= 0:
@@ -596,8 +638,10 @@ def search_cards(
         if len(results) >= limit_value:
             break
 
-    if not total_count and isinstance(cards, list):
-        total_count = len(cards)
+    if not total_count:
+        total_count = len(results)
+
+    total_count = min(max_results, total_count)
 
     return results, total_count
 

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -184,7 +184,6 @@ def test_card_search_and_detail(api_client, monkeypatch):
     payload = search.json()
     assert captured["name"].startswith("Eevee")
     assert captured["number"] == "133"
-    assert captured["limit"] == 5
     assert captured["sort"] is None
     assert captured["order"] is None
     assert captured["page"] == 1
@@ -417,9 +416,79 @@ def test_card_search_pagination_clamping(api_client, monkeypatch):
 
     assert response.status_code == 200, response.text
     payload = response.json()
-    assert captured["page"] == 5
+    assert captured["page"] == 1
     assert captured["per_page"] == 20
-    assert captured["limit"] == 20
+    assert captured["limit"] == 100
     assert payload["page"] == 5
     assert payload["per_page"] == 20
     assert payload["total_count"] == 100
+
+
+def test_card_search_uses_local_pagination(api_client, monkeypatch):
+    headers = _auth_headers(api_client, username="sabrina", password="alakazam")
+
+    captured: dict[str, object] = {}
+
+    records = [
+        {
+            "name": f"Pikachu {index:03d}",
+            "number": f"{index:03d}",
+            "number_display": f"{index:03d}",
+            "total": None,
+            "set_name": "Base Set",
+            "set_code": f"base{index % 5}",
+            "rarity": "Common",
+            "image_small": None,
+            "image_large": None,
+            "set_icon": None,
+            "artist": None,
+            "series": None,
+            "release_date": None,
+            "price": None,
+        }
+        for index in range(1, 101)
+    ]
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit=None,
+        sort=None,
+        order=None,
+        page=None,
+        per_page=None,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        captured.update(
+            {
+                "name": name,
+                "limit": limit,
+                "page": page,
+                "per_page": per_page,
+            }
+        )
+        return records, 100
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+
+    response = api_client.get(
+        "/cards/search",
+        params={"query": "Pikachu", "page": 3, "per_page": 20},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert captured["limit"] == 100
+    assert captured["page"] == 1
+    assert payload["page"] == 3
+    assert payload["per_page"] == 20
+    assert payload["total"] == 20
+    assert payload["total_count"] == 100
+    returned_numbers = [item["number"] for item in payload["items"]]
+    assert returned_numbers[0] == "041"
+    assert returned_numbers[-1] == "060"

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -44,6 +44,35 @@ class _DummySession:
 DEFAULT_HOST = tcg_api.RAPIDAPI_DEFAULT_HOST
 
 
+class _PagingSession:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self.pages = pages
+        self.calls: list[dict[str, object]] = []
+        self.headers = {"User-Agent": "pytest-agent"}
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        call_index = len(self.calls)
+        payload = self.pages[call_index] if call_index < len(self.pages) else {"data": []}
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers or {},
+                "timeout": timeout,
+            }
+        )
+
+        class _Response:
+            def __init__(self, data: Any) -> None:
+                self._data = data
+                self.status_code = 200
+
+            def json(self):
+                return self._data
+
+        return _Response(payload)
+
+
 def test_search_cards_uses_rapidapi_headers():
     session = _DummySession()
     results, total_count = tcg_api.search_cards(
@@ -185,6 +214,40 @@ def test_search_cards_matches_uppercase_collector_number():
     assert results, "Expected to receive at least one suggestion"
     assert results[0]["number"] == "rc5a"
     assert total_count == 1
+
+
+def test_search_cards_aggregates_multiple_pages():
+    pages: list[dict[str, Any]] = []
+    for index in range(3):
+        start = index * 50
+        cards = []
+        for offset in range(50):
+            number_value = f"{start + offset + 1:03d}"
+            cards.append(
+                {
+                    "name": "Pikachu",
+                    "number": number_value,
+                    "set": {
+                        "name": "Base Set",
+                        "id": f"base-{index}",
+                    },
+                }
+            )
+        pages.append({"data": cards, "totalCount": 150})
+
+    session = _PagingSession(pages)
+    results, total_count = tcg_api.search_cards(
+        name="Pikachu",
+        limit=100,
+        per_page=50,
+        session=session,
+    )
+
+    assert len(results) == 100
+    assert total_count == 100
+    assert len(session.calls) == 2
+    assert session.calls[0]["params"]["page"] == "1"
+    assert session.calls[1]["params"]["page"] == "2"
 
 
 def test_list_set_cards_without_key_uses_default_headers():


### PR DESCRIPTION
## Summary
- fetch RapidAPI card search pages until 100 results or exhaustion while deduplicating and tracking totals
- page card search responses locally in the API endpoint using the aggregated list and consistent total counts
- update unit tests to cover multi-page aggregation and local pagination behaviour

## Testing
- pytest tests/test_tcg_api.py
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68de1a79d4dc832f9473b800f5c363be