### PR TITLE
Show set codes and update rarity icons in card search grid

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -791,6 +791,34 @@
     image_large: form.elements.card_image_large?.value?.trim() || null,
   });
 
+  const RARITY_SYMBOL_CLASS_RULES = [
+    { pattern: /(rainbow|hyper)/i, className: "rarity-symbol--rare-rainbow" },
+    { pattern: /(secret|gold)/i, className: "rarity-symbol--rare-secret" },
+    {
+      pattern: /(ultra|vmax|v-star|vstar|v-union|gx|ex|mega|prime|legend)/i,
+      className: "rarity-symbol--rare-ultra",
+    },
+    { pattern: /(shiny|shining|radiant)/i, className: "rarity-symbol--rare-shiny" },
+    { pattern: /promo/i, className: "rarity-symbol--promo" },
+    { pattern: /ace/i, className: "rarity-symbol--rare-ace" },
+    { pattern: /illustration rare/i, className: "rarity-symbol--rare-illustration" },
+    { pattern: /holo/i, className: "rarity-symbol--rare-holo" },
+    { pattern: /rare/i, className: "rarity-symbol--rare" },
+    { pattern: /uncommon/i, className: "rarity-symbol--uncommon" },
+    { pattern: /common/i, className: "rarity-symbol--common" },
+  ];
+
+  const resolveRaritySymbolClass = (rarity) => {
+    if (!rarity) return null;
+    const normalized = rarity.toLowerCase();
+    for (const rule of RARITY_SYMBOL_CLASS_RULES) {
+      if (rule.pattern.test(normalized)) {
+        return rule.className;
+      }
+    }
+    return null;
+  };
+
   const renderSearchResults = (
     items = [],
     summaryElement,
@@ -837,9 +865,7 @@
       const cardName = (item.name || "").trim() || "Bez nazwy";
       const setName = (item.set_name || "").trim() || "Nieznany dodatek";
       const hasThumbnail = Boolean(item.image_small);
-      const hasSetIcon = Boolean(item.set_icon);
       const cardAlt = `Miniatura karty ${cardName}`;
-      const setAlt = `Ikona dodatku ${setName}`;
       const quickAddLabel = `Dodaj kartę ${cardName} do kolekcji`;
       const priceValue = getCardPriceValue(item);
       const priceText = priceValue === null ? "" : formatCardPrice(priceValue);
@@ -853,6 +879,27 @@
           || raritySymbol.startsWith("/")
           || /\.(svg|png|webp|jpe?g|gif)$/i.test(raritySymbol)
         );
