### PR TITLE
Add automatic migration for card price columns

### DIFF
--- a/kartoteka_web/database.py
+++ b/kartoteka_web/database.py
@@ -10,6 +10,8 @@ from contextlib import asynccontextmanager, contextmanager, nullcontext
 from typing import AsyncIterator, Iterator
 from weakref import WeakKeyDictionary
 
+from sqlalchemy import inspect
+from sqlalchemy.exc import NoSuchTableError
 from sqlmodel import Session, SQLModel, create_engine
 
 DATABASE_URL = os.getenv("KARTOTEKA_DATABASE_URL", "sqlite:///./kartoteka.db")
@@ -68,8 +70,41 @@ def init_db() -> None:
     from . import models  # noqa: F401  # pylint: disable=unused-import
 
     logger.info("Ensuring database tables are created")
+    _ensure_card_price_columns()
     SQLModel.metadata.create_all(engine)
     logger.info("Database tables confirmed")
+
+
+def _ensure_card_price_columns() -> None:
+    """Add missing price columns on the card table for older schemas."""
+
+    inspector = inspect(engine)
+
+    try:
+        existing_columns = {column["name"] for column in inspector.get_columns("card")}
+    except NoSuchTableError:
+        # Table does not exist yet, nothing to migrate.
+        return
+
+    missing_columns = [
+        column_name
+        for column_name in ("price", "price_7d_average")
+        if column_name not in existing_columns
+    ]
+
+    if not missing_columns:
+        return
+
+    logger.info(
+        "Migrating card table to include missing price columns: %s", missing_columns
+    )
+
+    with engine.begin() as connection:
+        for column_name in missing_columns:
+            connection.exec_driver_sql(
+                f"ALTER TABLE card ADD COLUMN {column_name} REAL"  # noqa: S608
+            )
+
 
 
 async def get_session() -> AsyncIterator[Session]:

--- a/tests/test_database_migration.py
+++ b/tests/test_database_migration.py
@@ -1,0 +1,75 @@
+"""Tests for database schema migrations."""
+
+from __future__ import annotations
+
+import importlib
+
+from sqlalchemy import inspect
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, create_engine
+
+
+def _create_legacy_card_table(engine: Engine) -> None:
+    """Create a legacy `card` table missing the price columns."""
+
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            """
+            CREATE TABLE card (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR NOT NULL,
+                number VARCHAR NOT NULL,
+                set_name VARCHAR NOT NULL,
+                set_code VARCHAR,
+                rarity VARCHAR,
+                image_small VARCHAR,
+                image_large VARCHAR
+            );
+            """
+        )
+
+
+def test_init_db_adds_missing_price_columns(monkeypatch, tmp_path):
+    """`init_db` should backfill price columns for legacy schemas."""
+
+    db_path = tmp_path / "legacy.db"
+    db_url = f"sqlite:///{db_path}"
+
+    legacy_engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    _create_legacy_card_table(legacy_engine)
+    legacy_engine.dispose()
+
+    monkeypatch.setenv("KARTOTEKA_DATABASE_URL", db_url)
+
+    import kartoteka_web.database as database
+
+    # Reload the database module so it picks up the temporary database URL.
+    database.engine.dispose()
+    database = importlib.reload(database)
+
+    database.init_db()
+
+    inspector = inspect(database.engine)
+    column_names = {column["name"] for column in inspector.get_columns("card")}
+    assert {"price", "price_7d_average"}.issubset(column_names)
+
+    # Insert and fetch a card with price data to prove the columns are operational.
+    from kartoteka_web.models import Card  # Imported lazily to avoid circular imports.
+
+    with Session(database.engine) as session:
+        card = Card(
+            name="Test Card",
+            number="001",
+            set_name="Test Set",
+            price=9.99,
+            price_7d_average=8.75,
+        )
+        session.add(card)
+        session.commit()
+
+        refreshed = session.get(Card, card.id)
+
+    assert refreshed is not None
+    assert refreshed.price == 9.99
+    assert refreshed.price_7d_average == 8.75
+


### PR DESCRIPTION
## Summary
- detect missing price columns on the card table before metadata creation
- automatically backfill the price columns when needed during database init
- cover the migration path with a regression test that verifies price persistence

## Testing
- pytest tests/test_database_migration.py

------
https://chatgpt.com/codex/tasks/task_e_68de681d8c20832f9e53f69066076b89