### PR TITLE
feat: enrich card details with pricing history and metadata

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+from pathlib import Path
 from typing import Any, Iterable
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -34,6 +36,12 @@ RAPIDAPI_HOST = (
 CARD_NUMBER_PATTERN = re.compile(
     r"(?i)([a-z]{0,5}\d+[a-z0-9]*)(?:\s*/\s*([a-z]{0,5}\d+[a-z0-9]*))?"
 )
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SHOP_URL = "https://kartoteka.shop/pl/c/Karty-Pokemon/38"
+SET_ICON_URL_BASE = "/icon/set"
+SET_ICON_DIRECTORY = Path(__file__).resolve().parents[2] / "icon" / "set"
 
 
 def _compose_query(*parts: str | None) -> str:
@@ -99,6 +107,23 @@ def _normalize_lower(value: str | None) -> str:
     return (value or "").strip().lower()
 
 
+def _sanitize_set_code(value: str | None) -> str:
+    return re.sub(r"[^a-z0-9-]", "", (value or "").strip().lower())
+
+
+def _local_set_icon_path(set_code: str | None) -> str | None:
+    normalized = _sanitize_set_code(set_code)
+    if not normalized:
+        return None
+    candidate = SET_ICON_DIRECTORY / f"{normalized}.png"
+    try:
+        if candidate.exists():
+            return f"{SET_ICON_URL_BASE}/{normalized}.png"
+    except OSError:
+        return None
+    return None
+
+
 def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
     return schemas.CardSearchResult(
         name=card.name,
@@ -128,6 +153,7 @@ def _card_to_detail(card: models.Card) -> schemas.CardDetail:
         set_name=card.set_name,
         set_code=card.set_code,
         set_icon=None,
+        set_icon_path=_local_set_icon_path(card.set_code),
         image_small=card.image_small,
         image_large=card.image_large,
         rarity=card.rarity,
@@ -136,7 +162,81 @@ def _card_to_detail(card: models.Card) -> schemas.CardDetail:
         release_date=None,
         price=card.price,
         price_7d_average=card.price_7d_average,
+        description=None,
+        shop_url=DEFAULT_SHOP_URL,
+        price_history=schemas.CardPriceHistory(),
     )
+
+
+def _history_points_to_schema(
+    points: list[dict[str, Any]]
+) -> list[schemas.CardPriceHistoryPoint]:
+    history: list[schemas.CardPriceHistoryPoint] = []
+    for point in points:
+        date_value = point.get("date")
+        if not isinstance(date_value, str) or not date_value.strip():
+            continue
+        price_value = point.get("price")
+        price_number: float | None
+        if isinstance(price_value, (int, float)):
+            price_number = float(price_value)
+        elif isinstance(price_value, str):
+            try:
+                price_number = float(price_value.replace(",", "."))
+            except ValueError:
+                price_number = None
+        else:
+            price_number = None
+        currency_value = point.get("currency")
+        if isinstance(currency_value, str):
+            currency_text = currency_value.strip() or None
+        else:
+            currency_text = None
+        history.append(
+            schemas.CardPriceHistoryPoint(
+                date=date_value,
+                price=price_number,
+                currency=currency_text,
+            )
+        )
+    return history
+
+
+def _select_remote_card(
+    records: list[dict[str, Any]], detail: schemas.CardDetail
+) -> dict[str, Any] | None:
+    if not records:
+        return None
+
+    def _norm(value: Any) -> str:
+        return (str(value or "").strip().lower())
+
+    target_number = _norm(detail.number)
+    target_set_code = _norm(detail.set_code)
+    target_set_name = _norm(detail.set_name)
+
+    best_score = -1
+    best_record: dict[str, Any] | None = None
+
+    for record in records:
+        score = 0
+        record_number = _norm(record.get("number"))
+        record_set_code = _norm(record.get("set_code"))
+        record_set_name = _norm(record.get("set_name"))
+
+        if target_number and record_number == target_number:
+            score += 3
+        if target_set_code and record_set_code == target_set_code:
+            score += 3
+        if target_set_name and record_set_name == target_set_name:
+            score += 1
+        if score > best_score:
+            best_score = score
+            best_record = record
+
+    if best_record and best_score > 0:
+        return best_record
+    return records[0]
 
 
 def _matches_filters(
@@ -418,6 +518,98 @@ def card_info(
     detail = _card_to_detail(card)
     if total and not detail.total:
         detail.total = text.sanitize_number(total)
+
+    detail.shop_url = (detail.shop_url or DEFAULT_SHOP_URL).strip() or DEFAULT_SHOP_URL
+
+    remote_results: list[dict[str, Any]] = []
+    try:
+        remote_results, _ = tcg_api.search_cards(
+            name=detail.name or name,
+            number=detail.number,
+            set_name=detail.set_name,
+            total=detail.total,
+            limit=6,
+            per_page=6,
+            rapidapi_key=RAPIDAPI_KEY,
+            rapidapi_host=RAPIDAPI_HOST,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to fetch remote card details for %s #%s: %s", name, number, exc)
+        remote_results = []
+
+    remote_card = _select_remote_card(remote_results, detail) if remote_results else None
+    remote_card_id: str | None = None
+
+    if remote_card:
+        remote_card_id_value = str(remote_card.get("id") or "").strip()
+        remote_card_id = remote_card_id_value or None
+
+        for attr in (
+            "name",
+            "number_display",
+            "total",
+            "set_name",
+            "set_code",
+            "image_small",
+            "image_large",
+            "rarity",
+            "artist",
+            "series",
+            "release_date",
+        ):
+            value = remote_card.get(attr)
+            if value:
+                setattr(detail, attr, value)
+
+        price_value = remote_card.get("price")
+        if price_value is not None:
+            detail.price = price_value
+        price_average = remote_card.get("price_7d_average")
+        if price_average is not None:
+            detail.price_7d_average = price_average
+
+        set_icon_value = remote_card.get("set_icon")
+        if set_icon_value:
+            detail.set_icon = set_icon_value
+
+        description_value = remote_card.get("description")
+        if description_value:
+            detail.description = description_value.strip()
+
+        shop_url_value = remote_card.get("shop_url")
+        if isinstance(shop_url_value, str) and shop_url_value.strip():
+            detail.shop_url = shop_url_value.strip()
+
+    detail.shop_url = detail.shop_url.strip() if detail.shop_url else DEFAULT_SHOP_URL
+    if not detail.shop_url:
+        detail.shop_url = DEFAULT_SHOP_URL
+
+    detail.set_icon_path = _local_set_icon_path(detail.set_code) or detail.set_icon_path
+
+    detail.price_history = schemas.CardPriceHistory()
+    if remote_card_id:
+        try:
+            raw_history = tcg_api.fetch_card_price_history(
+                remote_card_id,
+                rapidapi_key=RAPIDAPI_KEY,
+                rapidapi_host=RAPIDAPI_HOST,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to fetch price history for card %s: %s", remote_card_id, exc)
+            raw_history = []
+        normalized_history = tcg_api.normalize_price_history(raw_history)
+        if normalized_history:
+            detail.price_history = schemas.CardPriceHistory(
+                last_7=_history_points_to_schema(
+                    tcg_api.slice_price_history(normalized_history, 7)
+                ),
+                last_30=_history_points_to_schema(
+                    tcg_api.slice_price_history(normalized_history, 30)
+                ),
+                all=_history_points_to_schema(
+                    tcg_api.slice_price_history(normalized_history)
+                ),
+            )
 
     related_cards = _load_related_cards(session, card, limit_value)
     related_items = [_card_to_search_schema(item) for item in related_cards[:limit_value]]

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -81,6 +81,18 @@ class CardSearchResponse(SQLModel):
     suggested_query: Optional[str] = None
 
 
+class CardPriceHistoryPoint(SQLModel):
+    date: str
+    price: Optional[float] = None
+    currency: Optional[str] = None
+
+
+class CardPriceHistory(SQLModel):
+    last_7: List[CardPriceHistoryPoint] = Field(default_factory=list)
+    last_30: List[CardPriceHistoryPoint] = Field(default_factory=list)
+    all: List[CardPriceHistoryPoint] = Field(default_factory=list)
+
+
 class CardDetail(SQLModel):
     name: str
     number: str
@@ -89,6 +101,7 @@ class CardDetail(SQLModel):
     set_name: str
     set_code: Optional[str] = None
     set_icon: Optional[str] = None
+    set_icon_path: Optional[str] = None
     image_small: Optional[str] = None
     image_large: Optional[str] = None
     rarity: Optional[str] = None
@@ -97,11 +110,14 @@ class CardDetail(SQLModel):
     release_date: Optional[str] = None
     price: Optional[float] = None
     price_7d_average: Optional[float] = None
+    description: Optional[str] = None
+    shop_url: Optional[str] = None
+    price_history: CardPriceHistory = Field(default_factory=CardPriceHistory)
 
 
 class CardDetailResponse(SQLModel):
     card: CardDetail
-    related: List[CardSearchResult] = []
+    related: List[CardSearchResult] = Field(default_factory=list)
 
 
 class CollectionEntryBase(SQLModel):

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import time
 from difflib import SequenceMatcher
@@ -25,6 +26,28 @@ _SEVEN_DAY_AVERAGE_KEYS: tuple[str, ...] = (
     "sevenDayAverage",
     "seven_day_average",
     "sevenDayAvg",
+)
+
+_PRICE_HISTORY_KEYS: tuple[str, ...] = (
+    "marketPrice",
+    "market_price",
+    "market",
+    "price",
+    "averageSellPrice",
+    "avgSellPrice",
+    "avg",
+    "avg7",
+    "avg30",
+    "trend",
+    "trendPrice",
+    "lowPrice",
+    "low",
+    "highPrice",
+    "high",
+    "median",
+    "value",
+    "directLow",
+    "directHigh",
 )
 
 
@@ -354,6 +377,105 @@ def _normalize_text_field(value: Any) -> Optional[str]:
     return str(value)
 
 
+def _extract_shop_url(card: dict[str, Any]) -> Optional[str]:
+    candidates: list[str] = []
+
+    def _add_candidate(value: Any) -> None:
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if trimmed:
+                candidates.append(trimmed)
+
+    for key in ("cardmarket", "cardMarket", "tcgplayer", "tcgPlayer"):
+        container = card.get(key)
+        if isinstance(container, dict):
+            for field in (
+                "url",
+                "website",
+                "websiteUrl",
+                "productUrl",
+                "productURL",
+                "directLowUrl",
+                "directLowURL",
+                "directHighUrl",
+                "directHighURL",
+                "link",
+            ):
+                _add_candidate(container.get(field))
+
+    for key in ("purchaseUrls", "purchase_urls", "urls", "links"):
+        container = card.get(key)
+        if isinstance(container, dict):
+            for value in container.values():
+                _add_candidate(value)
+        elif isinstance(container, (list, tuple, set)):
+            for value in container:
+                _add_candidate(value)
+
+    return candidates[0] if candidates else None
+
+
+def _extract_description_text(card: dict[str, Any]) -> Optional[str]:
+    snippets: list[str] = []
+
+    def _append(value: Any, *, prefix: str | None = None) -> None:
+        text_value = _normalize_text_field(value)
+        if not text_value:
+            return
+        candidate = text_value.strip()
+        if not candidate:
+            return
+        if prefix:
+            prefix_value = prefix.strip()
+            if prefix_value:
+                candidate = f"{prefix_value}: {candidate}"
+        if candidate not in snippets:
+            snippets.append(candidate)
+
+    for key in ("flavorText", "flavor_text", "flavor", "description", "text"):
+        _append(card.get(key))
+
+    rules = card.get("rules")
+    if isinstance(rules, (list, tuple, set)):
+        for rule in rules:
+            _append(rule)
+
+    for key in ("abilities", "attacks", "skills"):
+        container = card.get(key)
+        if not isinstance(container, list):
+            continue
+        for item in container:
+            if isinstance(item, dict):
+                label = _normalize_text_field(item.get("name") or item.get("label"))
+                _append(
+                    item.get("text")
+                    or item.get("effect")
+                    or item.get("description"),
+                    prefix=label,
+                )
+            else:
+                _append(item)
+
+    for key in ("ability", "skill"):
+        ability = card.get(key)
+        if isinstance(ability, dict):
+            label = _normalize_text_field(ability.get("name") or ability.get("label"))
+            _append(
+                ability.get("text")
+                or ability.get("effect")
+                or ability.get("description"),
+                prefix=label,
+            )
+        else:
+            _append(ability)
+
+    info_fields = card.get("info") or card.get("card_text")
+    if info_fields:
+        _append(info_fields)
+
+    return "\n\n".join(snippets) if snippets else None
+
+
 def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
     episode = card.get("episode") or card.get("set") or {}
     set_name_value = (
@@ -449,6 +571,16 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         rarity_symbol = None
 
     image_small, image_large = _extract_images(card)
+    card_id_value = _normalize_text_field(
+        card.get("id")
+        or card.get("card_id")
+        or card.get("cardId")
+        or card.get("uuid")
+        or card.get("cardUuid")
+        or card.get("tcgplayerProductId")
+    )
+    card_id = card_id_value.strip() if isinstance(card_id_value, str) else None
+
     price_eur = _extract_card_price(card)
     price_7d_average_eur = _extract_7d_average_price(card)
 
@@ -463,6 +595,9 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
             price_pln = round(price_eur * rate * 1.24, 2)
         if price_7d_average_eur is not None:
             price_7d_average_pln = round(price_7d_average_eur * rate * 1.24, 2)
+
+    description = _extract_description_text(card)
+    shop_url = _extract_shop_url(card)
 
     return {
         "name": card.get("name") or "",
@@ -481,6 +616,9 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         "rarity_symbol": rarity_symbol,
         "price": price_pln,
         "price_7d_average": price_7d_average_pln,
+        "description": description,
+        "shop_url": shop_url,
+        "id": card_id,
     }
 
 
@@ -913,3 +1051,180 @@ def fetch_card_price_history(
         history = [item for item in payload if isinstance(item, dict)]
 
     return history
+
+
+def _parse_history_date(value: Any) -> Optional[dt.date]:
+    if value is None:
+        return None
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, (int, float)):
+        try:
+            timestamp = float(value)
+        except (TypeError, ValueError):
+            return None
+        if timestamp > 10_000_000_000:
+            timestamp /= 1000.0
+        if timestamp > 10_000_000_000:
+            timestamp /= 1000.0
+        try:
+            return dt.datetime.utcfromtimestamp(timestamp).date()
+        except (OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.isdigit():
+            return _parse_history_date(int(text))
+        try:
+            return dt.datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+        except ValueError:
+            pass
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d/%m/%Y", "%Y.%m.%d", "%Y%m%d"):
+            try:
+                return dt.datetime.strptime(text, fmt).date()
+            except ValueError:
+                continue
+        try:
+            return dt.datetime.strptime(text, "%Y-%m-%dT%H:%M:%S").date()
+        except ValueError:
+            pass
+        try:
+            numeric = float(text)
+        except ValueError:
+            numeric = None
+        if numeric is not None:
+            return _parse_history_date(numeric)
+    return None
+
+
+def _extract_history_date(entry: dict[str, Any]) -> Optional[dt.date]:
+    for key in (
+        "date",
+        "day",
+        "timestamp",
+        "time",
+        "updated",
+        "updatedAt",
+        "updated_at",
+        "lastUpdated",
+        "lastUpdate",
+        "created",
+        "createdAt",
+    ):
+        if key in entry:
+            parsed = _parse_history_date(entry.get(key))
+            if parsed:
+                return parsed
+
+    for nested_key in ("market", "prices", "price", "value"):
+        nested = entry.get(nested_key)
+        if isinstance(nested, dict) and nested is not entry:
+            parsed = _extract_history_date(nested)
+            if parsed:
+                return parsed
+
+    return None
+
+
+def _normalize_currency_code(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        code = text.upper()
+        if code in {"PL", "PLN", "ZŁ", "ZL", "PLN.", "PL ZŁ"}:
+            return "PLN"
+        if code in {"EUR", "EURO", "€"}:
+            return "EUR"
+        return code
+    if isinstance(value, dict):
+        for key in ("code", "value", "currency"):
+            if key in value:
+                candidate = _normalize_currency_code(value.get(key))
+                if candidate:
+                    return candidate
+    return None
+
+
+def _extract_history_currency(entry: dict[str, Any]) -> Optional[str]:
+    for key in ("currency", "currencyCode", "currency_code"):
+        if key in entry:
+            currency = _normalize_currency_code(entry.get(key))
+            if currency:
+                return currency
+    for nested_key in ("market", "prices", "value"):
+        nested = entry.get(nested_key)
+        if isinstance(nested, dict) and nested is not entry:
+            currency = _extract_history_currency(nested)
+            if currency:
+                return currency
+    return None
+
+
+def normalize_price_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not history:
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    eur_rate: Optional[float] = None
+
+    for item in history:
+        if not isinstance(item, dict):
+            continue
+        date_value = _extract_history_date(item)
+        if not date_value:
+            continue
+        price_value = _extract_nested_price(item, _PRICE_HISTORY_KEYS)
+        if price_value is None:
+            continue
+        currency_code = _extract_history_currency(item) or "EUR"
+        currency_code = currency_code.upper()
+
+        if currency_code == "PLN":
+            final_price = round(price_value, 2)
+            final_currency = "PLN"
+        else:
+            if currency_code in {"EUR", "EURO", "€"}:
+                if eur_rate is None:
+                    eur_rate = get_eur_pln_rate()
+                if eur_rate:
+                    final_price = round(price_value * eur_rate * 1.24, 2)
+                    final_currency = "PLN"
+                else:
+                    final_price = round(price_value, 2)
+                    final_currency = "EUR"
+            else:
+                final_price = round(price_value, 2)
+                final_currency = currency_code
+
+        normalized.append(
+            {
+                "date": date_value.isoformat(),
+                "price": final_price,
+                "currency": final_currency,
+            }
+        )
+
+    if not normalized:
+        return []
+
+    deduped: dict[str, dict[str, Any]] = {}
+    for entry in normalized:
+        deduped[entry["date"]] = entry
+
+    return [deduped[key] for key in sorted(deduped.keys())]
+
+
+def slice_price_history(
+    history: list[dict[str, Any]], window: Optional[int] = None
+) -> list[dict[str, Any]]:
+    if not history:
+        return []
+    ordered = sorted(history, key=lambda item: item.get("date") or "")
+    if window is None or window <= 0:
+        return [dict(point) for point in ordered]
+    return [dict(point) for point in ordered[-window:]]

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -154,6 +154,7 @@
     "price-desc",
   ];
   const CARD_SORT_ALLOWED = new Set(CARD_SORT_OPTIONS);
+  const DEFAULT_SHOP_URL = "https://kartoteka.shop/pl/c/Karty-Pokemon/38";
   let currentCardViewMode = "grid";
   let currentCardSortOrder = "relevance";
 
@@ -870,6 +871,10 @@
       return { primary: null, fallback: null };
     }
     const customIcon = (item.set_icon || "").trim() || null;
+    const localOverride = (item.set_icon_path || "").trim() || null;
+    if (localOverride) {
+      return { primary: localOverride, fallback: customIcon };
+    }
     const setCodeRaw = (item.set_code || "").trim();
     if (!setCodeRaw) {
       return { primary: customIcon, fallback: null };
@@ -1506,22 +1511,365 @@
     }
   };
 
-  const renderCardDetail = (card) => {
+  const PRICE_HISTORY_RANGE_LABELS = Object.freeze({
+    last_7: "ostatnie 7 dni",
+    last_30: "ostatnie 30 dni",
+    all: "pełny zakres",
+  });
+
+  const createPriceHistoryModule = () => {
+    const section = document.getElementById("card-price-history-section");
+    const chart = document.getElementById("card-price-chart");
+    const chartLayer = chart?.querySelector("#card-price-chart-data");
+    const emptyState = document.getElementById("card-price-chart-empty");
+    const controls = Array.from(document.querySelectorAll("[data-price-range]"));
+
+    if (!section || !chart || !chartLayer || !emptyState || !controls.length) {
+      return { setData: () => {} };
+    }
+
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const ranges = {
+      last_7: [],
+      last_30: [],
+      all: [],
+    };
+    let activeRange = "last_30";
+
+    const parseHistoryPoints = (items) => {
+      if (!Array.isArray(items)) return [];
+      const parsed = [];
+      for (const item of items) {
+        const price = normalizePriceInput(item?.price);
+        if (price === null) continue;
+        const dateValue = typeof item?.date === "string" ? item.date.trim() : "";
+        if (!dateValue) continue;
+        const parsedDate = new Date(dateValue);
+        const isValidDate = !Number.isNaN(parsedDate.getTime());
+        parsed.push({
+          price,
+          iso: dateValue,
+          date: isValidDate ? parsedDate : null,
+          label: isValidDate ? parsedDate.toLocaleDateString("pl-PL") : dateValue,
+        });
+      }
+      parsed.sort((a, b) => {
+        if (a.date && b.date) {
+          return a.date - b.date;
+        }
+        return a.iso.localeCompare(b.iso);
+      });
+      return parsed;
+    };
+
+    const updateControls = (rangeKey) => {
+      controls.forEach((button) => {
+        const key = button.dataset.priceRange;
+        const hasData = Boolean(key && ranges[key] && ranges[key].length);
+        button.disabled = !hasData;
+        const isActive = hasData && key === rangeKey;
+        button.classList.toggle("is-active", isActive);
+        button.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+    };
+
+    const setChartAriaLabel = (rangeKey, points) => {
+      if (!points.length) {
+        chart.setAttribute("aria-label", "Brak danych historii cen");
+        return;
+      }
+      const label = PRICE_HISTORY_RANGE_LABELS[rangeKey] || rangeKey || "";
+      const firstPoint = points[0];
+      const lastPoint = points[points.length - 1];
+      const priceText = Number.isFinite(lastPoint.price)
+        ? formatCardPrice(lastPoint.price)
+        : "";
+      const suffix = priceText ? `. Aktualna cena ${priceText}.` : ".";
+      chart.setAttribute(
+        "aria-label",
+        `Historia cen (${label}): od ${firstPoint.label} do ${lastPoint.label}${suffix}`,
+      );
+    };
+
+    const renderChart = (rangeKey) => {
+      const points = ranges[rangeKey] || [];
+      chartLayer.innerHTML = "";
+
+      if (!points.length) {
+        emptyState.hidden = false;
+        chart.setAttribute("aria-hidden", "true");
+        setChartAriaLabel(rangeKey, points);
+        return;
+      }
+
+      emptyState.hidden = true;
+      chart.setAttribute("aria-hidden", "false");
+
+      const width = 100;
+      const height = 48;
+      const marginX = 6;
+      const marginY = 8;
+      const prices = points.map((point) => point.price);
+      const minPrice = Math.min(...prices);
+      const maxPrice = Math.max(...prices);
+      const priceRange = maxPrice - minPrice || 1;
+      const step = points.length > 1 ? (width - marginX * 2) / (points.length - 1) : 0;
+
+      const areaParts = [];
+      const lineParts = [];
+      let lastX = width / 2;
+      let lastY = height / 2;
+
+      points.forEach((point, index) => {
+        const x = points.length === 1 ? width / 2 : marginX + index * step;
+        const normalized = (point.price - minPrice) / priceRange;
+        const y = height - marginY - normalized * (height - marginY * 2);
+        const command = index === 0 ? "M" : "L";
+        lineParts.push(`${command}${x.toFixed(2)} ${y.toFixed(2)}`);
+        areaParts.push(`${command}${x.toFixed(2)} ${y.toFixed(2)}`);
+        lastX = x;
+        lastY = y;
+      });
+
+      if (points.length > 1) {
+        areaParts.push(`L${lastX.toFixed(2)} ${height - marginY}`);
+        areaParts.push(`L${marginX.toFixed(2)} ${height - marginY}`);
+      } else {
+        areaParts.push(`L${lastX.toFixed(2)} ${height - marginY}`);
+        areaParts.push(`L${lastX.toFixed(2)} ${height - marginY}`);
+      }
+      areaParts.push("Z");
+
+      const areaPath = document.createElementNS(SVG_NS, "path");
+      areaPath.setAttribute("class", "card-price-chart-area");
+      areaPath.setAttribute("d", areaParts.join(" "));
+      areaPath.setAttribute("fill", "url(#card-price-chart-gradient)");
+
+      const linePath = document.createElementNS(SVG_NS, "path");
+      linePath.setAttribute("class", "card-price-chart-line");
+      linePath.setAttribute("d", lineParts.join(" "));
+
+      const marker = document.createElementNS(SVG_NS, "circle");
+      marker.setAttribute("class", "card-price-chart-marker");
+      marker.setAttribute("cx", lastX.toFixed(2));
+      marker.setAttribute("cy", lastY.toFixed(2));
+      marker.setAttribute("r", "1.6");
+
+      chartLayer.appendChild(areaPath);
+      chartLayer.appendChild(linePath);
+      chartLayer.appendChild(marker);
+      chart.dataset.range = rangeKey;
+      setChartAriaLabel(rangeKey, points);
+    };
+
+    controls.forEach((button) => {
+      button.addEventListener("click", () => {
+        const rangeKey = button.dataset.priceRange;
+        if (!rangeKey || !ranges[rangeKey] || !ranges[rangeKey].length) {
+          return;
+        }
+        activeRange = rangeKey;
+        updateControls(activeRange);
+        renderChart(activeRange);
+      });
+    });
+
+    return {
+      setData(history) {
+        ranges.last_7 = parseHistoryPoints(history?.last_7);
+        ranges.last_30 = parseHistoryPoints(history?.last_30);
+        ranges.all = parseHistoryPoints(history?.all);
+
+        const availableRange = ["last_7", "last_30", "all"].find(
+          (key) => ranges[key] && ranges[key].length,
+        );
+
+        if (!availableRange) {
+          chartLayer.innerHTML = "";
+          chart.setAttribute("aria-hidden", "true");
+          emptyState.hidden = false;
+          controls.forEach((button) => {
+            button.disabled = true;
+            button.classList.remove("is-active");
+            button.setAttribute("aria-pressed", "false");
+          });
+          section.hidden = true;
+          return;
+        }
+
+        section.hidden = false;
+        activeRange = availableRange;
+        updateControls(activeRange);
+        renderChart(activeRange);
+      },
+    };
+  };
+
+  const renderCardDetail = (card, options = {}) => {
     if (!card) return;
+    const { priceHistoryModule } = options;
+
+    const sanitizeText = (value) => (typeof value === "string" ? value.trim() : value);
+    const setTextOrFallback = (element, value, fallback = "—") => {
+      if (!element) return;
+      const textValue = sanitizeText(value);
+      if (textValue || textValue === 0) {
+        element.textContent = String(textValue);
+      } else {
+        element.textContent = fallback;
+      }
+    };
+
     const title = document.getElementById("card-detail-title");
     if (title) {
-      title.textContent = card.name || "Szczegóły karty";
+      title.textContent = sanitizeText(card.name) || "Szczegóły karty";
     }
+
+    const era = document.getElementById("card-detail-era");
+    if (era) {
+      const eraValue = sanitizeText(card.series);
+      if (eraValue) {
+        era.textContent = eraValue;
+        era.hidden = false;
+      } else {
+        era.textContent = "";
+        era.hidden = true;
+      }
+    }
+
     const setName = document.getElementById("card-detail-set-name");
-    if (setName) setName.textContent = card.set_name || "";
-    const number = document.getElementById("card-detail-number");
-    if (number) number.textContent = card.number_display || card.number || "";
-    const rarity = document.getElementById("card-detail-rarity");
-    if (rarity) rarity.textContent = card.rarity || "";
-    const total = document.getElementById("card-detail-total");
-    if (total) total.textContent = card.total || "";
-    const release = document.getElementById("card-detail-release");
-    if (release) release.textContent = card.release_date || "";
+    if (setName) {
+      setName.textContent = sanitizeText(card.set_name) || "Nieznany dodatek";
+    }
+
+    const setCodeElement = document.getElementById("card-detail-set-code");
+    if (setCodeElement) {
+      const codeValue = sanitizeText(card.set_code);
+      setCodeElement.textContent = (codeValue || "SET").toUpperCase();
+    }
+
+    const { primary: setIconUrl, fallback: setIconFallbackUrl } = resolveSetIconUrl(card);
+    const setIconImage = document.getElementById("card-detail-set-icon");
+    if (setIconImage) {
+      const fallbackElement = setCodeElement;
+      if (setIconUrl) {
+        setIconImage.hidden = false;
+        setIconImage.alt = sanitizeText(card.set_name)
+          ? `Symbol dodatku ${sanitizeText(card.set_name)}`
+          : "Symbol dodatku";
+        setIconImage.src = setIconUrl;
+        if (fallbackElement) {
+          fallbackElement.hidden = true;
+        }
+        if (setIconFallbackUrl && setIconFallbackUrl !== setIconUrl) {
+          setIconImage.dataset.cardSetIconFallbackUrl = setIconFallbackUrl;
+          setIconImage.dataset.cardSetIconFallbackTried = "false";
+        } else {
+          delete setIconImage.dataset.cardSetIconFallbackUrl;
+          delete setIconImage.dataset.cardSetIconFallbackTried;
+        }
+        if (!setIconImage.dataset.cardSetIconHandlerAttached) {
+          setIconImage.addEventListener("error", () => {
+            const fallbackUrl = setIconImage.dataset.cardSetIconFallbackUrl;
+            if (fallbackUrl && setIconImage.dataset.cardSetIconFallbackTried !== "true") {
+              setIconImage.dataset.cardSetIconFallbackTried = "true";
+              setIconImage.src = fallbackUrl;
+              return;
+            }
+            setIconImage.hidden = true;
+            setIconImage.removeAttribute("src");
+            if (fallbackElement) {
+              fallbackElement.hidden = false;
+            }
+          });
+          setIconImage.dataset.cardSetIconHandlerAttached = "true";
+        }
+      } else {
+        setIconImage.hidden = true;
+        setIconImage.removeAttribute("src");
+        if (fallbackElement) {
+          fallbackElement.hidden = false;
+        }
+      }
+    } else if (setCodeElement) {
+      setCodeElement.hidden = !sanitizeText(card.set_code);
+    }
+
+    const numberElement = document.getElementById("card-detail-number");
+    setTextOrFallback(numberElement, card.number_display || card.number);
+    const rarityElement = document.getElementById("card-detail-rarity");
+    setTextOrFallback(rarityElement, card.rarity);
+    const totalElement = document.getElementById("card-detail-total");
+    setTextOrFallback(totalElement, card.total);
+    const releaseElement = document.getElementById("card-detail-release");
+    setTextOrFallback(releaseElement, card.release_date);
+
+    const artistElement = document.getElementById("card-detail-artist");
+    const artistValue = sanitizeText(card.artist);
+    if (artistElement) {
+      if (artistValue) {
+        artistElement.textContent = `Ilustrator: ${artistValue}`;
+        artistElement.hidden = false;
+      } else {
+        artistElement.textContent = "";
+        artistElement.hidden = true;
+      }
+    }
+
+    const descriptionSection = document.getElementById("card-detail-description-section");
+    const descriptionContent = document.getElementById("card-detail-description");
+    const descriptionMeta = document.getElementById("card-detail-description-meta");
+    const descriptionValue = sanitizeText(card.description);
+    if (descriptionSection && descriptionContent) {
+      if (descriptionValue) {
+        descriptionContent.textContent = descriptionValue;
+        descriptionSection.hidden = false;
+      } else {
+        descriptionContent.textContent = "";
+        descriptionSection.hidden = true;
+      }
+    }
+    if (descriptionMeta) {
+      if (artistValue) {
+        descriptionMeta.textContent = `Ilustrator: ${artistValue}`;
+        descriptionMeta.hidden = false;
+      } else {
+        descriptionMeta.textContent = "";
+        descriptionMeta.hidden = true;
+      }
+    }
+
+    const priceBadge = document.getElementById("card-detail-price-badge");
+    const priceElement = document.getElementById("card-detail-price");
+    const priceValue = normalizePriceInput(card.price);
+    if (priceBadge && priceElement) {
+      if (priceValue !== null) {
+        priceElement.textContent = formatCardPrice(priceValue);
+        priceBadge.hidden = false;
+      } else {
+        priceElement.textContent = "";
+        priceBadge.hidden = true;
+      }
+    }
+
+    const averageBadge = document.getElementById("card-detail-price-average-badge");
+    const averageElement = document.getElementById("card-detail-price-average");
+    const averageValue = normalizePriceInput(card.price_7d_average);
+    if (averageBadge && averageElement) {
+      if (averageValue !== null) {
+        averageElement.textContent = formatCardPrice(averageValue);
+        averageBadge.hidden = false;
+      } else {
+        averageElement.textContent = "";
+        averageBadge.hidden = true;
+      }
+    }
+
+    const buyButton = document.getElementById("detail-buy-button");
+    if (buyButton) {
+      const shopUrl = sanitizeText(card.shop_url) || DEFAULT_SHOP_URL;
+      buyButton.href = shopUrl;
+    }
 
     const image = document.getElementById("card-detail-image");
     const placeholder = document.getElementById("card-detail-placeholder");
@@ -1534,6 +1882,10 @@
         image.hidden = true;
         if (placeholder) placeholder.hidden = false;
       }
+    }
+
+    if (priceHistoryModule && typeof priceHistoryModule.setData === "function") {
+      priceHistoryModule.setData(card.price_history || {});
     }
   };
 
@@ -1569,6 +1921,7 @@
     const container = document.getElementById("card-detail-page");
     if (!container) return;
     const alertBox = document.getElementById("card-detail-alert");
+    const priceHistoryModule = createPriceHistoryModule();
     const params = new URLSearchParams();
     const name = container.dataset.name || "";
     const number = container.dataset.number || "";
@@ -1587,7 +1940,7 @@
 
     apiFetch(`/cards/info?${params.toString()}`)
       .then((data) => {
-        renderCardDetail(data?.card);
+        renderCardDetail(data?.card, { priceHistoryModule });
         renderRelatedCards(data?.related || []);
         showAlert(alertBox, "");
       })

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1308,9 +1308,187 @@ img {
 }
 
 .card-detail-set {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   font-size: 1rem;
   color: var(--color-muted);
   margin-bottom: 16px;
+}
+
+.card-detail-set-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.card-detail-set-icon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+
+.card-detail-set-code {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.card-detail-set-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card-detail-price-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.card-price-badge {
+  min-width: 150px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.card-price-badge-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.card-price-badge-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.card-detail-artist {
+  margin: 0 0 12px;
+  color: var(--color-muted);
+}
+
+.card-detail-description {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-detail-description-content {
+  white-space: pre-line;
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.card-detail-description-meta {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.card-detail-history {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-detail-history-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card-price-history-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.card-price-history-button {
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.card-price-history-button:hover:not(:disabled),
+.card-price-history-button:focus-visible:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.card-price-history-button.is-active {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.card-price-history-button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.card-price-chart-container {
+  position: relative;
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-price-chart-figure {
+  width: 100%;
+  height: 220px;
+}
+
+.card-price-chart-area {
+  opacity: 0.45;
+}
+
+.card-price-chart-line {
+  stroke: var(--color-accent);
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.card-price-chart-marker {
+  fill: var(--color-surface);
+  stroke: var(--color-accent);
+  stroke-width: 1.4;
+}
+
+.card-price-chart-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--color-muted);
+  padding: 24px;
 }
 
 .card-detail-meta {
@@ -1730,6 +1908,19 @@ img {
 
   .card-detail-main {
     grid-template-columns: 1fr;
+  }
+
+  .card-detail-price-badges {
+    flex-direction: column;
+  }
+
+  .card-detail-history-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .card-price-history-controls {
+    justify-content: flex-start;
   }
 
   .collection-table {

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -26,9 +26,38 @@
       <p class="card-detail-era" id="card-detail-era" hidden></p>
       <h1 id="card-detail-title">{{ card_name or 'Szczegóły karty' }}</h1>
       <div class="card-detail-set">
-        <span id="card-detail-set-name">{{ card_set_name or '' }}</span>
+        <div class="card-detail-set-badge">
+          <img
+            id="card-detail-set-icon"
+            class="card-detail-set-icon"
+            alt="Symbol dodatku"
+            loading="lazy"
+            decoding="async"
+            hidden
+            data-card-set-icon
+          />
+          <span
+            class="card-detail-set-code"
+            id="card-detail-set-code"
+            hidden
+            data-card-set-icon-fallback
+          ></span>
+        </div>
+        <div class="card-detail-set-text">
+          <span id="card-detail-set-name">{{ card_set_name or '' }}</span>
+        </div>
       </div>
-      <p class="card-detail-artist" id="card-detail-artist"></p>
+      <div class="card-detail-price-badges">
+        <div class="card-price-badge" id="card-detail-price-badge" hidden>
+          <span class="card-price-badge-label">Aktualna cena</span>
+          <span class="card-price-badge-value" id="card-detail-price"></span>
+        </div>
+        <div class="card-price-badge" id="card-detail-price-average-badge" hidden>
+          <span class="card-price-badge-label">Średnia 7 dni</span>
+          <span class="card-price-badge-value" id="card-detail-price-average"></span>
+        </div>
+      </div>
+      <p class="card-detail-artist" id="card-detail-artist" hidden></p>
       <dl class="card-detail-meta">
         <div>
           <dt>Numer</dt>
@@ -53,6 +82,50 @@
       </div>
       <div class="alert" id="card-detail-alert" hidden></div>
     </div>
+  </div>
+</section>
+
+<section class="panel card-detail-description" id="card-detail-description-section" hidden>
+  <div class="panel-header">
+    <div>
+      <h2>Opis karty</h2>
+      <p class="card-detail-description-meta" id="card-detail-description-meta" hidden></p>
+    </div>
+  </div>
+  <div class="card-detail-description-content" id="card-detail-description"></div>
+</section>
+
+<section class="panel card-detail-history" id="card-price-history-section" hidden>
+  <div class="panel-header card-detail-history-header">
+    <div>
+      <h2>Historia cen</h2>
+      <p>Zobacz, jak zmieniała się wartość tej karty.</p>
+    </div>
+    <div class="card-price-history-controls" role="group" aria-label="Zakres historii cen">
+      <button type="button" class="card-price-history-button is-active" data-price-range="last_7">7d</button>
+      <button type="button" class="card-price-history-button" data-price-range="last_30">30d</button>
+      <button type="button" class="card-price-history-button" data-price-range="all">All</button>
+    </div>
+  </div>
+  <div class="card-price-chart-container">
+    <svg
+      class="card-price-chart-figure"
+      id="card-price-chart"
+      viewBox="0 0 100 48"
+      role="img"
+      aria-labelledby="card-price-chart-title"
+      preserveAspectRatio="none"
+    >
+      <title id="card-price-chart-title">Historia ceny karty</title>
+      <defs>
+        <linearGradient id="card-price-chart-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.3" />
+          <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+      <g id="card-price-chart-data" class="card-price-chart-data"></g>
+    </svg>
+    <p class="card-price-chart-empty" id="card-price-chart-empty" hidden>Brak danych do wyświetlenia.</p>
   </div>
 </section>
 

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
 from sqlmodel import select
 
 from kartoteka_web import database, models
@@ -116,6 +118,9 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "release_date": "1999/06/16",
             "price": 12.34,
             "price_7d_average": 11.11,
+            "id": "jng-133",
+            "description": "Opis testowy karty",
+            "shop_url": "https://example.com/shop/jungle",
         },
         {
             "name": "Eevee",
@@ -133,6 +138,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "release_date": "1999/10/10",
             "price": 8.5,
             "price_7d_average": 7.25,
+            "id": "fsl-133",
         },
     ]
 
@@ -173,6 +179,19 @@ def test_card_search_and_detail(api_client, monkeypatch):
         "kartoteka_web.routes.cards.tcg_api.search_cards",
         fake_search_cards,
     )
+
+    price_history_payload = [
+        {"date": "2024-01-01", "marketPrice": 10.0, "currency": "EUR"},
+        {"date": "2024-01-05", "marketPrice": 12.5, "currency": "EUR"},
+        {"date": "2024-01-10", "marketPrice": 9.75, "currency": "EUR"},
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "fetch_card_price_history",
+        lambda *args, **kwargs: price_history_payload,
+    )
+    monkeypatch.setattr(cards_routes.tcg_api, "get_eur_pln_rate", lambda: 4.0)
 
     with database.session_scope() as session:
         assert session.exec(select(models.Card)).all() == []
@@ -239,6 +258,15 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert info.status_code == 200, info.text
     detail = info.json()
     assert detail["card"]["set_name"] == "Jungle"
+    assert detail["card"]["shop_url"] == "https://example.com/shop/jungle"
+    assert detail["card"]["description"] == "Opis testowy karty"
+    history = detail["card"]["price_history"]
+    assert history["all"]
+    assert len(history["all"]) == 3
+    assert len(history["last_7"]) == 3
+    assert len(history["last_30"]) == 3
+    assert history["all"][0]["currency"] == "PLN"
+    assert history["all"][0]["price"] == pytest.approx(10.0 * 4.0 * 1.24, rel=1e-3)
     assert len(detail["related"]) == 2
 
     missing = api_client.get(

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -392,6 +392,27 @@ def test_build_card_payload_includes_rarity_symbol():
     assert payload["rarity_symbol"] == "https://example.com/rarity.svg"
 
 
+def test_build_card_payload_includes_description_and_shop_url(monkeypatch):
+    monkeypatch.setattr(tcg_api, "get_eur_pln_rate", lambda: None)
+    card = {
+        "id": "base1-4",
+        "name": "Charizard",
+        "number": "4/102",
+        "set": {"name": "Base Set"},
+        "abilities": [{"name": "Energy Burn", "text": "All Energy attached becomes Fire."}],
+        "attacks": [{"name": "Fire Spin", "text": "Discard 2 Energy from Charizard."}],
+        "cardmarket": {"url": "https://example.com/cardmarket"},
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert "Energy Burn" in (payload.get("description") or "")
+    assert "Fire Spin" in (payload.get("description") or "")
+    assert payload.get("shop_url") == "https://example.com/cardmarket"
+    assert payload.get("id") == "base1-4"
+
+
 def test_build_cards_endpoint_supports_nested_paths():
     url = tcg_api._build_cards_endpoint(
         "https://pokemon-tcg-api.p.rapidapi.com",
@@ -444,3 +465,36 @@ def test_fetch_card_price_history_handles_non_200_response():
     call = session.calls[0]
     assert call["url"] == "https://pokemon-tcg-api.p.rapidapi.com/cards/base1-4/history-prices"
     assert history == []
+
+
+def test_normalize_price_history_converts_to_pln(monkeypatch):
+    monkeypatch.setattr(tcg_api, "get_eur_pln_rate", lambda: 4.0)
+    history = [
+        {"date": "2024-01-01", "marketPrice": 10.0, "currency": "EUR"},
+        {"date": "2024-01-02T00:00:00Z", "prices": {"market": 11.0}, "currencyCode": "EUR"},
+        {"date": "2024-01-03", "marketPrice": 15.0, "currency": "PLN"},
+    ]
+
+    normalized = tcg_api.normalize_price_history(history)
+
+    assert [entry["date"] for entry in normalized] == [
+        "2024-01-01",
+        "2024-01-02",
+        "2024-01-03",
+    ]
+    assert normalized[0]["price"] == pytest.approx(10.0 * 4.0 * 1.24, rel=1e-3)
+    assert normalized[0]["currency"] == "PLN"
+    assert normalized[-1]["price"] == pytest.approx(15.0, rel=1e-3)
+    assert normalized[-1]["currency"] == "PLN"
+
+
+def test_slice_price_history_returns_limited_range():
+    history = [
+        {"date": f"2024-01-{day:02d}", "price": float(day), "currency": "PLN"}
+        for day in range(1, 11)
+    ]
+
+    sliced = tcg_api.slice_price_history(history, 3)
+
+    assert len(sliced) == 3
+    assert [entry["date"] for entry in sliced] == ["2024-01-08", "2024-01-09", "2024-01-10"]


### PR DESCRIPTION
## Summary
- extend card detail schema and API route to fetch set icons, descriptions, shop links, and price history via RapidAPI
- expose new metadata on the frontend with updated template, JavaScript renderer, and interactive price history chart
- add supporting styles and unit tests covering new payload helpers and API behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de6135b3f0832f9b4ad147e7c0c4fd