+      const setCodeRaw = (item.set_code || "").trim();
+      const setCodeText = setCodeRaw || "—";
+      const raritySymbolClassTokens = [];
+      if (hasRaritySymbol && !raritySymbolIsImage) {
+        raritySymbol
+          .split(/\s+/)
+          .map((token) => token.trim())
+          .filter(Boolean)
+          .forEach((token) => {
+            raritySymbolClassTokens.push(token);
+          });
+      }
+      if (!raritySymbolIsImage && raritySymbolClassTokens.length === 0) {
+        const fallbackClass = resolveRaritySymbolClass(rarityRaw);
+        if (fallbackClass) {
+          raritySymbolClassTokens.push(fallbackClass);
+        }
+      }
+      const raritySymbolClassAttr = raritySymbolClassTokens.join(" ");
+      const hasRarityClassSymbol = raritySymbolClassTokens.length > 0;
+      const hasRarityVisual = raritySymbolIsImage || hasRarityClassSymbol;
       const rarityAlt = `Symbol rzadkości ${rarityText}`;
       const rarityFallback = rarityRaw ? rarityRaw.charAt(0).toUpperCase() : "?";
       if (isListView) {
@@ -943,23 +990,16 @@
               </button>
             </div>
           <div class="card-search-set">
-            <div class="card-search-set-icon">
-              ${
-                hasSetIcon
-                  ? `<img src="${escapeHtml(item.set_icon)}" alt="${escapeHtml(setAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
-                  : ""
-              }
-              <span class="card-search-set-icon-fallback"${hasSetIcon ? " hidden" : ""} data-card-set-icon-fallback aria-hidden="true">?</span>
-            </div>
+            <span class="card-search-set-code" data-card-set-code>${escapeHtml(setCodeText)}</span>
             <div class="card-search-rarity-icon">
               ${
                 raritySymbolIsImage
                   ? `<img src="${escapeHtml(raritySymbol)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
-                  : hasRaritySymbol
-                    ? `<span class="card-search-rarity-symbol" role="img" aria-label="${escapeHtml(rarityAlt)}" data-card-rarity-symbol data-symbol-class="${escapeHtml(raritySymbol)}"></span>`
+                  : hasRarityClassSymbol
+                    ? `<span class="card-search-rarity-symbol" role="img" aria-label="${escapeHtml(rarityAlt)}" data-card-rarity-symbol data-symbol-class="${escapeHtml(raritySymbolClassAttr)}"></span>`
                     : ""
               }
-              <span class="card-search-rarity-icon-fallback"${hasRaritySymbol ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
+              <span class="card-search-rarity-icon-fallback"${hasRarityVisual ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
             </div>
           </div>
         </div>
@@ -1017,15 +1057,6 @@
             thumbnailFallback.hidden = false;
           };
           thumbnail.addEventListener("error", handleThumbnailError, { once: true });
-        }
-        const setIcon = article.querySelector("[data-card-set-icon]");
-        const setIconFallback = article.querySelector("[data-card-set-icon-fallback]");
-        if (setIcon && setIconFallback) {
-          const handleSetIconError = () => {
-            setIcon.remove();
-            setIconFallback.hidden = false;
-          };
-          setIcon.addEventListener("error", handleSetIconError, { once: true });
         }
         const rarityIcon = article.querySelector("[data-card-rarity-icon]");
         const rarityIconFallback = article.querySelector("[data-card-rarity-icon-fallback]");

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -933,55 +933,46 @@ img {
 .card-search-set {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: none;
 }
 
-.card-search-set-icon,
-.card-search-rarity-icon {
-  border-radius: var(--radius-sm);
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.card-search-set-icon {
-  width: 56px;
-  height: 56px;
-  padding: 6px;
-}
-
-.card-search-rarity-icon {
-  width: 44px;
-  height: 44px;
-}
-
-.card-search-set-icon img,
-.card-search-rarity-icon img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.card-search-set-icon-fallback,
-.card-search-rarity-icon-fallback {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--color-muted);
-  letter-spacing: 0.08em;
+.card-search-set-code {
+  font-weight: 700;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--color-muted-strong, var(--color-text));
+  white-space: nowrap;
+  line-height: 1;
 }
 
 .card-search-rarity-icon {
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+}
+
+.card-search-rarity-icon img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  display: block;
+}
+
+.card-search-rarity-icon-fallback {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .card-search-rarity-symbol {
@@ -993,8 +984,44 @@ img {
   background-size: contain;
 }
 
-.card-search-results--grid .card-search-set {
-  padding: 6px 10px;
+.card-search-rarity-symbol.rarity-symbol--common {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Ccircle%20cx='16'%20cy='16'%20r='12'%20fill='%231f2937'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--uncommon {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cpath%20d='M16%202l12%2014-12%2014-12-14z'%20fill='%230f766e'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='%23c08401'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-holo {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cdefs%3E%3ClinearGradient%20id='g'%20x1='0'%20y1='0'%20x2='1'%20y2='1'%3E%3Cstop%20offset='0'%20stop-color='%23fde68a'/%3E%3Cstop%20offset='1'%20stop-color='%23fbbf24'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='url(%23g)'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-ultra {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='%237c3aed'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-secret {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cdefs%3E%3ClinearGradient%20id='gs'%20x1='0'%20y1='0'%20x2='0'%20y2='1'%3E%3Cstop%20offset='0'%20stop-color='%23facc15'/%3E%3Cstop%20offset='1'%20stop-color='%23d97706'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='url(%23gs)'%20stroke='%23b45309'%20stroke-width='1.6'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-shiny {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cdefs%3E%3ClinearGradient%20id='sh'%20x1='0'%20y1='0'%20x2='1'%20y2='1'%3E%3Cstop%20offset='0'%20stop-color='%2367e8f9'/%3E%3Cstop%20offset='1'%20stop-color='%230ea5e9'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='url(%23sh)'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-ace {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='%23dc2626'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--rare-illustration {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cdefs%3E%3ClinearGradient%20id='ir'%20x1='0'%20y1='0'%20x2='1'%20y2='1'%3E%3Cstop%20offset='0'%20stop-color='%23f472b6'/%3E%3Cstop%20offset='1'%20stop-color='%239433c9'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='url(%23ir)'/%3E%3C/svg%3E");
+}
+
+.card-search-rarity-symbol.rarity-symbol--promo {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cpath%20d='M16%202l3.8%209.7%2010.2.3-8.1%206.5%202.9%209.5-8.8-5.5-8.8%205.5%202.9-9.5-8.1-6.5%2010.2-.3z'%20fill='%230b1120'/%3E%3C/svg%3E");
 }
 
 .card-search-info {


### PR DESCRIPTION
## Summary
- show the card set code in the grid result badge and fall back to rarity class mapping when an icon URL is unavailable
- restyle the set/rarity badge to sit inline with the grid metadata and add CSS-backed icons for common rarity categories

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de34a12750832f9810d84acafcf904