### PR TITLE
Adjust add card toolbar layout and icon buttons

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -573,7 +573,6 @@ img {
   margin-top: 16px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;
 }
@@ -582,6 +581,11 @@ img {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.card-search-toolbar-group--view {
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .card-search-toolbar-label {
@@ -604,13 +608,22 @@ img {
 .card-search-view-toggle button {
   border: 1px solid transparent;
   border-radius: calc(var(--radius-sm) - 2px);
-  padding: 6px 14px;
-  font-size: 0.9rem;
-  font-weight: 600;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
   color: var(--color-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-search-view-toggle button svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .card-search-view-toggle button:hover,
@@ -1163,6 +1176,10 @@ img {
   .card-search-toolbar-group {
     justify-content: space-between;
     width: 100%;
+  }
+
+  .card-search-toolbar-group--view {
+    margin-left: 0;
   }
 
   .card-search-toolbar-group--sort {

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -38,13 +38,6 @@
   </form>
   <div class="alert" id="add-card-alert" hidden></div>
   <div class="card-search-toolbar" data-card-search-toolbar>
-    <div class="card-search-toolbar-group" role="group" aria-label="Przełącz widok wyników wyszukiwania">
-      <span class="card-search-toolbar-label">Widok</span>
-      <div class="card-search-view-toggle">
-        <button type="button" data-card-view="grid" aria-pressed="true" class="is-active">Kratka</button>
-        <button type="button" data-card-view="list" aria-pressed="false">Lista</button>
-      </div>
-    </div>
     <div class="card-search-toolbar-group card-search-toolbar-group--sort">
       <label for="card-sort-select">Sortowanie</label>
       <select id="card-sort-select" data-card-sort>
@@ -57,6 +50,35 @@
         <option value="price-asc">Cena rosnąco</option>
         <option value="price-desc">Cena malejąco</option>
       </select>
+    </div>
+    <div
+      class="card-search-toolbar-group card-search-toolbar-group--view"
+      role="group"
+      aria-label="Przełącz widok wyników wyszukiwania"
+    >
+      <span class="card-search-toolbar-label">Widok</span>
+      <div class="card-search-view-toggle">
+        <button type="button" data-card-view="grid" aria-pressed="true" class="is-active">
+          <span class="sr-only">Widok siatki</span>
+          <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+            <rect x="2" y="2" width="6" height="6" rx="1.2" />
+            <rect x="12" y="2" width="6" height="6" rx="1.2" />
+            <rect x="2" y="12" width="6" height="6" rx="1.2" />
+            <rect x="12" y="12" width="6" height="6" rx="1.2" />
+          </svg>
+        </button>
+        <button type="button" data-card-view="list" aria-pressed="false">
+          <span class="sr-only">Widok listy</span>
+          <svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+            <rect x="2" y="3" width="4" height="4" rx="1.2" />
+            <rect x="2" y="9" width="4" height="4" rx="1.2" />
+            <rect x="2" y="15" width="4" height="4" rx="1.2" />
+            <rect x="8" y="3" width="10" height="2.4" rx="1.2" />
+            <rect x="8" y="9" width="10" height="2.4" rx="1.2" />
+            <rect x="8" y="15" width="10" height="2.4" rx="1.2" />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
   <p id="card-search-summary" class="search-summary" hidden aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- move the sort dropdown ahead of the view toggle and position the view controls on the right
- replace text view toggle buttons with SVG icon buttons and update styles for consistent sizing

## Testing
- not run (front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68de4af52764832f853e425dee38d8b5