### PR TITLE
Adjust add card search layout

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -119,6 +119,18 @@ img {
   display: none !important;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app-header {
   width: min(1080px, calc(100% - 32px));
   margin: 24px auto 0;
@@ -221,6 +233,17 @@ img {
   font-size: 0.95rem;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.button.icon-only {
+  padding: 0 14px;
+  min-width: 44px;
+  height: 100%;
+}
+
+.button.icon-only .button-icon {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 .button.primary {
@@ -507,11 +530,26 @@ img {
   max-width: 540px;
 }
 
-.add-card-form label {
+.add-card-form-field {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.add-card-form label {
   font-weight: 600;
+}
+
+.add-card-form-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.add-card-form-control {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
 }
 
 .add-card-form input[type="text"],

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -17,19 +17,23 @@
     </div>
   </div>
   <form id="add-card-form" class="add-card-form" autocomplete="off" data-card-search-form>
-    <label>
-      Nazwa lub numer karty
-      <input
-        type="text"
-        name="query"
-        id="add-card-query"
-        autocomplete="off"
-        placeholder="np. Pikachu 25/102"
-        required
-      />
-    </label>
-    <div class="form-footer">
-      <button type="submit" class="button primary" id="card-search-trigger">Szukaj</button>
+    <div class="add-card-form-field">
+      <label for="add-card-query">Nazwa lub numer karty</label>
+      <div class="add-card-form-row">
+        <input
+          type="text"
+          name="query"
+          id="add-card-query"
+          autocomplete="off"
+          placeholder="np. Pikachu 25/102"
+          required
+          class="add-card-form-control"
+        />
+        <button type="submit" class="button primary icon-only" id="card-search-trigger">
+          <span class="sr-only">Szukaj</span>
+          <span aria-hidden="true" class="button-icon">🔍</span>
+        </button>
+      </div>
     </div>
   </form>
   <div class="alert" id="add-card-alert" hidden></div>


### PR DESCRIPTION
## Summary
- align the add card search input and submit control in a single flex row with an icon-only button
- add utility styles for the add card form layout, icon buttons, and screen reader only text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de490793b0832f84838536abf4239a