### PR TITLE
Add seven-day average price support

### DIFF
--- a/kartoteka_web/models.py
+++ b/kartoteka_web/models.py
@@ -37,6 +37,8 @@ class Card(SQLModel, table=True):
     rarity: Optional[str] = None
     image_small: Optional[str] = Field(default=None)
     image_large: Optional[str] = Field(default=None)
+    price: Optional[float] = Field(default=None)
+    price_7d_average: Optional[float] = Field(default=None)
 
     entries: List["CollectionEntry"] = Relationship(back_populates="card")
 
@@ -65,6 +67,8 @@ class CardRecord(SQLModel, table=True):
     image_small: Optional[str] = Field(default=None)
     image_large: Optional[str] = Field(default=None)
     set_icon: Optional[str] = Field(default=None)
+    price: Optional[float] = Field(default=None)
+    price_7d_average: Optional[float] = Field(default=None)
     created_at: dt.datetime = Field(
         default_factory=lambda: dt.datetime.now(dt.timezone.utc)
     )

--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -114,7 +114,8 @@ def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
         artist=None,
         series=None,
         release_date=None,
-        price=None,
+        price=card.price,
+        price_7d_average=card.price_7d_average,
     )
 
 
@@ -133,6 +134,8 @@ def _card_to_detail(card: models.Card) -> schemas.CardDetail:
         artist=None,
         series=None,
         release_date=None,
+        price=card.price,
+        price_7d_average=card.price_7d_average,
     )
 
 
@@ -303,6 +306,7 @@ def _payload_to_search_schema(payload: dict[str, Any]) -> schemas.CardSearchResu
         series=payload.get("series"),
         release_date=payload.get("release_date"),
         price=payload.get("price"),
+        price_7d_average=payload.get("price_7d_average"),
     )
 
 

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -69,6 +69,7 @@ class CardSearchResult(SQLModel):
     series: Optional[str] = None
     release_date: Optional[str] = None
     price: Optional[float] = None
+    price_7d_average: Optional[float] = None
 
 
 class CardSearchResponse(SQLModel):
@@ -94,6 +95,8 @@ class CardDetail(SQLModel):
     artist: Optional[str] = None
     series: Optional[str] = None
     release_date: Optional[str] = None
+    price: Optional[float] = None
+    price_7d_average: Optional[float] = None
 
 
 class CardDetailResponse(SQLModel):

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -18,6 +18,15 @@ RAPIDAPI_DEFAULT_HOST = "pokemon-tcg-api.p.rapidapi.com"
 _EUR_PLN_RATE_CACHE: dict[str, float | None] = {"value": None, "expires": 0.0}
 _EUR_PLN_RATE_TTL = 60 * 60  # 1 hour
 
+_SEVEN_DAY_AVERAGE_KEYS: tuple[str, ...] = (
+    "7d_average",
+    "avg7",
+    "avg_7",
+    "sevenDayAverage",
+    "seven_day_average",
+    "sevenDayAvg",
+)
+
 
 def get_eur_pln_rate(
     session: Optional[requests.sessions.Session] = None,
@@ -231,14 +240,54 @@ def _extract_generic_price(card: dict[str, Any]) -> Optional[float]:
     if isinstance(prices, dict):
         for value in prices.values():
             if isinstance(value, dict):
-                for nested in value.values():
-                    price = _normalize_price_value(nested)
+                for nested_key, nested_value in value.items():
+                    if nested_key in _SEVEN_DAY_AVERAGE_KEYS:
+                        continue
+                    price = _normalize_price_value(nested_value)
                     if price is not None:
                         return price
             else:
                 price = _normalize_price_value(value)
                 if price is not None:
                     return price
+    return None
+
+
+def _extract_nested_price(
+    data: Any, keys: tuple[str, ...],
+) -> Optional[float]:
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        price = _normalize_price_value(data.get(key))
+        if price is not None:
+            return price
+    for value in data.values():
+        if isinstance(value, dict):
+            price = _extract_nested_price(value, keys)
+            if price is not None:
+                return price
+    return None
+
+
+def _extract_7d_average_price(card: dict[str, Any]) -> Optional[float]:
+    prices = card.get("prices")
+    price = _extract_nested_price(prices, _SEVEN_DAY_AVERAGE_KEYS)
+    if price is not None:
+        return price
+
+    cardmarket = card.get("cardmarket") or card.get("cardMarket") or {}
+    if isinstance(cardmarket, dict):
+        price = _extract_nested_price(cardmarket.get("prices"), _SEVEN_DAY_AVERAGE_KEYS)
+        if price is not None:
+            return price
+
+    tcgplayer = card.get("tcgplayer") or card.get("tcgPlayer") or {}
+    if isinstance(tcgplayer, dict):
+        price = _extract_nested_price(tcgplayer.get("prices"), _SEVEN_DAY_AVERAGE_KEYS)
+        if price is not None:
+            return price
+
     return None
 
 
@@ -401,11 +450,19 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
 
     image_small, image_large = _extract_images(card)
     price_eur = _extract_card_price(card)
+    price_7d_average_eur = _extract_7d_average_price(card)
+
     price_pln = None
-    if price_eur is not None:
+    price_7d_average_pln = None
+    if price_eur is not None or price_7d_average_eur is not None:
         rate = get_eur_pln_rate()
-        if rate is not None:
+    else:
+        rate = None
+    if rate is not None:
+        if price_eur is not None:
             price_pln = round(price_eur * rate * 1.24, 2)
+        if price_7d_average_eur is not None:
+            price_7d_average_pln = round(price_7d_average_eur * rate * 1.24, 2)
 
     return {
         "name": card.get("name") or "",
@@ -423,6 +480,7 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         "set_icon": set_icon,
         "rarity_symbol": rarity_symbol,
         "price": price_pln,
+        "price_7d_average": price_7d_average_pln,
     }
 
 

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -237,6 +237,10 @@
 
   const getCardPriceValue = (item) => {
     if (!item) return null;
+    const average = normalizePriceInput(item.price_7d_average);
+    if (average !== null) {
+      return average;
+    }
     return normalizePriceInput(item.price);
   };
 

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -115,6 +115,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "series": "Base",
             "release_date": "1999/06/16",
             "price": 12.34,
+            "price_7d_average": 11.11,
         },
         {
             "name": "Eevee",
@@ -131,6 +132,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "series": "Base",
             "release_date": "1999/10/10",
             "price": 8.5,
+            "price_7d_average": 7.25,
         },
     ]
 
