### PR TITLE
Serve set icons locally in card search views

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -849,7 +849,7 @@
   };
 
   const SET_ICON_FALLBACK_URL = "/static/icons/sets/fallback.svg";
-  const SET_ICON_EXTERNAL_BASE = "https://images.pokemontcg.io";
+  const SET_ICON_LOCAL_BASE = "/icon/set";
 
   const resolveSetIconUrl = (item) => {
     if (!item) return SET_ICON_FALLBACK_URL;
@@ -865,7 +865,7 @@
     if (!normalizedCode) {
       return SET_ICON_FALLBACK_URL;
     }
-    return `${SET_ICON_EXTERNAL_BASE}/${encodeURIComponent(normalizedCode)}/symbol.png`;
+    return `${SET_ICON_LOCAL_BASE}/${encodeURIComponent(normalizedCode)}.png`;
   };
 
   const renderSearchResults = (
@@ -941,7 +941,7 @@
       const setIconAltBase = setName && setName !== "Nieznany dodatek" ? setName : setCodeText;
       const setIconAlt = setIconAltBase ? `Symbol dodatku ${setIconAltBase}` : "Symbol dodatku";
       const setIconMarkup = setIconUrl
-        ? `<img src="${escapeHtml(setIconUrl)}" alt="${escapeHtml(setIconAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
+        ? `<img class="card-search-set-icon" src="${escapeHtml(setIconUrl)}" alt="${escapeHtml(setIconAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
         : "";
       const setIconFallbackHiddenAttr = setIconMarkup ? " hidden" : "";
       const rarityIconMarkup = `

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -855,17 +855,22 @@ img {
 
 .card-search-list-set {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 40px;
+  gap: 6px;
+  width: 56px;
   flex-shrink: 0;
 }
 
 .card-search-set-icon {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
+  max-width: 36px;
+  max-height: 36px;
   object-fit: contain;
   display: block;
+  flex: 0 0 auto;
 }
 
 .card-search-set-fallback {
@@ -1009,12 +1014,12 @@ img {
 .card-search-set {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
+  justify-content: center;
+  gap: 6px;
   padding: 0;
   border: 0;
   background: none;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .card-search-set-code {
@@ -1025,6 +1030,14 @@ img {
   color: var(--color-muted-strong, var(--color-text));
   white-space: nowrap;
   line-height: 1;
+}
+
+.card-search-results--grid .card-search-set {
+  text-align: center;
+}
+
+.card-search-set-fallback {
+  text-align: center;
 }
 
 .card-search-rarity-icon {

--- a/server.py
+++ b/server.py
@@ -64,6 +64,7 @@ app.include_router(users.router)
 app.include_router(cards.router)
 
 app.mount("/static", StaticFiles(directory="kartoteka_web/static"), name="static")
+app.mount("/icon", StaticFiles(directory="icon"), name="icon-assets")
 
 image_utils.ensure_directory()
 card_image_mount = image_utils.CARD_IMAGE_URL_PREFIX


### PR DESCRIPTION
## Summary
- resolve card set icons to local `/icon/set` assets and tag rendered images for styling
- expose the `icon` directory through FastAPI so set symbols are served from the application
- tweak card search layouts so the resized set icons align with rarity indicators in both views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4a090bd8832fab45edf9548e5afc