### PR TITLE
Run set icon refresh in background thread

### DIFF
--- a/kartoteka_web/services/set_icons.py
+++ b/kartoteka_web/services/set_icons.py
@@ -116,45 +116,50 @@ def ensure_set_icons(
         logger.warning("Unable to create icon directory %s: %s", target_directory, exc)
         return []
 
+    created_session = session is None
     http = session or _build_retrying_session()
-    saved_paths: list[Path] = []
-    for set_payload in _fetch_set_payloads(session=http, timeout=timeout):
-        clean_code = _extract_clean_code(set_payload)
-        if not clean_code:
-            continue
-        symbol_url = _extract_symbol_url(set_payload)
-        if not symbol_url:
-            continue
-        destination = target_directory / f"{clean_code}.png"
-        if destination.exists() and not force:
-            continue
+    try:
+        saved_paths: list[Path] = []
+        for set_payload in _fetch_set_payloads(session=http, timeout=timeout):
+            clean_code = _extract_clean_code(set_payload)
+            if not clean_code:
+                continue
+            symbol_url = _extract_symbol_url(set_payload)
+            if not symbol_url:
+                continue
+            destination = target_directory / f"{clean_code}.png"
+            if destination.exists() and not force:
+                continue
 
-        try:
-            response = http.get(symbol_url, timeout=timeout)
-        except requests.Timeout:
-            logger.warning("Timeout while downloading symbol for set %s", clean_code)
-            continue
-        except requests.RequestException as exc:  # pragma: no cover - network errors
-            logger.warning("Failed to download symbol for set %s: %s", clean_code, exc)
-            continue
+            try:
+                response = http.get(symbol_url, timeout=timeout)
+            except requests.Timeout:
+                logger.warning("Timeout while downloading symbol for set %s", clean_code)
+                continue
+            except requests.RequestException as exc:  # pragma: no cover - network errors
+                logger.warning("Failed to download symbol for set %s: %s", clean_code, exc)
+                continue
 
-        if response.status_code != 200:
-            logger.warning(
-                "Pokémon TCG API returned status %s for symbol %s",
-                response.status_code,
-                clean_code,
-            )
-            continue
+            if response.status_code != 200:
+                logger.warning(
+                    "Pokémon TCG API returned status %s for symbol %s",
+                    response.status_code,
+                    clean_code,
+                )
+                continue
 
-        try:
-            destination.write_bytes(response.content)
-        except OSError as exc:  # pragma: no cover - filesystem errors
-            logger.warning("Failed to save symbol for set %s: %s", clean_code, exc)
-            continue
+            try:
+                destination.write_bytes(response.content)
+            except OSError as exc:  # pragma: no cover - filesystem errors
+                logger.warning("Failed to save symbol for set %s: %s", clean_code, exc)
+                continue
 
-        saved_paths.append(destination)
+            saved_paths.append(destination)
 
-    return saved_paths
+        return saved_paths
+    finally:
+        if created_session:
+            http.close()
 
 
 __all__ = ["ensure_set_icons"]

--- a/server.py
+++ b/server.py
@@ -6,6 +6,7 @@ import contextlib
 from pathlib import Path
 from typing import Any
 
+import anyio
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
@@ -27,7 +28,7 @@ from kartoteka_web.utils import images as image_utils, sets as set_utils, text
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
-    set_icons.ensure_set_icons()
+    await anyio.to_thread.run_sync(set_icons.ensure_set_icons)
     yield
 
 

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -1,0 +1,35 @@
+import asyncio
+import threading
+import time
+
+import server
+
+
+def test_lifespan_runs_set_icon_refresh_in_background(monkeypatch):
+    call_details: dict[str, threading.Thread] = {}
+
+    def slow_ensure() -> list[object]:
+        call_details["thread"] = threading.current_thread()
+        time.sleep(0.2)
+        return []
+
+    monkeypatch.setattr(server, "init_db", lambda: None)
+    monkeypatch.setattr(server.set_icons, "ensure_set_icons", slow_ensure)
+
+    async def exercise_lifespan():
+        async with server.lifespan(server.app):
+            pass
+
+    async def run_test():
+        start = time.perf_counter()
+        task = asyncio.create_task(exercise_lifespan())
+        await asyncio.sleep(0)
+        mid = time.perf_counter()
+        assert mid - start < 0.1
+        await asyncio.wait_for(task, timeout=1.0)
+
+    asyncio.run(run_test())
+
+    thread = call_details.get("thread")
+    assert thread is not None
+    assert thread is not threading.main_thread()

--- a/tests/test_set_icons_service.py
+++ b/tests/test_set_icons_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+
+import anyio
 
 from kartoteka_web.services import set_icons
 
@@ -122,4 +125,63 @@ def test_set_icons_force_overwrites_existing(tmp_path: Path):
 
     assert existing_path.read_bytes() == b"updated"
     assert saved == [existing_path]
+
+
+def test_set_icons_thread_invocation_matches_results(tmp_path: Path):
+    symbol_url = "https://img.example/swsh1.png"
+
+    def build_session() -> DummySession:
+        return _session_with_set_payload(
+            [
+                {"id": "swsh1", "images": {"symbol": symbol_url}},
+            ],
+            symbol_responses={
+                symbol_url: [DummyResponse(content=b"threaded")],
+            },
+        )
+
+    direct_dir = tmp_path / "direct"
+    thread_dir = tmp_path / "thread"
+    direct_dir.mkdir()
+    thread_dir.mkdir()
+
+    direct_saved = set_icons.ensure_set_icons(
+        icons_directory=direct_dir,
+        session=build_session(),
+    )
+
+    async def run_in_thread() -> list[Path]:
+        return await anyio.to_thread.run_sync(
+            lambda: set_icons.ensure_set_icons(
+                icons_directory=thread_dir,
+                session=build_session(),
+            )
+        )
+
+    threaded_saved = asyncio.run(run_in_thread())
+
+    assert [path.name for path in threaded_saved] == [path.name for path in direct_saved]
+    for path in threaded_saved:
+        assert path.read_bytes() == b"threaded"
+
+
+def test_set_icons_closes_created_session(monkeypatch, tmp_path: Path):
+    class CloseTrackingSession(DummySession):
+        def __init__(self):
+            super().__init__(
+                {
+                    set_icons.SET_LIST_URL: [DummyResponse(json_data={"data": []})],
+                }
+            )
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    session = CloseTrackingSession()
+    monkeypatch.setattr(set_icons, "_build_retrying_session", lambda: session)
+
+    set_icons.ensure_set_icons(icons_directory=tmp_path)
+
+    assert session.closed is True
 


### PR DESCRIPTION
## Summary
- run the set icon bootstrap in the FastAPI lifespan using `anyio.to_thread.run_sync`
- close internally created HTTP sessions inside `ensure_set_icons`
- add regression tests covering threaded execution and the non-blocking lifespan startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de6e23c39c832fa48324b744e5b125