### PR TITLE
Adjust list view card search layout

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -798,6 +798,7 @@
     totalCount = 0,
     page = 1,
     perPage = 20,
+    viewMode = "grid",
   ) => {
     const container = document.getElementById("card-search-results");
     if (!container) return;
@@ -828,6 +829,7 @@
       const safeEnd = Math.max(safeStart, endIndex);
       summaryElement.textContent = `Znaleziono ${effectiveTotal} wyników. Wyświetlam ${safeStart}–${safeEnd}. Strona ${normalizedPage} z ${totalPages}.`;
     }
+    const isListView = viewMode === "list";
     for (const item of items) {
       const article = document.createElement("article");
       article.className = "card-search-item";
@@ -841,96 +843,163 @@
       const quickAddLabel = `Dodaj kartę ${cardName} do kolekcji`;
       const priceValue = getCardPriceValue(item);
       const priceText = priceValue === null ? "" : formatCardPrice(priceValue);
-      article.innerHTML = `
-        <div class="card-search-media">
-          <div class="card-search-thumbnail">
-            ${
-              hasThumbnail
-                ? `<img src="${escapeHtml(item.image_small)}" alt="${escapeHtml(cardAlt)}" loading="lazy" decoding="async" data-card-thumbnail />`
-                : ""
-            }
-            <div class="card-search-thumbnail-fallback"${hasThumbnail ? " hidden" : ""} data-card-thumbnail-fallback>
-              Brak miniatury
-            </div>
-            <button
-              type="button"
-              class="card-quick-add"
-              data-card-quick-add
-              aria-label="${escapeHtml(quickAddLabel)}"
-              title="Dodaj do kolekcji"
-            >
-              <span aria-hidden="true">+</span>
-            </button>
-          </div>
-          <div class="card-search-set">
-            <div class="card-search-set-icon">
+      const rarityText = (item.rarity || "").trim() || "Brak danych";
+      if (isListView) {
+        article.innerHTML = `
+          <div class="card-search-info">
+            <h3>${escapeHtml(cardName)}</h3>
+            <div class="card-search-inline-fields">
+              <span class="card-search-inline-field">
+                <span class="card-search-inline-label">Numer</span>
+                <span class="card-search-inline-value">${escapeHtml(numberLabel)}</span>
+              </span>
+              <span class="card-search-inline-field">
+                <span class="card-search-inline-label">Dodatek</span>
+                <span class="card-search-inline-value">${escapeHtml(setName)}</span>
+              </span>
+              <span class="card-search-inline-field">
+                <span class="card-search-inline-label">Rzadkość</span>
+                <span class="card-search-inline-value">${escapeHtml(rarityText)}</span>
+              </span>
               ${
-                hasSetIcon
-                  ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+                priceText
+                  ? `<span class="card-search-inline-field">
+                      <span class="card-search-inline-label">Cena</span>
+                      <span class="card-search-inline-value" data-card-price>${escapeHtml(priceText)}</span>
+                    </span>`
                   : ""
               }
-              <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
-            </div>
-            <div class="card-search-set-text">
-              <span class="card-search-set-label">Dodatek</span>
-              <span class="card-search-set-value">${escapeHtml(setName)}</span>
             </div>
           </div>
-        </div>
-        <div class="card-search-info">
-          <h3>${escapeHtml(cardName)}</h3>
-          <p>${escapeHtml(setName)}</p>
-          <p class="card-search-meta">${escapeHtml(numberLabel)}</p>
-          ${
-            priceText
-              ? `<p class="card-search-price" data-card-price>Cena: ${escapeHtml(priceText)}</p>`
-              : ""
-          }
-        </div>
-        <form class="card-search-form" data-card-form>
-          <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
-          <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
-          <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
-          <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
-          <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
-          <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
-          <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
-          <label>
-            Ilość
-            <input type="number" name="quantity" min="0" step="1" value="1" />
-          </label>
-          <label>
-            Cena zakupu
-            <input type="number" name="purchase_price" min="0" step="0.01" inputmode="decimal" placeholder="0.00" />
-          </label>
-          <label class="checkbox">
-            <input type="checkbox" name="is_reverse" /> Reverse
-          </label>
-          <label class="checkbox">
-            <input type="checkbox" name="is_holo" /> Holo
-          </label>
-          <div class="form-footer">
-            <button type="submit" class="button primary">Dodaj do kolekcji</button>
+          <form class="card-search-form" data-card-form>
+            <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
+            <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
+            <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
+            <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
+            <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
+            <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
+            <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
+            <label>
+              Ilość
+              <input type="number" name="quantity" min="0" step="1" value="1" />
+            </label>
+            <label>
+              Cena zakupu
+              <input type="number" name="purchase_price" min="0" step="0.01" inputmode="decimal" placeholder="0.00" />
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="is_reverse" /> Reverse
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="is_holo" /> Holo
+            </label>
+            <div class="form-footer">
+              <button
+                type="submit"
+                class="card-quick-add"
+                data-card-quick-add
+                aria-label="${escapeHtml(quickAddLabel)}"
+                title="Dodaj do kolekcji"
+              >
+                <span aria-hidden="true">+</span>
+              </button>
+            </div>
+          </form>
+        `;
+      } else {
+        article.innerHTML = `
+          <div class="card-search-media">
+            <div class="card-search-thumbnail">
+              ${
+                hasThumbnail
+                  ? `<img src="${escapeHtml(item.image_small)}" alt="${escapeHtml(cardAlt)}" loading="lazy" decoding="async" data-card-thumbnail />`
+                  : ""
+              }
+              <div class="card-search-thumbnail-fallback"${hasThumbnail ? " hidden" : ""} data-card-thumbnail-fallback>
+                Brak miniatury
+              </div>
+              <button
+                type="button"
+                class="card-quick-add"
+                data-card-quick-add
+                aria-label="${escapeHtml(quickAddLabel)}"
+                title="Dodaj do kolekcji"
+              >
+                <span aria-hidden="true">+</span>
+              </button>
+            </div>
+            <div class="card-search-set">
+              <div class="card-search-set-icon">
+                ${
+                  hasSetIcon
+                    ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+                    : ""
+                }
+                <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
+              </div>
+              <div class="card-search-set-text">
+                <span class="card-search-set-label">Dodatek</span>
+                <span class="card-search-set-value">${escapeHtml(setName)}</span>
+              </div>
+            </div>
           </div>
-        </form>
-      `;
-      const thumbnail = article.querySelector("[data-card-thumbnail]");
-      const thumbnailFallback = article.querySelector("[data-card-thumbnail-fallback]");
-      if (thumbnail && thumbnailFallback) {
-        const handleThumbnailError = () => {
-          thumbnail.remove();
-          thumbnailFallback.hidden = false;
-        };
-        thumbnail.addEventListener("error", handleThumbnailError, { once: true });
+          <div class="card-search-info">
+            <h3>${escapeHtml(cardName)}</h3>
+            <p>${escapeHtml(setName)}</p>
+            <p class="card-search-meta">${escapeHtml(numberLabel)}</p>
+            ${
+              priceText
+                ? `<p class="card-search-price" data-card-price>Cena: ${escapeHtml(priceText)}</p>`
+                : ""
+            }
+          </div>
+          <form class="card-search-form" data-card-form>
+            <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
+            <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
+            <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
+            <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
+            <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
+            <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
+            <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
+            <label>
+              Ilość
+              <input type="number" name="quantity" min="0" step="1" value="1" />
+            </label>
+            <label>
+              Cena zakupu
+              <input type="number" name="purchase_price" min="0" step="0.01" inputmode="decimal" placeholder="0.00" />
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="is_reverse" /> Reverse
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="is_holo" /> Holo
+            </label>
+            <div class="form-footer">
+              <button type="submit" class="button primary">Dodaj do kolekcji</button>
+            </div>
+          </form>
+        `;
       }
