### PR TITLE
Add numeric pagination controls to add card search

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -949,6 +949,7 @@
     const paginationStatus = pagination?.querySelector("[data-page-status]");
     const paginationPrev = pagination?.querySelector("[data-page-action='prev']");
     const paginationNext = pagination?.querySelector("[data-page-action='next']");
+    const paginationIndexList = document.querySelector("[data-page-index-list]");
     let latestItems = [];
     let latestTotalCount = 0;
     let latestQuery = "";
@@ -997,28 +998,69 @@
       }
     };
 
+    const renderPageIndexButtons = (totalPages) => {
+      if (!paginationIndexList) return;
+      if (!Number.isFinite(totalPages) || totalPages <= 1) {
+        paginationIndexList.hidden = true;
+        paginationIndexList.innerHTML = "";
+        return;
+      }
+      const maxPagesToRender = Math.min(totalPages, 5);
+      const fragment = document.createDocumentFragment();
+      for (let page = 1; page <= maxPagesToRender; page += 1) {
+        const item = document.createElement("li");
+        const button = document.createElement("button");
+        button.type = "button";
+        button.textContent = String(page);
+        button.dataset.pageIndex = String(page);
+        const isCurrent = page === latestPage;
+        button.disabled = isCurrent;
+        button.classList.toggle("is-active", isCurrent);
+        button.setAttribute("aria-label", `Przejdź do strony ${page}`);
+        if (isCurrent) {
+          button.setAttribute("aria-current", "page");
+        } else {
+          button.removeAttribute("aria-current");
+        }
+        item.appendChild(button);
+        fragment.appendChild(item);
+      }
+      paginationIndexList.innerHTML = "";
+      paginationIndexList.appendChild(fragment);
+      paginationIndexList.hidden = false;
+    };
+
     const updatePaginationControls = () => {
-      if (!pagination) return;
+      if (!pagination && !paginationIndexList) return;
       const totalAvailable = latestTotalCount > 0 ? latestTotalCount : latestItems.length;
       if (!latestItems.length || !totalAvailable) {
-        pagination.hidden = true;
-        if (paginationStatus) paginationStatus.textContent = "";
-        if (paginationPrev) paginationPrev.disabled = true;
-        if (paginationNext) paginationNext.disabled = true;
+        if (pagination) {
+          pagination.hidden = true;
+          if (paginationStatus) paginationStatus.textContent = "";
+          if (paginationPrev) paginationPrev.disabled = true;
+          if (paginationNext) paginationNext.disabled = true;
+        }
+        if (paginationIndexList) {
+          paginationIndexList.hidden = true;
+          paginationIndexList.innerHTML = "";
+        }
         return;
       }
       const perPage = latestPerPage > 0 ? latestPerPage : latestItems.length;
       const totalPages = Math.max(1, Math.ceil(totalAvailable / perPage));
-      pagination.hidden = totalPages <= 1 && latestPage <= 1;
-      if (paginationStatus) {
-        paginationStatus.textContent = `Strona ${latestPage} z ${totalPages}`;
+      if (pagination) {
+        pagination.hidden = totalPages <= 1 && latestPage <= 1;
+        if (paginationStatus) {
+          paginationStatus.textContent = `Strona ${latestPage} z ${totalPages}`;
+        }
+        if (paginationPrev) {
+          paginationPrev.disabled = latestPage <= 1;
+        }
+        if (paginationNext) {
+          paginationNext.disabled = latestPage >= totalPages;
+        }
       }
-      if (paginationPrev) {
-        paginationPrev.disabled = latestPage <= 1;
-      }
-      if (paginationNext) {
-        paginationNext.disabled = latestPage >= totalPages;
-      }
+      renderPageIndexButtons(totalPages);
     };
 
     const renderLatestResults = () => {
@@ -1107,6 +1149,20 @@
         isFetching = false;
       }
     };
+
+    if (paginationIndexList) {
+      paginationIndexList.addEventListener("click", async (event) => {
+        if (isFetching) return;
+        const target = event.target instanceof Element
+          ? event.target.closest("[data-page-index]")
+          : null;
+        if (!target || !(target instanceof HTMLElement)) return;
+        if (target.hasAttribute("disabled")) return;
+        const page = toPositiveInteger(target.dataset.pageIndex, 0);
+        if (!page || page === latestPage) return;
+        await fetchResults({ page, message: `Ładuję stronę ${page}…` });
+      });
+    }
 
     form.addEventListener("submit", async (event) => {
       event.preventDefault();

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -72,6 +72,12 @@
     role="list"
     data-view-mode="grid"
   ></div>
+  <ul
+    class="pagination pagination-pages"
+    data-page-index-list
+    hidden
+    aria-label="Przejdź do wybranej strony wyników"
+  ></ul>
   <p id="card-search-empty" class="empty-state" hidden aria-live="polite"></p>
 </section>
 {% endblock %}

--- a/tests/QA_CHECKLIST.md
+++ b/tests/QA_CHECKLIST.md
@@ -1,3 +1,4 @@
 # Manual QA Checklist
 
 - [ ] **Header visibility:** Open the web dashboard in a desktop browser, scroll downward until the content moves past the hero section and confirm the sticky header hides. Scroll up or return to the top and verify the header smoothly reappears. Refresh the page or resize the browser window and confirm the header is visible again before scrolling.
+- [ ] **Add card pagination buttons:** Na stronie dodawania kart wykonaj wyszukiwanie zwracające więcej niż 20 wyników i upewnij się, że poniżej listy kart pojawiają się numery stron 1–5, bieżąca strona jest wyróżniona/nieaktywna, a kliknięcie innego numeru przełącza wyniki oraz aktualizuje przyciski poprzednia/następna. Wyszukaj zapytanie z pojedynczą stroną wyników i sprawdź, że listwa z numerami znika.


### PR DESCRIPTION
## Summary
- add a dedicated pagination list below the add-card search results template
- render numeric page buttons tied to latest search metadata and keep prev/next controls in sync
- document manual QA covering pagination button visibility and behaviour

## Testing
- pytest tests/test_frontend_theme.py

------
https://chatgpt.com/codex/tasks/task_e_68de1c840908832fa4de7b5861868bd7