### PR TITLE
Add local set icon paths to card APIs

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -107,21 +107,14 @@ def _normalize_lower(value: str | None) -> str:
     return (value or "").strip().lower()
 
 
-def _sanitize_set_code(value: str | None) -> str:
-    return re.sub(r"[^a-z0-9-]", "", (value or "").strip().lower())
-
-
-def _local_set_icon_path(set_code: str | None) -> str | None:
-    normalized = _sanitize_set_code(set_code)
-    if not normalized:
-        return None
-    candidate = SET_ICON_DIRECTORY / f"{normalized}.png"
-    try:
-        if candidate.exists():
-            return f"{SET_ICON_URL_BASE}/{normalized}.png"
-    except OSError:
-        return None
-    return None
+def _local_set_icon_path(set_code: str | None, set_name: str | None = None) -> str | None:
+    _, icon_path = set_utils.resolve_cached_set_icon(
+        set_code=set_code,
+        set_name=set_name,
+        icons_directory=SET_ICON_DIRECTORY,
+        url_base=SET_ICON_URL_BASE,
+    )
+    return icon_path
 
 
 def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
@@ -136,6 +129,7 @@ def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
         image_small=card.image_small,
         image_large=card.image_large,
         set_icon=None,
+        set_icon_path=_local_set_icon_path(card.set_code, card.set_name),
         artist=None,
         series=None,
         release_date=None,
@@ -153,7 +147,7 @@ def _card_to_detail(card: models.Card) -> schemas.CardDetail:
         set_name=card.set_name,
         set_code=card.set_code,
         set_icon=None,
-        set_icon_path=_local_set_icon_path(card.set_code),
+        set_icon_path=_local_set_icon_path(card.set_code, card.set_name),
         image_small=card.image_small,
         image_large=card.image_large,
         rarity=card.rarity,
