### PR TITLE
Add Pokémon TCG set icon synchronizer

### DIFF
--- a/kartoteka_web/services/__init__.py
+++ b/kartoteka_web/services/__init__.py
@@ -1,5 +1,5 @@
 """External service integrations used by the web layer."""
 
-from . import tcg_api
+from . import set_icons, tcg_api
 
-__all__ = ["tcg_api"]
+__all__ = ["tcg_api", "set_icons"]

--- a/kartoteka_web/services/set_icons.py
+++ b/kartoteka_web/services/set_icons.py
@@ -1,0 +1,161 @@
+"""Utilities for fetching and caching official Pokémon TCG set icons."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+import requests
+from requests import Response
+from requests.adapters import HTTPAdapter, Retry
+
+from kartoteka_web.utils import sets as set_utils
+
+logger = logging.getLogger(__name__)
+
+SET_ICON_DIRECTORY = Path("icon/set")
+SET_LIST_URL = "https://api.pokemontcg.io/v2/sets"
+SET_API_KEY_ENV = "POKEMON_TCG_API_KEY"
+
+
+def _build_retrying_session() -> requests.Session:
+    session = requests.Session()
+    retries = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("GET",),
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    session.headers.setdefault("User-Agent", "kartoteka/1.0")
+    api_key = os.getenv(SET_API_KEY_ENV, "").strip()
+    if api_key:
+        session.headers.setdefault("X-Api-Key", api_key)
+    return session
+
+
+def _extract_clean_code(set_payload: dict[str, object]) -> Optional[str]:
+    raw_candidates: Iterable[Optional[str]] = (
+        set_payload.get("id"),
+        set_payload.get("code"),
+        set_payload.get("setCode"),
+        set_payload.get("ptcgoCode"),
+        set_payload.get("name"),
+    )
+    for candidate in raw_candidates:
+        if not isinstance(candidate, str):
+            continue
+        cleaned = set_utils.clean_code(candidate)
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _extract_symbol_url(set_payload: dict[str, object]) -> Optional[str]:
+    images = set_payload.get("images")
+    if isinstance(images, dict):
+        symbol = images.get("symbol")
+        if isinstance(symbol, str) and symbol.strip():
+            return symbol.strip()
+    return None
+
+
+def _fetch_set_payloads(
+    *, session: requests.Session, timeout: float = 10.0
+) -> list[dict[str, object]]:
+    try:
+        response: Response = session.get(SET_LIST_URL, timeout=timeout)
+    except requests.Timeout:
+        logger.warning("Timed out while fetching Pokémon set definitions")
+        return []
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.warning("Failed to fetch Pokémon set definitions: %s", exc)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "Pokémon TCG API returned status %s while fetching sets", response.status_code
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError:
+        logger.warning("Pokémon TCG API returned invalid JSON for set list")
+        return []
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        logger.warning("Pokémon TCG API payload lacked a set list")
+        return []
+
+    sets: list[dict[str, object]] = []
+    for item in data:
+        if isinstance(item, dict):
+            sets.append(item)
+    return sets
+
+
+def ensure_set_icons(
+    *,
+    force: bool = False,
+    icons_directory: Path | str = SET_ICON_DIRECTORY,
+    session: requests.Session | None = None,
+    timeout: float = 10.0,
+) -> list[Path]:
+    """Ensure the Pokémon set icon cache is populated locally."""
+
+    target_directory = Path(icons_directory)
+    try:
+        target_directory.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - filesystem errors
+        logger.warning("Unable to create icon directory %s: %s", target_directory, exc)
+        return []
+
+    http = session or _build_retrying_session()
+    saved_paths: list[Path] = []
+    for set_payload in _fetch_set_payloads(session=http, timeout=timeout):
+        clean_code = _extract_clean_code(set_payload)
+        if not clean_code:
+            continue
+        symbol_url = _extract_symbol_url(set_payload)
+        if not symbol_url:
+            continue
+        destination = target_directory / f"{clean_code}.png"
+        if destination.exists() and not force:
+            continue
+
+        try:
+            response = http.get(symbol_url, timeout=timeout)
+        except requests.Timeout:
+            logger.warning("Timeout while downloading symbol for set %s", clean_code)
+            continue
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to download symbol for set %s: %s", clean_code, exc)
+            continue
+
+        if response.status_code != 200:
+            logger.warning(
+                "Pokémon TCG API returned status %s for symbol %s",
+                response.status_code,
+                clean_code,
+            )
+            continue
+
+        try:
+            destination.write_bytes(response.content)
+        except OSError as exc:  # pragma: no cover - filesystem errors
+            logger.warning("Failed to save symbol for set %s: %s", clean_code, exc)
+            continue
+
+        saved_paths.append(destination)
+
+    return saved_paths
+
+
+__all__ = ["ensure_set_icons"]
+

--- a/server.py
+++ b/server.py
@@ -21,11 +21,13 @@ from kartoteka_web import models
 from kartoteka_web.auth import get_current_user, oauth2_scheme
 from kartoteka_web.database import init_db, session_scope
 from kartoteka_web.routes import cards, users
+from kartoteka_web.services import set_icons
 from kartoteka_web.utils import images as image_utils, sets as set_utils, text
 
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
+    set_icons.ensure_set_icons()
     yield
 
 

--- a/tests/test_set_icons_service.py
+++ b/tests/test_set_icons_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from kartoteka_web.services import set_icons
+
+
+class DummyResponse:
+    def __init__(self, *, status_code: int = 200, json_data=None, content: bytes = b""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.content = content
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("No JSON payload present")
+        return self._json_data
+
+
+class DummySession:
+    def __init__(self, responses: dict[str, list[DummyResponse]]):
+        self._responses = responses
+        self.headers: dict[str, str] = {}
+        self.requested: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None):  # noqa: D401 - mimic requests
+        self.requested.append(url)
+        try:
+            queue = self._responses[url]
+        except KeyError as exc:  # pragma: no cover - guard for misconfigured tests
+            raise AssertionError(f"Unexpected URL requested: {url}") from exc
+        if not queue:
+            raise AssertionError(f"No more responses available for {url}")
+        return queue.pop(0)
+
+
+def _session_with_set_payload(set_payloads: list[dict[str, object]], *, symbol_responses):
+    responses: dict[str, list[DummyResponse]] = {
+        set_icons.SET_LIST_URL: [
+            DummyResponse(json_data={"data": set_payloads}),
+        ]
+    }
+    responses.update(symbol_responses)
+    return DummySession(responses)
+
+
+def test_set_icons_downloads_missing_symbols(tmp_path: Path):
+    symbol_url = "https://img.example/swsh1.png"
+    session = _session_with_set_payload(
+        [
+            {"id": "swsh1", "images": {"symbol": symbol_url}},
+            {"id": "Missing", "images": {}},
+            {"name": "Promo Collection"},
+        ],
+        symbol_responses={
+            symbol_url: [DummyResponse(content=b"fake-bytes")],
+        },
+    )
+
+    saved = set_icons.ensure_set_icons(
+        icons_directory=tmp_path,
+        session=session,
+    )
+
+    expected_path = tmp_path / "swsh1.png"
+    assert expected_path.exists()
+    assert expected_path.read_bytes() == b"fake-bytes"
+    assert saved == [expected_path]
+
+    # Ensure a clean code was derived for the entry with only a name.
+    assert not (tmp_path / "promocollection.png").exists()
+
+
+def test_set_icons_skips_existing_files_without_force(tmp_path: Path):
+    existing_path = tmp_path / "base1.png"
+    existing_path.write_bytes(b"original")
+
+    symbol_url = "https://img.example/base1.png"
+    another_symbol_url = "https://img.example/base2.png"
+    session = _session_with_set_payload(
+        [
+            {"id": "base1", "images": {"symbol": symbol_url}},
+            {"id": "base2", "images": {"symbol": another_symbol_url}},
+        ],
+        symbol_responses={
+            another_symbol_url: [DummyResponse(content=b"new")],
+        },
+    )
+
+    saved = set_icons.ensure_set_icons(
+        icons_directory=tmp_path,
+        session=session,
+        force=False,
+    )
+
+    assert existing_path.read_bytes() == b"original"
+    assert saved == [tmp_path / "base2.png"]
+    assert session.requested.count(symbol_url) == 0
+    assert session.requested.count(another_symbol_url) == 1
+
+
+def test_set_icons_force_overwrites_existing(tmp_path: Path):
+    existing_path = tmp_path / "svpblackstar.png"
+    existing_path.write_bytes(b"old")
+
+    set_payload = {
+        "name": "SVP Black Star",
+        "images": {"symbol": "https://img.example/svp.png"},
+    }
+    session = _session_with_set_payload(
+        [set_payload],
+        symbol_responses={
+            "https://img.example/svp.png": [DummyResponse(content=b"updated")],
+        },
+    )
+
+    saved = set_icons.ensure_set_icons(
+        icons_directory=tmp_path,
+        session=session,
+        force=True,
+    )
+
+    assert existing_path.read_bytes() == b"updated"
+    assert saved == [existing_path]
+


### PR DESCRIPTION
## Summary
- add a service that pulls Pokémon set metadata via the official API and downloads missing symbol icons
- invoke the icon updater during FastAPI startup so new sets populate automatically
- cover the downloader with regression tests that exercise skipping and overwrite behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de6c1c75c8832fbbf5ab8c01910f90