### PR TITLE
Add rarity symbol support to card search UI

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -378,6 +378,27 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         or card.get("set_logo")
     )
 
+    rarity_symbol = (
+        card.get("rarity_symbol")
+        or card.get("raritySymbol")
+        or card.get("rarity_icon")
+        or card.get("rarityIcon")
+        or episode.get("rarity_symbol")
+        or episode.get("raritySymbol")
+    )
+    if isinstance(rarity_symbol, dict):
+        symbol_value = None
+        for key in ("url", "image", "icon", "src", "default"):
+            value = rarity_symbol.get(key)
+            if isinstance(value, str) and value.strip():
+                symbol_value = value.strip()
+                break
+        rarity_symbol = symbol_value
+    if isinstance(rarity_symbol, str):
+        rarity_symbol = rarity_symbol.strip() or None
+    else:
+        rarity_symbol = None
+
     image_small, image_large = _extract_images(card)
     price_eur = _extract_card_price(card)
     price_pln = None
@@ -400,6 +421,7 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         "series": series,
         "release_date": release_date,
         "set_icon": set_icon,
+        "rarity_symbol": rarity_symbol,
         "price": price_pln,
     }
 

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -843,7 +843,18 @@
       const quickAddLabel = `Dodaj kartę ${cardName} do kolekcji`;
       const priceValue = getCardPriceValue(item);
       const priceText = priceValue === null ? "" : formatCardPrice(priceValue);
-      const rarityText = (item.rarity || "").trim() || "Brak danych";
+      const rarityRaw = (item.rarity || "").trim();
+      const rarityText = rarityRaw || "Brak danych";
+      const raritySymbol = (item.rarity_symbol || "").trim();
+      const hasRaritySymbol = Boolean(raritySymbol);
+      const raritySymbolIsImage =
+        hasRaritySymbol && (
+          /^(data:|https?:|\/\/)/i.test(raritySymbol)
+          || raritySymbol.startsWith("/")
+          || /\.(svg|png|webp|jpe?g|gif)$/i.test(raritySymbol)
+        );
+      const rarityAlt = `Symbol rzadkości ${rarityText}`;
+      const rarityFallback = rarityRaw ? rarityRaw.charAt(0).toUpperCase() : "?";
       if (isListView) {
         article.innerHTML = `
           <div class="card-search-info">
@@ -928,23 +939,29 @@
                 <span aria-hidden="true">+</span>
               </button>
             </div>
-            <div class="card-search-set">
-              <div class="card-search-set-icon">
-                ${
-                  hasSetIcon
-                    ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+          <div class="card-search-set">
+            <div class="card-search-set-icon">
+              ${
+                hasSetIcon
+                  ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+                  : ""
+              }
+              <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
+            </div>
+            <div class="card-search-rarity-icon">
+              ${
+                raritySymbolIsImage
+                  ? `<img src="${escapeHtml(raritySymbol)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
+                  : hasRaritySymbol
+                    ? `<span class="card-search-rarity-symbol" role="img" aria-label="${escapeHtml(rarityAlt)}" data-card-rarity-symbol data-symbol-class="${escapeHtml(raritySymbol)}"></span>`
                     : ""
-                }
-                <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
-              </div>
-              <div class="card-search-set-text">
-                <span class="card-search-set-label">Dodatek</span>
-                <span class="card-search-set-value">${escapeHtml(setName)}</span>
-              </div>
+              }
+              <span class="card-search-rarity-icon-fallback"${hasRaritySymbol ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
             </div>
           </div>
-          <div class="card-search-info">
-            <h3>${escapeHtml(cardName)}</h3>
+        </div>
+        <div class="card-search-info">
+          <h3>${escapeHtml(cardName)}</h3>
             <p>${escapeHtml(setName)}</p>
             <p class="card-search-meta">${escapeHtml(numberLabel)}</p>
             ${
@@ -999,6 +1016,28 @@
             setIconFallback.hidden = false;
           };
           setIcon.addEventListener("error", handleSetIconError, { once: true });
+        }
+        const rarityIcon = article.querySelector("[data-card-rarity-icon]");
+        const rarityIconFallback = article.querySelector("[data-card-rarity-icon-fallback]");
+        if (rarityIcon && rarityIconFallback) {
+          const handleRarityIconError = () => {
+            rarityIcon.remove();
+            rarityIconFallback.hidden = false;
+          };
+          rarityIcon.addEventListener("error", handleRarityIconError, { once: true });
+        }
+        const raritySymbolElement = article.querySelector("[data-card-rarity-symbol]");
+        if (raritySymbolElement) {
+          const symbolClass = (raritySymbolElement.dataset.symbolClass || "").trim();
+          if (symbolClass) {
+            symbolClass
+              .split(/\s+/)
+              .map((token) => token.trim())
+              .filter(Boolean)
+              .forEach((token) => {
+                raritySymbolElement.classList.add(token);
+              });
+          }
         }
       }
       container.appendChild(article);

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -742,17 +742,18 @@ img {
 .card-search-set {
   display: flex;
   align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding: 10px 12px;
+  justify-content: center;
+  gap: 10px;
+  padding: 8px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
 }
 
-.card-search-set-icon {
-  width: 48px;
-  height: 48px;
+.card-search-set-icon,
+.card-search-rarity-icon {
+  width: 40px;
+  height: 40px;
   border-radius: var(--radius-sm);
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
@@ -760,36 +761,40 @@ img {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
-.card-search-set-icon img {
+.card-search-set-icon img,
+.card-search-rarity-icon img {
   width: 100%;
   height: 100%;
   object-fit: contain;
 }
 
-.card-search-set-icon-fallback {
+.card-search-set-icon-fallback,
+.card-search-rarity-icon-fallback {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.85rem;
   color: var(--color-muted);
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card-search-rarity-icon {
+  position: relative;
+}
+
+.card-search-rarity-symbol {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
 }
 
 .card-search-results--grid .card-search-set {
-  padding: 8px 10px;
-}
-
-.card-search-set-text {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.card-search-set-label {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-muted);
+  padding: 6px 10px;
 }
 
 .card-search-info {
@@ -888,11 +893,6 @@ img {
   margin-left: auto;
 }
 
-
-.card-search-set-value {
-  font-weight: 600;
-  font-size: 0.95rem;
-}
 
 @media (max-width: 860px) {
   .card-search-toolbar {

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -345,6 +345,20 @@ def test_build_card_payload_skips_price_when_rate_unavailable(monkeypatch):
     assert payload["price"] is None
 
 
+def test_build_card_payload_includes_rarity_symbol():
+    card = {
+        "name": "Pikachu",
+        "number": "58/102",
+        "set": {"name": "Base Set"},
+        "raritySymbol": "https://example.com/rarity.svg",
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert payload["rarity_symbol"] == "https://example.com/rarity.svg"
+
+
 def test_build_cards_endpoint_supports_nested_paths():
     url = tcg_api._build_cards_endpoint(
         "https://pokemon-tcg-api.p.rapidapi.com",


### PR DESCRIPTION
## Summary
- extend the TCG card payload to surface rarity symbol information
- render set and rarity icons side by side in card search results
- tweak styling for the compact icon row and cover the new field with a test

## Testing
- pytest tests/test_tcg_api.py::test_build_card_payload_includes_rarity_symbol

------
https://chatgpt.com/codex/tasks/task_e_68de23696b08832fa71bd952df49b04a