@@ -406,6 +400,9 @@ def _serialize_entries(
 
 
 def _payload_to_search_schema(payload: dict[str, Any]) -> schemas.CardSearchResult:
+    local_icon = payload.get("set_icon_path") or _local_set_icon_path(
+        payload.get("set_code"), payload.get("set_name")
+    )
     return schemas.CardSearchResult(
         name=payload.get("name") or "",
         number=payload.get("number") or "",
@@ -417,6 +414,7 @@ def _payload_to_search_schema(payload: dict[str, Any]) -> schemas.CardSearchResu
         image_small=payload.get("image_small"),
         image_large=payload.get("image_large"),
         set_icon=payload.get("set_icon"),
+        set_icon_path=local_icon,
         artist=payload.get("artist"),
         series=payload.get("series"),
         release_date=payload.get("release_date"),
@@ -565,6 +563,7 @@ def card_info(
             "total",
             "set_name",
             "set_code",
+            "set_icon_path",
             "image_small",
             "image_large",
             "rarity",
@@ -599,7 +598,9 @@ def card_info(
     if not detail.shop_url:
         detail.shop_url = DEFAULT_SHOP_URL
 
-    detail.set_icon_path = _local_set_icon_path(detail.set_code) or detail.set_icon_path
+    local_icon = _local_set_icon_path(detail.set_code, detail.set_name)
+    if local_icon:
+        detail.set_icon_path = local_icon
 
     detail.price_history = schemas.CardPriceHistory()
     if remote_card_id:

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -65,6 +65,7 @@ class CardSearchResult(SQLModel):
     image_small: Optional[str] = None
     image_large: Optional[str] = None
     set_icon: Optional[str] = None
+    set_icon_path: Optional[str] = None
     artist: Optional[str] = None
     series: Optional[str] = None
     release_date: Optional[str] = None

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from ..utils import text
+from ..utils import text, sets as set_utils
 
 logger = logging.getLogger(__name__)
 
@@ -549,6 +549,12 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         or card.get("set_logo")
     )
 
+    icon_slug, set_icon_path = set_utils.resolve_cached_set_icon(
+        episode,
+        set_code=set_code_value,
+        set_name=set_name_value,
+    )
+
     rarity_symbol = (
         card.get("rarity_symbol")
         or card.get("raritySymbol")
@@ -613,6 +619,8 @@ def build_card_payload(card: dict[str, Any]) -> Optional[dict[str, Any]]:
         "series": series,
         "release_date": release_date,
         "set_icon": set_icon,
+        "set_icon_path": set_icon_path,
+        "set_icon_slug": icon_slug,
         "rarity_symbol": rarity_symbol,
         "price": price_pln,
         "price_7d_average": price_7d_average_pln,

--- a/kartoteka_web/utils/sets.py
+++ b/kartoteka_web/utils/sets.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
 
 from . import text
+
+
+SET_ICON_URL_BASE = "/icon/set"
+DEFAULT_ICON_DIRECTORY = Path(__file__).resolve().parents[2] / "icon" / "set"
 
 
 def clean_code(code: Optional[str]) -> Optional[str]:
@@ -28,3 +33,45 @@ def slugify_set_identifier(*, set_code: Optional[str] = None, set_name: Optional
         return "unknown"
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
     return slug or "unknown"
+
+
+def resolve_cached_set_icon(
+    set_payload: Mapping[str, object] | None = None,
+    *,
+    set_code: Optional[str] = None,
+    set_name: Optional[str] = None,
+    icons_directory: Path | str | None = None,
+    url_base: str = SET_ICON_URL_BASE,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return a cached set icon slug and URL if the file exists locally."""
+
+    directory = Path(icons_directory) if icons_directory is not None else DEFAULT_ICON_DIRECTORY
+
+    raw_candidates: Sequence[Optional[str]]
+    if set_payload is not None:
+        raw_candidates = (
+            set_payload.get("id"),
+            set_payload.get("code"),
+            set_payload.get("setCode"),
+            set_payload.get("ptcgoCode"),
+            set_payload.get("name"),
+            set_code,
+            set_name,
+        )
+    else:
+        raw_candidates = (set_code, set_name)
+
+    for candidate in raw_candidates:
+        if not isinstance(candidate, str):
+            continue
+        slug = clean_code(candidate)
+        if not slug:
+            continue
+        try:
+            icon_path = directory / f"{slug}.png"
+            if icon_path.is_file():
+                normalized_base = url_base.rstrip("/") or "/"
+                return slug, f"{normalized_base}/{slug}.png"
+        except OSError:
+            return slug, None
+    return None, None

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -107,8 +107,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "number": "133",
             "number_display": "133/151",
             "total": "151",
-            "set_name": "Jungle",
-            "set_code": "jng",
+            "set_name": "Base Set",
+            "set_code": "base1",
             "rarity": "Common",
             "image_small": "https://example.com/eevee-jungle-small.jpg",
             "image_large": "https://example.com/eevee-jungle-large.jpg",
@@ -127,8 +127,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
             "number": "133",
             "number_display": "133/151",
             "total": "151",
-            "set_name": "Fossil",
-            "set_code": "fsl",
+            "set_name": "Base Set 2",
+            "set_code": "base2",
             "rarity": "Common",
             "image_small": "https://example.com/eevee-fossil-small.jpg",
             "image_large": "https://example.com/eevee-fossil-large.jpg",
@@ -214,9 +214,12 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert payload["page"] == 1
     assert payload["per_page"] == 20
     assert payload["suggested_query"] == "Eevee"
-    assert {item["set_code"] for item in payload["items"]} == {"jng", "fsl"}
+    assert {item["set_code"] for item in payload["items"]} == {"base1", "base2"}
     assert sorted(item["price"] for item in payload["items"]) == [8.5, 12.34]
     assert sorted(item["price_7d_average"] for item in payload["items"]) == [7.25, 11.11]
+    icon_map = {item["set_code"]: item["set_icon_path"] for item in payload["items"]}
+    assert icon_map["base1"] == "/icon/set/base1.png"
+    assert icon_map["base2"] == "/icon/set/base2.png"
 
     with database.session_scope() as session:
         session.add_all(
@@ -224,22 +227,22 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 models.Card(
                     name="Eevee",
                     number="133",
-                    set_name="Jungle",
-                    set_code="jng",
+                    set_name="Base Set",
+                    set_code="base1",
                     rarity="Common",
                 ),
                 models.Card(
                     name="Eevee",
                     number="133",
-                    set_name="Fossil",
-                    set_code="fsl",
+                    set_name="Base Set 2",
+                    set_code="base2",
                     rarity="Common",
                 ),
                 models.Card(
                     name="Eevee",
                     number="060",
-                    set_name="Base Set",
-                    set_code="base",
+                    set_name="Base Set 3",
+                    set_code="base3",
                     rarity="Common",
                 ),
             ]
@@ -250,14 +253,15 @@ def test_card_search_and_detail(api_client, monkeypatch):
         params={
             "name": "Eevee",
             "number": "133",
-            "set_name": "Jungle",
-            "set_code": "jng",
+            "set_name": "Base Set",
+            "set_code": "base1",
             "related_limit": 2,
         },
     )
     assert info.status_code == 200, info.text
     detail = info.json()
-    assert detail["card"]["set_name"] == "Jungle"
+    assert detail["card"]["set_name"] == "Base Set"
+    assert detail["card"]["set_icon_path"] == "/icon/set/base1.png"
     assert detail["card"]["shop_url"] == "https://example.com/shop/jungle"
     assert detail["card"]["description"] == "Opis testowy karty"
     history = detail["card"]["price_history"]
@@ -268,6 +272,9 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert history["all"][0]["currency"] == "PLN"
     assert history["all"][0]["price"] == pytest.approx(10.0 * 4.0 * 1.24, rel=1e-3)
     assert len(detail["related"]) == 2
+    related_icons = {item["set_code"]: item["set_icon_path"] for item in detail["related"]}
+    assert related_icons["base2"] == "/icon/set/base2.png"
+    assert related_icons["base3"] == "/icon/set/base3.png"
 
     missing = api_client.get(
         "/cards/info",


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve cached set icon slugs and URLs
- populate set_icon_path in card payloads and schemas using the cached icons
- extend API tests to assert search and detail responses expose the local icon paths

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68deb7e2cd58832f99581c26fe270aa0