@@ -195,6 +197,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert payload["suggested_query"] == "Eevee"
     assert {item["set_code"] for item in payload["items"]} == {"jng", "fsl"}
     assert sorted(item["price"] for item in payload["items"]) == [8.5, 12.34]
+    assert sorted(item["price_7d_average"] for item in payload["items"]) == [7.25, 11.11]
 
     with database.session_scope() as session:
         session.add_all(

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -307,6 +307,7 @@ def test_build_card_payload_extracts_cardmarket_price(monkeypatch):
 
     assert payload is not None
     assert payload["price"] == round(9.5 * 4.5 * 1.24, 2)
+    assert payload["price_7d_average"] is None
 
 
 def test_build_card_payload_prefers_tcgplayer_price_when_available(monkeypatch):
@@ -328,6 +329,7 @@ def test_build_card_payload_prefers_tcgplayer_price_when_available(monkeypatch):
 
     assert payload is not None
     assert payload["price"] == round(3.75 * 4.0 * 1.24, 2)
+    assert payload["price_7d_average"] is None
 
 
 def test_build_card_payload_skips_price_when_rate_unavailable(monkeypatch):
@@ -337,12 +339,43 @@ def test_build_card_payload_skips_price_when_rate_unavailable(monkeypatch):
         "number": "7/102",
         "set": {"name": "Base Set"},
         "cardmarket": {"prices": {"averageSellPrice": 2.5}},
+        "prices": {"normal": {"7d_average": 1.5}},
     }
 
     payload = tcg_api.build_card_payload(card)
 
     assert payload is not None
     assert payload["price"] is None
+    assert payload["price_7d_average"] is None
+
+
+def test_build_card_payload_extracts_7d_average_price(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_rate():
+        captured["called"] = captured.get("called", 0) + 1
+        return 4.2
+
+    monkeypatch.setattr(tcg_api, "get_eur_pln_rate", fake_rate)
+
+    card = {
+        "name": "Pikachu",
+        "number": "58/102",
+        "set": {"name": "Base Set"},
+        "prices": {
+            "normal": {
+                "7d_average": "2,75",
+                "market": 2.4,
+            }
+        },
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert payload["price_7d_average"] == round(2.75 * 4.2 * 1.24, 2)
+    assert payload["price"] == round(2.4 * 4.2 * 1.24, 2)
+    assert captured["called"] == 1
 
 
 def test_build_card_payload_includes_rarity_symbol():


### PR DESCRIPTION
## Summary
- extract and convert seven-day average prices in the TCG API payloads while preserving existing fallbacks
- surface the new price field through database models, API schemas, and the card search serialization
- update the frontend price handling and extend unit tests for the new data shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de394c76a0832f9d188dbe9bad6022