### PR TITLE
Switch Ultra Rare rarity icons to PNG assets

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -796,16 +796,17 @@
   });
 
   const RARITY_ICON_BASE_PATH = "/static/icons/rarity";
+  const RARITY_ICON_IMAGE_BASE_PATH = "/icon/rarity";
   const RARITY_ICON_MAP = Object.freeze({
     "common": `${RARITY_ICON_BASE_PATH}/common.svg`,
     "uncommon": `${RARITY_ICON_BASE_PATH}/uncommon.svg`,
     "rare": `${RARITY_ICON_BASE_PATH}/rare.svg`,
     "rare-holo": `${RARITY_ICON_BASE_PATH}/rare-holo.svg`,
     "holo-rare": `${RARITY_ICON_BASE_PATH}/rare-holo.svg`,
-    "rare-ultra": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
-    "ultra-rare": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
-    "rare-double": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
-    "double-rare": `${RARITY_ICON_BASE_PATH}/rare-ultra.svg`,
+    "rare-ultra": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Ultra_Rare.png`,
+    "ultra-rare": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Ultra_Rare.png`,
+    "rare-double": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Double_Rare.png`,
+    "double-rare": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Double_Rare.png`,
     "rare-secret": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
     "secret-rare": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
     "hyper-rare": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`,
@@ -826,8 +827,9 @@
   const RARITY_ICON_RULES = [
     { pattern: /(rainbow|hyper)/i, key: "rare-rainbow" },
     { pattern: /(secret|gold)/i, key: "rare-secret" },
+    { pattern: /double/i, key: "double-rare" },
     {
-      pattern: /(ultra|double|vmax|v-star|vstar|v-union|gx|ex|mega|prime|legend)/i,
+      pattern: /(ultra|vmax|v-star|vstar|v-union|gx|ex|mega|prime|legend)/i,
       key: "rare-ultra",
     },
     { pattern: /(shiny|shining|radiant)/i, key: "rare-shiny" },

--- a/tests/test_rarity_icons.py
+++ b/tests/test_rarity_icons.py
@@ -2,33 +2,77 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import re
-
 EXPECTED_RARITY_ICONS = {
-    "common": "common.svg",
-    "uncommon": "uncommon.svg",
-    "rare": "rare.svg",
-    "rare-holo": "rare-holo.svg",
-    "rare-ultra": "rare-ultra.svg",
-    "rare-secret": "rare-secret.svg",
-    "rare-shiny": "rare-shiny.svg",
-    "rare-ace": "rare-ace.svg",
-    "rare-illustration": "rare-illustration.svg",
-    "promo": "promo.svg",
-    "rare-rainbow": "rare-rainbow.svg",
+    "common": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/common.svg"),
+        "snippet": '"common": `${RARITY_ICON_BASE_PATH}/common.svg`',
+    },
+    "uncommon": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/uncommon.svg"),
+        "snippet": '"uncommon": `${RARITY_ICON_BASE_PATH}/uncommon.svg`',
+    },
+    "rare": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare.svg"),
+        "snippet": '"rare": `${RARITY_ICON_BASE_PATH}/rare.svg`',
+    },
+    "rare-holo": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-holo.svg"),
+        "snippet": '"rare-holo": `${RARITY_ICON_BASE_PATH}/rare-holo.svg`',
+    },
+    "rare-ultra": {
+        "asset_path": Path("icon/rarity/Rarity_Ultra_Rare.png"),
+        "snippet": '"rare-ultra": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Ultra_Rare.png`',
+    },
+    "ultra-rare": {
+        "asset_path": Path("icon/rarity/Rarity_Ultra_Rare.png"),
+        "snippet": '"ultra-rare": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Ultra_Rare.png`',
+    },
+    "rare-double": {
+        "asset_path": Path("icon/rarity/Rarity_Double_Rare.png"),
+        "snippet": '"rare-double": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Double_Rare.png`',
+    },
+    "double-rare": {
+        "asset_path": Path("icon/rarity/Rarity_Double_Rare.png"),
+        "snippet": '"double-rare": `${RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Double_Rare.png`',
+    },
+    "rare-secret": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-secret.svg"),
+        "snippet": '"rare-secret": `${RARITY_ICON_BASE_PATH}/rare-secret.svg`',
+    },
+    "rare-shiny": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-shiny.svg"),
+        "snippet": '"rare-shiny": `${RARITY_ICON_BASE_PATH}/rare-shiny.svg`',
+    },
+    "rare-ace": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-ace.svg"),
+        "snippet": '"rare-ace": `${RARITY_ICON_BASE_PATH}/rare-ace.svg`',
+    },
+    "rare-illustration": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-illustration.svg"),
+        "snippet": '"rare-illustration": `${RARITY_ICON_BASE_PATH}/rare-illustration.svg`',
+    },
+    "promo": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/promo.svg"),
+        "snippet": '"promo": `${RARITY_ICON_BASE_PATH}/promo.svg`',
+    },
+    "rare-rainbow": {
+        "asset_path": Path("kartoteka_web/static/icons/rarity/rare-rainbow.svg"),
+        "snippet": '"rare-rainbow": `${RARITY_ICON_BASE_PATH}/rare-rainbow.svg`',
+    },
 }
 
 
 def test_rarity_icon_assets_exist():
-    base_path = Path("kartoteka_web/static/icons/rarity")
-    assert base_path.is_dir(), "Brakuje katalogu z ikonami rzadkości"
-    missing = [name for name in EXPECTED_RARITY_ICONS.values() if not (base_path / name).is_file()]
-    assert not missing, f"Brakuje plików ikon: {missing}"
+    missing_assets = {
+        details["asset_path"]
+        for details in EXPECTED_RARITY_ICONS.values()
+        if not details["asset_path"].is_file()
+    }
+    assert not missing_assets, f"Brakuje plików ikon: {[str(path) for path in sorted(missing_assets)]}"
 
 
 def test_rarity_icon_map_contains_expected_entries():
     js_path = Path("kartoteka_web/static/js/app.js")
     content = js_path.read_text(encoding="utf-8")
-    for key, filename in EXPECTED_RARITY_ICONS.items():
-        pattern = re.escape(f'"{key}": `${{RARITY_ICON_BASE_PATH}}/{filename}`')
-        assert re.search(pattern, content), f"Nie znaleziono mapowania dla rzadkości '{key}'"
+    for key, details in EXPECTED_RARITY_ICONS.items():
+        assert details["snippet"] in content, f"Nie znaleziono mapowania dla rzadkości '{key}'"


### PR DESCRIPTION
## Summary
- map Ultra Rare and Double Rare rarities to the dedicated PNG icon assets served from /icon/rarity
- adjust rarity pattern rules so double rares and ultra rares resolve to the intended mappings
- extend the rarity icon tests to cover the new asset locations and mapping snippets

## Testing
- pytest tests/test_rarity_icons.py

------
https://chatgpt.com/codex/tasks/task_e_68de5b545d90832f9c4396dc30a9fb53