### PR TITLE
Normalize local card set code lookups

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -16,7 +16,7 @@ from .. import models, schemas
 from ..auth import get_current_user, get_optional_user
 from ..database import get_session
 from ..services import tcg_api
-from ..utils import images as image_utils, text
+from ..utils import images as image_utils, text, sets as set_utils
 
 router = APIRouter(prefix="/cards", tags=["cards"])
 
@@ -297,7 +297,7 @@ def _find_card(
     name_value = name.strip()
     number_value = number.strip()
     set_name_value = (set_name or "").strip()
-    set_code_value = (set_code or "").strip()
+    set_code_value = set_utils.clean_code(set_code) or ""
 
     if number_value:
         stmt = select(models.Card).where(models.Card.number == number_value)
@@ -325,14 +325,29 @@ def _find_card(
                     return candidate
 
     if set_code_value:
-        stmt = select(models.Card).where(models.Card.set_code == set_code_value)
-        if number_value:
-            stmt = stmt.where(models.Card.number == number_value)
-        elif number_clean and number_clean != number_value:
-            stmt = stmt.where(models.Card.number == number_clean)
-        card = session.exec(stmt).first()
-        if card:
-            return card
+        stmt = select(models.Card).where(models.Card.set_code.is_not(None))
+        if set_name_value:
+            stmt = stmt.where(models.Card.set_name == set_name_value)
+        candidates = session.exec(stmt).all()
+        for candidate in candidates:
+            candidate_code = set_utils.clean_code(candidate.set_code)
+            if candidate_code != set_code_value:
+                continue
+            numbers_to_match = {
+                value for value in (number_value, number_clean) if value
+            }
+            if numbers_to_match:
+                candidate_numbers = {
+                    value
+                    for value in (
+                        candidate.number or "",
+                        text.sanitize_number(candidate.number or ""),
+                    )
+                    if value
+                }
+                if candidate_numbers.isdisjoint(numbers_to_match):
+                    continue
+            return candidate
 
     if name_value and number_value:
         stmt = select(models.Card).where(

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -279,6 +279,32 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert unauthenticated_search.status_code == 401
 
 
+def test_card_info_accepts_normalized_set_code(api_client):
+    with database.session_scope() as session:
+        session.add(
+            models.Card(
+                name="Charizard",
+                number="4",
+                set_name="Base Set",
+                set_code="UPPER-SET",
+                rarity="Rare",
+            )
+        )
+
+    response = api_client.get(
+        "/cards/info",
+        params={
+            "name": "Charizard",
+            "number": "4",
+            "set_code": "upper-set",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["card"]["set_code"] == "UPPER-SET"
+
+
 def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
     headers = _auth_headers(api_client, username="misty", password="starmie")
 


### PR DESCRIPTION
## Summary
- normalize incoming and stored set codes when resolving local card records so lookups handle mixed casing
- fall back to Python-level comparisons using sanitized set codes while still respecting optional number and set filters
- add a regression test ensuring /cards/info succeeds when a stored uppercase set code is queried with its normalized lowercase form

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68de6ac1ada4832f85e04e07bc85cd4b