### PR TITLE
Refine list-view card search thumbnails

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -858,20 +858,28 @@
       if (isListView) {
         const previewImage = item.image_large || item.image_small || "";
         const hasPreviewImage = Boolean(previewImage);
-        const fallbackInitial = escapeHtml(cardName.charAt(0) || "?");
+        const thumbAttributeParts = [];
+        if (hasPreviewImage) {
+          thumbAttributeParts.push("data-has-preview=\"true\"");
+          thumbAttributeParts.push("tabindex=\"0\"");
+          thumbAttributeParts.push(`aria-label=\"Podgląd karty ${escapeHtml(cardName)}\"`);
+        }
+        const thumbAttributes = thumbAttributeParts.length
+          ? ` ${thumbAttributeParts.join(" ")}`
+          : "";
         article.innerHTML = `
           <div class="card-search-list-row">
-            <div class="card-search-list-thumb" ${hasPreviewImage ? "data-has-preview=\"true\"" : ""}>
-              ${
-                hasThumbnail
-                  ? `<img src="${escapeHtml(item.image_small)}" alt="${escapeHtml(cardAlt)}" loading="lazy" />`
-                  : hasSetIcon
-                    ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" />`
-                    : `<span class="card-search-list-thumb-fallback" aria-hidden="true">${fallbackInitial}</span>`
-              }
+            <div class="card-search-list-thumb"${thumbAttributes}>
+              <svg class="card-search-list-icon" viewBox="0 0 48 48" role="img" aria-hidden="true">
+                <rect class="card-search-list-icon-frame" x="5" y="6" width="38" height="36" rx="6" />
+                <rect class="card-search-list-icon-stripe" x="11" y="14" width="26" height="6" rx="3" />
+                <rect class="card-search-list-icon-stripe" x="11" y="24" width="20" height="6" rx="3" />
+              </svg>
               ${
                 hasPreviewImage
-                  ? `<img class="card-search-list-preview" src="${escapeHtml(previewImage)}" alt="${escapeHtml(cardAlt)}" loading="lazy" />`
+                  ? `<div class="card-search-list-preview" role="presentation">
+                      <img src="${escapeHtml(previewImage)}" alt="${escapeHtml(cardAlt)}" loading="lazy" />
+                    </div>`
                   : ""
               }
             </div>

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -729,20 +729,16 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
+  overflow: visible;
 }
 
-.card-search-list-thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.card-search-list-thumb[data-has-preview="true"] {
+  cursor: pointer;
 }
 
-.card-search-list-thumb-fallback {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-muted);
-  text-transform: uppercase;
+.card-search-list-thumb[data-has-preview="true"]:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .card-search-list-thumb[data-has-preview="true"]::after {
@@ -752,6 +748,23 @@ img {
   border-radius: inherit;
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
   pointer-events: none;
+}
+
+.card-search-list-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--color-muted);
+}
+
+.card-search-list-icon-frame {
+  fill: rgba(148, 163, 184, 0.12);
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
+.card-search-list-icon-stripe {
+  fill: currentColor;
+  opacity: 0.32;
 }
 
 .card-search-list-preview {
@@ -766,15 +779,26 @@ img {
   transform: translateY(-50%) scale(0.96);
   transform-origin: left center;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
   z-index: 10;
 }
 
+.card-search-list-preview img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: calc(var(--radius-sm) - 4px);
+}
+
 .card-search-list-thumb:hover .card-search-list-preview,
+.card-search-list-thumb:focus .card-search-list-preview,
+.card-search-list-thumb:focus-visible .card-search-list-preview,
 .card-search-list-thumb:focus-within .card-search-list-preview {
   opacity: 1;
   transform: translateY(-50%) scale(1);
+  visibility: visible;
 }
 
 .card-search-list-main {


### PR DESCRIPTION
## Summary
- render the list view thumbnail as a fixed inline SVG icon and move the real artwork into the preview tooltip
- restyle the card preview to animate on hover/focus and expose keyboard focus states for the hover target

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de2fb842a0832fbfeda7552fa7b169