### PR TITLE
Prioritize set codes for cached icon slugs

### DIFF
--- a/kartoteka_web/services/set_icons.py
+++ b/kartoteka_web/services/set_icons.py
@@ -40,10 +40,11 @@ def _build_retrying_session() -> requests.Session:
 
 def _extract_clean_code(set_payload: dict[str, object]) -> Optional[str]:
     raw_candidates: Iterable[Optional[str]] = (
-        set_payload.get("id"),
         set_payload.get("code"),
         set_payload.get("setCode"),
         set_payload.get("ptcgoCode"),
+        set_payload.get("slug"),
+        set_payload.get("id"),
         set_payload.get("name"),
     )
     for candidate in raw_candidates:

--- a/kartoteka_web/utils/sets.py
+++ b/kartoteka_web/utils/sets.py
@@ -50,12 +50,13 @@ def resolve_cached_set_icon(
     raw_candidates: Sequence[Optional[str]]
     if set_payload is not None:
         raw_candidates = (
-            set_payload.get("id"),
+            set_code,
             set_payload.get("code"),
             set_payload.get("setCode"),
             set_payload.get("ptcgoCode"),
+            set_payload.get("slug"),
+            set_payload.get("id"),
             set_payload.get("name"),
-            set_code,
             set_name,
         )
     else:

--- a/tests/test_set_icons_service.py
+++ b/tests/test_set_icons_service.py
@@ -185,3 +185,12 @@ def test_set_icons_closes_created_session(monkeypatch, tmp_path: Path):
 
     assert session.closed is True
 
+
+def test_extract_clean_code_prefers_code_over_id():
+    payload = {
+        "id": "special-set",
+        "code": "base1",
+    }
+
+    assert set_icons._extract_clean_code(payload) == "base1"
+

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -310,6 +310,24 @@ def test_build_card_payload_extracts_cardmarket_price(monkeypatch):
     assert payload["price_7d_average"] is None
 
 
+def test_build_card_payload_prefers_episode_code_for_icon():
+    card = {
+        "name": "Pikachu",
+        "number": "025",
+        "set": {
+            "name": "Base Set",
+            "code": "base1",
+            "id": "base-set-001",
+        },
+    }
+
+    payload = tcg_api.build_card_payload(card)
+
+    assert payload is not None
+    assert payload["set_icon_slug"] == "base1"
+    assert payload["set_icon_path"] == "/icon/set/base1.png"
+
+
 def test_build_card_payload_prefers_tcgplayer_price_when_available(monkeypatch):
     monkeypatch.setattr(tcg_api, "get_eur_pln_rate", lambda: 4.0)
     card = {


### PR DESCRIPTION
## Summary
- prioritize set code fields when deriving cached icon filenames and lookup slugs
- add regression tests covering code-vs-id precedence for set icon resolution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dec35ba0c8832fac2968c20e73275a