### PR TITLE
Add badges for card search metadata

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -795,33 +795,32 @@
     image_large: form.elements.card_image_large?.value?.trim() || null,
   });
 
-  const RARITY_ICON_BASE_PATH = "/icon/rarity";
-  const getRarityIconPath = (fileName) => `${RARITY_ICON_BASE_PATH}/${fileName}`;
+  const RARITY_ICON_BASE_PATH = "/static/icons/rarity";
   const RARITY_ICON_MAP = Object.freeze({
-    "common": getRarityIconPath("Rarity_Common.png"),
-    "uncommon": getRarityIconPath("Rarity_Uncommon.png"),
-    "rare": getRarityIconPath("Rarity_Rare.png"),
-    "rare-holo": getRarityIconPath("Rarity_Rare.png"),
-    "holo-rare": getRarityIconPath("Rarity_Rare.png"),
-    "rare-ultra": getRarityIconPath("Rarity_Double_Rare.png"),
-    "ultra-rare": getRarityIconPath("Rarity_Double_Rare.png"),
-    "rare-double": getRarityIconPath("Rarity_Double_Rare.png"),
-    "double-rare": getRarityIconPath("Rarity_Double_Rare.png"),
-    "rare-secret": getRarityIconPath("Rarity_Hyper_Rare.png"),
-    "secret-rare": getRarityIconPath("Rarity_Hyper_Rare.png"),
-    "hyper-rare": getRarityIconPath("Rarity_Hyper_Rare.png"),
-    "rare-rainbow": getRarityIconPath("Rarity_Hyper_Rare.png"),
-    "rainbow-rare": getRarityIconPath("Rarity_Hyper_Rare.png"),
-    "rare-shiny": getRarityIconPath("Rarity_Shiny_Rare.png"),
-    "shiny-rare": getRarityIconPath("Rarity_Shiny_Rare.png"),
-    "shinyrare": getRarityIconPath("Rarity_ShinyRare.png"),
-    "rare-ace": getRarityIconPath("Rarity_ACE_SPEC_Rare.png"),
-    "ace-spec-rare": getRarityIconPath("Rarity_ACE_SPEC_Rare.png"),
-    "rare-illustration": getRarityIconPath("Rarity_Special_Illustration_Rare.png"),
-    "illustration-rare": getRarityIconPath("Rarity_Special_Illustration_Rare.png"),
-    "special-illustration-rare": getRarityIconPath("Rarity_Special_Illustration_Rare.png"),
-    "rare-special-illustration": getRarityIconPath("Rarity_Special_Illustration_Rare.png"),
-    "promo": getRarityIconPath("Rarity_Common.png"),
+    "common": `${RARITY_ICON_BASE_PATH}/common.svg`,
+    "uncommon": `${RARITY_ICON_BASE_PATH}/uncommon.svg`,
+    "rare": `${RARITY_ICON_BASE_PATH}/rare.svg`,
+    "rare-holo": `${RARITY_ICON_BASE_PATH}/rare-holo.svg`,
+    "holo-rare": `${RARITY_ICON_BASE_PATH}/rare-holo.svg`,
+    "rare-ultra": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
+    "ultra-rare": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
+    "rare-double": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
+    "double-rare": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
+    "rare-secret": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
+    "secret-rare": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
+    "hyper-rare": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
+    "rare-rainbow": `${RARITY_ICON_BASE_PATH}/rare-rainbow.svg`,
+    "rainbow-rare": `${RARITY_ICON_BASE_PATH}/rare-rainbow.svg`,
+    "rare-shiny": `${RARITY_ICON_BASE_PATH}/rare-shiny.svg`,
+    "shiny-rare": `${RARITY_ICON_BASE_PATH}/rare-shiny.svg`,
+    "shinyrare": `${RARITY_ICON_BASE_PATH}/rare-shiny.svg`,
+    "rare-ace": `${RARITY_ICON_BASE_PATH}/rare-ace.svg`,
+    "ace-spec-rare": `${RARITY_ICON_BASE_PATH}/rare-ace.svg`,
+    "rare-illustration": `${RARITY_ICON_BASE_PATH}/rare-illustration.svg`,
+    "illustration-rare": `${RARITY_ICON_BASE_PATH}/rare-illustration.svg`,
+    "special-illustration-rare": `${RARITY_ICON_BASE_PATH}/rare-illustration.svg`,
+    "rare-special-illustration": `${RARITY_ICON_BASE_PATH}/rare-illustration.svg`,
+    "promo": `${RARITY_ICON_BASE_PATH}/promo.svg`,
   });
 
   const RARITY_ICON_RULES = [
@@ -954,18 +953,27 @@
       const setIconUrl = resolveSetIconUrl(item);
       const setIconAltBase = setName && setName !== "Nieznany dodatek" ? setName : setCodeText;
       const setIconAlt = setIconAltBase ? `Symbol dodatku ${setIconAltBase}` : "Symbol dodatku";
-      const setIconMarkup = setIconUrl
+      const hasSetIconVisual = Boolean(setIconUrl);
+      const setIconFallbackHiddenAttr = hasSetIconVisual ? " hidden" : "";
+      const setIconImageMarkup = hasSetIconVisual
         ? `<img class="card-search-set-icon" src="${escapeHtml(setIconUrl)}" alt="${escapeHtml(setIconAlt)}" loading="lazy" decoding="async" data-card-set-icon />`
         : "";
-      const setIconFallbackHiddenAttr = setIconMarkup ? " hidden" : "";
+      const setIconMarkup = `
+        <div class="card-search-badge card-search-badge--set">
+          ${setIconImageMarkup}
+          <span class="card-search-set-code card-search-set-fallback"${setIconFallbackHiddenAttr} data-card-set-code data-card-set-icon-fallback>${escapeHtml(setCodeText)}</span>
+        </div>
+      `;
       const rarityIconMarkup = `
-        <div class="card-search-rarity-icon">
-          ${
-            rarityIconUrl
-              ? `<img src="${escapeHtml(rarityIconUrl)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
-              : ""
-          }
-          <span class="card-search-rarity-icon-fallback"${hasRarityVisual ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
+        <div class="card-search-badge card-search-badge--rarity">
+          <div class="card-search-rarity-icon">
+            ${
+              rarityIconUrl
+                ? `<img src="${escapeHtml(rarityIconUrl)}" alt="${escapeHtml(rarityAlt)}" loading="lazy" decoding="async" data-card-rarity-icon />`
+                : ""
+            }
+            <span class="card-search-rarity-icon-fallback"${hasRarityVisual ? " hidden" : ""} data-card-rarity-icon-fallback aria-hidden="true">${escapeHtml(rarityFallback)}</span>
+          </div>
         </div>
       `;
       const numberDisplay = numberLabel || "—";
@@ -1000,7 +1008,6 @@
             </div>
             <div class="card-search-list-set" title="${escapeHtml(setName)}">
               ${setIconMarkup}
-              <span class="card-search-set-code card-search-set-fallback"${setIconFallbackHiddenAttr} data-card-set-code data-card-set-icon-fallback>${escapeHtml(setCodeText)}</span>
             </div>
             <h3 class="card-search-list-title card-search-list-name" title="${escapeHtml(cardName)}">${escapeHtml(cardName)}</h3>
             <div class="card-search-list-number">${escapeHtml(numberDisplay)}</div>
@@ -1060,7 +1067,6 @@
             </div>
           <div class="card-search-set">
             ${setIconMarkup}
-            <span class="card-search-set-code card-search-set-fallback"${setIconFallbackHiddenAttr} data-card-set-code data-card-set-icon-fallback>${escapeHtml(setCodeText)}</span>
             ${rarityIconMarkup}
           </div>
         </div>

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -876,6 +876,26 @@ img {
   flex-shrink: 0;
 }
 
+.card-search-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  line-height: 1;
+  min-height: 32px;
+  min-width: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.card-search-badge--rarity {
+  gap: 8px;
+}
+
 .card-search-set-icon {
   width: 32px;
   height: 32px;
@@ -903,9 +923,9 @@ img {
 }
 
 .card-search-list-rarity {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   font-size: 0.85rem;
   color: var(--color-muted);
   white-space: nowrap;
@@ -1026,13 +1046,13 @@ img {
 
 .card-search-set {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 12px;
   padding: 0;
   border: 0;
   background: none;
-  flex-wrap: wrap;
 }
 
 .card-search-set-code {


### PR DESCRIPTION
## Summary
- wrap set and rarity fragments in card search results with a shared badge container
- style the new `.card-search-badge` wrapper and tweak card search layout for grid and list views
- switch rarity icons to the svg assets under `static/icons/rarity` for consistency with the new styling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de528a7b48832f89c298f1e876df3e