-      const setIcon = article.querySelector("[data-card-set-icon]");
-      const setIconFallback = article.querySelector("[data-card-set-icon-fallback]");
-      if (setIcon && setIconFallback) {
-        const handleSetIconError = () => {
-          setIcon.remove();
-          setIconFallback.hidden = false;
-        };
-        setIcon.addEventListener("error", handleSetIconError, { once: true });
+      if (!isListView) {
+        const thumbnail = article.querySelector("[data-card-thumbnail]");
+        const thumbnailFallback = article.querySelector("[data-card-thumbnail-fallback]");
+        if (thumbnail && thumbnailFallback) {
+          const handleThumbnailError = () => {
+            thumbnail.remove();
+            thumbnailFallback.hidden = false;
+          };
+          thumbnail.addEventListener("error", handleThumbnailError, { once: true });
+        }
+        const setIcon = article.querySelector("[data-card-set-icon]");
+        const setIconFallback = article.querySelector("[data-card-set-icon-fallback]");
+        if (setIcon && setIconFallback) {
+          const handleSetIconError = () => {
+            setIcon.remove();
+            setIconFallback.hidden = false;
+          };
+          setIcon.addEventListener("error", handleSetIconError, { once: true });
+        }
       }
       container.appendChild(article);
     }
@@ -1072,6 +1141,7 @@
         latestTotalCount,
         latestPage,
         latestPerPage,
