### PR TITLE
Revamp list search layout for card results

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -856,66 +856,61 @@
       const rarityAlt = `Symbol rzadkości ${rarityText}`;
       const rarityFallback = rarityRaw ? rarityRaw.charAt(0).toUpperCase() : "?";
       if (isListView) {
+        const previewImage = item.image_large || item.image_small || "";
+        const hasPreviewImage = Boolean(previewImage);
+        const fallbackInitial = escapeHtml(cardName.charAt(0) || "?");
         article.innerHTML = `
-          <div class="card-search-info">
-            <h3>${escapeHtml(cardName)}</h3>
-            <div class="card-search-inline-fields">
-              <span class="card-search-inline-field">
-                <span class="card-search-inline-label">Numer</span>
-                <span class="card-search-inline-value">${escapeHtml(numberLabel)}</span>
-              </span>
-              <span class="card-search-inline-field">
-                <span class="card-search-inline-label">Dodatek</span>
-                <span class="card-search-inline-value">${escapeHtml(setName)}</span>
-              </span>
-              <span class="card-search-inline-field">
-                <span class="card-search-inline-label">Rzadkość</span>
-                <span class="card-search-inline-value">${escapeHtml(rarityText)}</span>
-              </span>
+          <div class="card-search-list-row">
+            <div class="card-search-list-thumb" ${hasPreviewImage ? "data-has-preview=\"true\"" : ""}>
               ${
-                priceText
-                  ? `<span class="card-search-inline-field">
-                      <span class="card-search-inline-label">Cena</span>
-                      <span class="card-search-inline-value" data-card-price>${escapeHtml(priceText)}</span>
-                    </span>`
+                hasThumbnail
+                  ? `<img src="${escapeHtml(item.image_small)}" alt="${escapeHtml(cardAlt)}" loading="lazy" />`
+                  : hasSetIcon
+                    ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" />`
+                    : `<span class="card-search-list-thumb-fallback" aria-hidden="true">${fallbackInitial}</span>`
+              }
+              ${
+                hasPreviewImage
+                  ? `<img class="card-search-list-preview" src="${escapeHtml(previewImage)}" alt="${escapeHtml(cardAlt)}" loading="lazy" />`
                   : ""
               }
             </div>
-          </div>
-          <form class="card-search-form" data-card-form>
-            <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
-            <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
-            <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
-            <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
-            <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
-            <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
-            <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
-            <label>
-              Ilość
-              <input type="number" name="quantity" min="0" step="1" value="1" />
-            </label>
-            <label>
-              Cena zakupu
-              <input type="number" name="purchase_price" min="0" step="0.01" inputmode="decimal" placeholder="0.00" />
-            </label>
-            <label class="checkbox">
-              <input type="checkbox" name="is_reverse" /> Reverse
-            </label>
-            <label class="checkbox">
-              <input type="checkbox" name="is_holo" /> Holo
-            </label>
-            <div class="form-footer">
-              <button
-                type="submit"
-                class="card-quick-add"
-                data-card-quick-add
-                aria-label="${escapeHtml(quickAddLabel)}"
-                title="Dodaj do kolekcji"
-              >
-                <span aria-hidden="true">+</span>
-              </button>
+            <div class="card-search-list-main">
+              <h3 class="card-search-list-title">${escapeHtml(cardName)}</h3>
+              <div class="card-search-list-meta">
+                <span class="card-search-list-meta-item card-search-list-set">${escapeHtml(setName)}</span>
+                <span class="card-search-list-meta-divider" aria-hidden="true">•</span>
+                <span class="card-search-list-meta-item card-search-list-number">${escapeHtml(numberLabel)}</span>
+                ${
+                  priceText
+                    ? `<span class="card-search-list-meta-divider" aria-hidden="true">•</span>
+                       <span class="card-search-list-meta-item card-search-list-price" data-card-price>${escapeHtml(priceText)}</span>`
+                    : ""
+                }
+              </div>
             </div>
-          </form>
+            <form class="card-search-form" data-card-form>
+              <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
+              <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
+              <input type="hidden" name="card_set_name" value="${escapeHtml(item.set_name)}" />
+              <input type="hidden" name="card_set_code" value="${escapeHtml(item.set_code || "")}" />
+              <input type="hidden" name="card_rarity" value="${escapeHtml(item.rarity || "")}" />
+              <input type="hidden" name="card_image_small" value="${escapeHtml(item.image_small || "")}" />
+              <input type="hidden" name="card_image_large" value="${escapeHtml(item.image_large || "")}" />
+              <input type="hidden" name="quantity" value="1" />
+              <div class="form-footer">
+                <button
+                  type="submit"
+                  class="card-quick-add"
+                  data-card-quick-add
+                  aria-label="${escapeHtml(quickAddLabel)}"
+                  title="Dodaj do kolekcji"
+                >
+                  <span aria-hidden="true">+</span>
+                </button>
+              </div>
+            </form>
+          </div>
         `;
       } else {
         article.innerHTML = `

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -692,10 +692,129 @@ img {
 
 .card-search-results--list .card-search-item {
   display: grid;
-  gap: 20px;
-  padding: 20px;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
-  align-items: start;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 18px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card-search-results--list .card-search-item:hover,
+.card-search-results--list .card-search-item:focus-within {
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-1px);
+}
+
+.card-search-list-row {
+  display: contents;
+}
+
+.card-search-list-thumb {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, var(--color-background-alt), var(--color-surface));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-search-list-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-search-list-thumb-fallback {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.card-search-list-thumb[data-has-preview="true"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  pointer-events: none;
+}
+
+.card-search-list-preview {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12px);
+  width: 160px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
+  background: var(--color-surface);
+  transform: translateY(-50%) scale(0.96);
+  transform-origin: left center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.card-search-list-thumb:hover .card-search-list-preview,
+.card-search-list-thumb:focus-within .card-search-list-preview {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+.card-search-list-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.card-search-list-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-search-list-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.card-search-list-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.card-search-list-meta-divider {
+  color: rgba(107, 114, 128, 0.5);
+}
+
+.card-search-results--list .card-search-form {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.card-search-results--list .card-search-form .form-footer {
+  margin-left: 12px;
 }
 
 .card-search-results--grid .card-search-media {
@@ -902,37 +1021,8 @@ img {
   display: none;
 }
 
-.card-search-results--list .card-search-form {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  align-items: end;
-}
-
-.card-search-results--list .card-search-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.9rem;
-}
-
-.card-search-results--list .card-search-form input[type="number"] {
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-}
-
-.card-search-results--list .card-search-form .form-footer {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-}
-
 .card-search-results--list .card-quick-add {
   display: inline-flex;
-  margin-left: auto;
 }
 
 
@@ -959,6 +1049,7 @@ img {
 @media (max-width: 720px) {
   .card-search-results--list .card-search-item {
     grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
   }
 
   .card-search-inline-fields {
@@ -966,11 +1057,11 @@ img {
   }
 
   .card-search-results--list .card-search-form {
-    grid-template-columns: minmax(0, 1fr);
+    justify-content: flex-start;
   }
 
   .card-search-results--list .card-search-form .form-footer {
-    justify-content: flex-start;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the list-mode card search results to render compact rows with inline metadata and a hoverable preview thumbnail
- simplify the quick-add form to only submit default quantity while preserving hidden card payload fields
- extend list-view styling to support the new row layout, hover effects, and preview tooltip behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de29f0ac94832fab6f49218cc8d88c