### PR TITLE
Add set icons to card search results

### DIFF
--- a/kartoteka_web/static/icons/sets/fallback.svg
+++ b/kartoteka_web/static/icons/sets/fallback.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5" />
+      <stop offset="1" stop-color="#2563eb" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="8" width="56" height="48" rx="12" fill="url(#grad)" />
+  <rect x="14" y="20" width="36" height="6" rx="3" fill="rgba(255, 255, 255, 0.82)" />
+  <rect x="14" y="32" width="26" height="6" rx="3" fill="rgba(255, 255, 255, 0.72)" />
+  <rect x="14" y="44" width="20" height="6" rx="3" fill="rgba(255, 255, 255, 0.62)" />
+</svg>

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -823,6 +823,26 @@
     return null;
   };
 
+  const SET_ICON_FALLBACK_URL = "/static/icons/sets/fallback.svg";
+  const SET_ICON_EXTERNAL_BASE = "https://images.pokemontcg.io";
+
+  const resolveSetIconUrl = (item) => {
+    if (!item) return SET_ICON_FALLBACK_URL;
+    const customIcon = (item.set_icon || "").trim();
+    if (customIcon) {
+      return customIcon;
+    }
+    const setCodeRaw = (item.set_code || "").trim();
+    if (!setCodeRaw) {
+      return SET_ICON_FALLBACK_URL;
+    }
+    const normalizedCode = setCodeRaw.toLowerCase().replace(/[^a-z0-9-]/g, "");
+    if (!normalizedCode) {
+      return SET_ICON_FALLBACK_URL;
+    }
+    return `${SET_ICON_EXTERNAL_BASE}/${encodeURIComponent(normalizedCode)}/symbol.png`;
+  };
+
   const renderSearchResults = (
     items = [],
     summaryElement,
@@ -906,6 +926,27 @@
       const hasRarityVisual = raritySymbolIsImage || hasRarityClassSymbol;
       const rarityAlt = `Symbol rzadkości ${rarityText}`;
       const rarityFallback = rarityRaw ? rarityRaw.charAt(0).toUpperCase() : "?";
+      const setIconUrl = resolveSetIconUrl(item);
+      const setIconAltBase = setName && setName !== "Nieznany dodatek" ? setName : setCodeText;
+      const setIconAlt = setIconAltBase ? `Symbol dodatku ${setIconAltBase}` : "Symbol dodatku";
+      const setIconMarkup = setIconUrl
+        ? `<img src="${escapeHtml(setIconUrl)}" alt="${escapeHtml(setIconAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+        : "";
+      const setIconFallbackHiddenAttr = setIconMarkup ? " hidden" : "";
+      const rarityIconMarkup = `
+        <div class="card-search-rarity-icon">
+          ${
+            raritySymbolIsImage
+              ? `<img src="${escapeHtml(raritySymbol)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
+              : hasRarityClassSymbol
+                ? `<span class="card-search-rarity-symbol" role="img" aria-label="${escapeHtml(rarityAlt)}" data-card-rarity-symbol data-symbol-class="${escapeHtml(raritySymbolClassAttr)}"></span>`
+                : ""
+          }
+          <span class="card-search-rarity-icon-fallback"${hasRarityVisual ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
+        </div>
+      `;
+      const numberDisplay = numberLabel || "—";
+      const priceDisplay = priceText || "—";
       if (isListView) {
         const previewImage = item.image_large || item.image_small || "";
         const hasPreviewImage = Boolean(previewImage);
@@ -934,20 +975,21 @@
                   : ""
               }
             </div>
-            <div class="card-search-list-main">
-              <h3 class="card-search-list-title">${escapeHtml(cardName)}</h3>
-              <div class="card-search-list-meta">
-                <span class="card-search-list-meta-item card-search-list-set">${escapeHtml(setName)}</span>
-                <span class="card-search-list-meta-divider" aria-hidden="true">•</span>
-                <span class="card-search-list-meta-item card-search-list-number">${escapeHtml(numberLabel)}</span>
-                ${
-                  priceText
-                    ? `<span class="card-search-list-meta-divider" aria-hidden="true">•</span>
-                       <span class="card-search-list-meta-item card-search-list-price" data-card-price>${escapeHtml(priceText)}</span>`
-                    : ""
-                }
-              </div>
+            <div class="card-search-list-set" title="${escapeHtml(setName)}">
+              ${setIconMarkup}
+              <span class="card-search-set-code card-search-set-fallback"${setIconFallbackHiddenAttr} data-card-set-code data-card-set-icon-fallback>${escapeHtml(setCodeText)}</span>
             </div>
+            <h3 class="card-search-list-title card-search-list-name" title="${escapeHtml(cardName)}">${escapeHtml(cardName)}</h3>
+            <div class="card-search-list-number">${escapeHtml(numberDisplay)}</div>
+            <div class="card-search-list-rarity" title="${escapeHtml(rarityText)}">
+              ${rarityIconMarkup}
+              <span class="card-search-list-rarity-label">${escapeHtml(rarityText)}</span>
+            </div>
+            ${
+              priceText
+                ? `<div class="card-search-list-price" data-card-price>${escapeHtml(priceDisplay)}</div>`
+                : `<div class="card-search-list-price card-search-list-price--empty">${escapeHtml(priceDisplay)}</div>`
+            }
             <form class="card-search-form" data-card-form>
               <input type="hidden" name="card_name" value="${escapeHtml(item.name)}" />
               <input type="hidden" name="card_number" value="${escapeHtml(item.number)}" />
@@ -994,17 +1036,9 @@
               </button>
             </div>
           <div class="card-search-set">
-            <span class="card-search-set-code" data-card-set-code>${escapeHtml(setCodeText)}</span>
-            <div class="card-search-rarity-icon">
-              ${
-                raritySymbolIsImage
-                  ? `<img src="${escapeHtml(raritySymbol)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
-                  : hasRarityClassSymbol
-                    ? `<span class="card-search-rarity-symbol" role="img" aria-label="${escapeHtml(rarityAlt)}" data-card-rarity-symbol data-symbol-class="${escapeHtml(raritySymbolClassAttr)}"></span>`
-                    : ""
-              }
-              <span class="card-search-rarity-icon-fallback"${hasRarityVisual ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
-            </div>
+            ${setIconMarkup}
+            <span class="card-search-set-code card-search-set-fallback"${setIconFallbackHiddenAttr} data-card-set-code data-card-set-icon-fallback>${escapeHtml(setCodeText)}</span>
+            ${rarityIconMarkup}
           </div>
         </div>
         <div class="card-search-info">
@@ -1083,6 +1117,15 @@
                 raritySymbolElement.classList.add(token);
               });
           }
+        }
+        const setIconElement = article.querySelector("[data-card-set-icon]");
+        const setIconFallback = article.querySelector("[data-card-set-icon-fallback]");
+        if (setIconElement && setIconFallback) {
+          const handleSetIconError = () => {
+            setIconElement.remove();
+            setIconFallback.hidden = false;
+          };
+          setIconElement.addEventListener("error", handleSetIconError, { once: true });
         }
       }
       container.appendChild(article);

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -698,14 +698,14 @@ img {
 }
 
 .card-search-results--list .card-search-item {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   padding: 12px 18px;
   background: none;
   border: none;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  flex-wrap: nowrap;
 }
 
 .card-search-results--list .card-search-item:hover,
@@ -800,51 +800,94 @@ img {
   visibility: visible;
 }
 
-.card-search-list-main {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
 .card-search-list-title {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
   color: var(--color-text);
+}
+
+.card-search-list-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.card-search-list-set {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  flex-shrink: 0;
+}
+
+.card-search-set-icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  display: block;
+}
+
+.card-search-set-fallback {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--color-muted-strong, var(--color-text));
   white-space: nowrap;
 }
 
-.card-search-list-meta {
-  display: flex;
-  flex-wrap: wrap;
+.card-search-list-number {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.card-search-list-rarity {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: 0.85rem;
   color: var(--color-muted);
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 
-.card-search-list-meta-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+.card-search-list-rarity .card-search-rarity-icon {
+  width: 26px;
+  height: 26px;
+}
+
+.card-search-list-rarity-label {
   white-space: nowrap;
 }
 
-.card-search-list-meta-divider {
-  color: rgba(107, 114, 128, 0.5);
+.card-search-list-price {
+  font-weight: 600;
+  color: var(--color-accent-dark);
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.card-search-list-price--empty {
+  color: var(--color-muted);
+  font-weight: 500;
 }
 
 .card-search-results--list .card-search-form {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 8px;
+  margin-left: 8px;
+  flex: 0 0 auto;
 }
 
 .card-search-results--list .card-search-form .form-footer {
-  margin-left: 12px;
+  margin-left: 0;
 }
 
 .card-search-results--grid .card-search-media {
@@ -938,6 +981,7 @@ img {
   padding: 0;
   border: 0;
   background: none;
+  flex-wrap: nowrap;
 }
 
 .card-search-set-code {
@@ -1049,6 +1093,11 @@ img {
   font-size: 0.9rem;
 }
 
+.card-search-price {
+  font-weight: 600;
+  color: var(--color-accent-dark);
+}
+
 .card-search-info-meta {
   display: flex;
   align-items: center;
@@ -1130,8 +1179,12 @@ img {
 
 @media (max-width: 720px) {
   .card-search-results--list .card-search-item {
-    grid-template-columns: minmax(0, 1fr);
+    flex-wrap: wrap;
     gap: 12px;
+  }
+
+  .card-search-list-name {
+    flex-basis: 100%;
   }
 
   .card-search-inline-fields {
@@ -1140,6 +1193,8 @@ img {
 
   .card-search-results--list .card-search-form {
     justify-content: flex-start;
+    width: 100%;
+    margin-left: 0;
   }
 
   .card-search-results--list .card-search-form .form-footer {


### PR DESCRIPTION
## Summary
- resolve Pokémon TCG set icons with a fallback asset and surface them in search results
- streamline list and grid result markup to display set symbols, rarity visuals, and pricing in-line
- update styles to size the new icons, keep the list row single-line, and highlight prices

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de3a7d6918832fb1a386d6fe1cea13