+        currentCardViewMode,
       );
       applyViewMode(currentCardViewMode, { persist: false });
       updatePaginationControls();
@@ -1091,6 +1161,7 @@
     viewButtons.forEach((button) => {
       button.addEventListener("click", () => {
         applyViewMode(button.dataset.cardView || "list");
+        renderLatestResults();
       });
     });
 

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -652,18 +652,8 @@ img {
   display: grid;
   gap: 20px;
   padding: 20px;
-  grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
-  grid-template-areas:
-    "media info"
-    "form form";
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
   align-items: start;
-}
-
-.card-search-results--list .card-search-media {
-  grid-area: media;
-  display: grid;
-  gap: 12px;
-  align-content: start;
 }
 
 .card-search-results--grid .card-search-media {
@@ -809,6 +799,10 @@ img {
   gap: 8px;
 }
 
+.card-search-results--list .card-search-info {
+  gap: 12px;
+}
+
 .card-search-results--grid .card-search-info {
   gap: 6px;
 }
@@ -823,6 +817,34 @@ img {
   font-size: 0.9rem;
 }
 
+.card-search-inline-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px 24px;
+  align-items: start;
+}
+
+.card-search-inline-field {
+  display: grid;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  min-width: 0;
+}
+
+.card-search-inline-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.card-search-inline-value {
+  font-weight: 600;
+  color: var(--color-text);
+  overflow-wrap: anywhere;
+}
+
 .card-search-meta {
   margin-top: 4px;
   font-size: 0.85rem;
@@ -834,10 +856,9 @@ img {
 }
 
 .card-search-results--list .card-search-form {
-  grid-area: form;
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   align-items: end;
 }
 
@@ -853,6 +874,18 @@ img {
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
+}
+
+.card-search-results--list .card-search-form .form-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.card-search-results--list .card-quick-add {
+  display: inline-flex;
+  margin-left: auto;
 }
 
 
@@ -884,17 +917,17 @@ img {
 @media (max-width: 720px) {
   .card-search-results--list .card-search-item {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "media"
-      "info"
-      "form";
   }
 
-  .card-search-results--list .card-search-media {
+  .card-search-inline-fields {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .card-search-results--list .card-search-set {
+  .card-search-results--list .card-search-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .card-search-results--list .card-search-form .form-footer {
     justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- update card search rendering to tailor markup for list and grid layouts
- replace the list view call-to-action with the quick add button while keeping hidden form inputs
- refresh list view styles to align inline metadata and quick add placement without thumbnails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de2180eef8832fb06f225d39a21c26