### PR TITLE
Adjust card search list spacing

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -663,7 +663,7 @@ img {
 
 .card-search-results--list {
   display: grid;
-  gap: 16px;
+  gap: 0;
 }
 
 .card-search-results--grid {
@@ -701,10 +701,10 @@ img {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 18px;
-  padding: 14px 18px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  gap: 12px;
+  padding: 12px 18px;
+  background: none;
+  border: none;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
@@ -724,7 +724,6 @@ img {
   width: 52px;
   height: 52px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
   background: linear-gradient(135deg, var(--color-background-alt), var(--color-surface));
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove the extra spacing, border, and background from list view search rows so they sit flush while keeping padding for alignment
- drop the list view thumbnail border to keep the artwork aligned with the row

## Testing
- Manual verification: launched `uvicorn server:app` locally, authenticated, switched the add-card search to list view (RapidAPI card data unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de32a29218832fac4a1d011b14a149