### PR TITLE
Fix quick add handling in card search

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1370,7 +1370,8 @@
           ? event.target.closest("[data-card-quick-add]")
           : null;
         if (!button) return;
-        const formTarget = button.closest("form[data-card-form]");
+        const formTarget = button.closest("form[data-card-form]")
+          || button.closest(".card-search-item")?.querySelector("form[data-card-form]");
         if (!(formTarget instanceof HTMLFormElement)) return;
         event.preventDefault();
         await handleCardFormSubmission(formTarget, button);


### PR DESCRIPTION
## Summary
- ensure quick-add buttons locate their associated card form before submitting so grid quick-add works

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68de2921bd44832f9cfd8ee0e22aecc6