### PR TITLE
Normalize set icon lookup using canonical slugs

### DIFF
--- a/kartoteka_web/utils/sets.py
+++ b/kartoteka_web/utils/sets.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import re
+from collections.abc import Mapping as MappingABC, Sequence as SequenceABC
+from functools import lru_cache
 from pathlib import Path
 from typing import Mapping, Optional, Sequence
 
@@ -10,7 +13,64 @@ from . import text
 
 
 SET_ICON_URL_BASE = "/icon/set"
-DEFAULT_ICON_DIRECTORY = Path(__file__).resolve().parents[2] / "icon" / "set"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ICON_DIRECTORY = REPO_ROOT / "icon" / "set"
+SET_DATA_PATH = REPO_ROOT / "tcg_sets.json"
+
+
+def _register_mapping_entry(mapping: dict[str, str], key: Optional[str], slug: str) -> None:
+    """Register ``key`` -> ``slug`` in ``mapping`` if the key is valid."""
+
+    normalized = clean_code(key)
+    if not normalized:
+        return
+    mapping.setdefault(normalized, slug)
+
+
+@lru_cache(maxsize=1)
+def load_canonical_set_code_map() -> Mapping[str, str]:
+    """Return a mapping of normalized identifiers to canonical set slugs."""
+
+    mapping: dict[str, str] = {}
+
+    try:
+        raw_data = json.loads(SET_DATA_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return mapping
+
+    for sets in raw_data.values():
+        if not isinstance(sets, SequenceABC):
+            continue
+        for entry in sets:
+            if not isinstance(entry, MappingABC):
+                continue
+            slug = clean_code(entry.get("code"))
+            if not slug:
+                continue
+
+            _register_mapping_entry(mapping, slug, slug)
+            _register_mapping_entry(mapping, entry.get("name"), slug)
+            _register_mapping_entry(mapping, entry.get("abbr"), slug)
+
+            base = re.sub(r"\d+$", "", slug)
+            if base and base != slug:
+                _register_mapping_entry(mapping, base, slug)
+
+            no_leading_zero = re.sub(r"^([a-z]+)0+(\d+)$", r"\1\2", slug)
+            if no_leading_zero and no_leading_zero != slug:
+                _register_mapping_entry(mapping, no_leading_zero, slug)
+
+    return mapping
+
+
+def resolve_canonical_set_slug(identifier: Optional[str]) -> Optional[str]:
+    """Return the canonical slug for ``identifier`` if available."""
+
+    slug = clean_code(identifier)
+    if not slug:
+        return None
+    mapping = load_canonical_set_code_map()
+    return mapping.get(slug, slug)
 
 
 def clean_code(code: Optional[str]) -> Optional[str]:
@@ -68,11 +128,19 @@ def resolve_cached_set_icon(
         slug = clean_code(candidate)
         if not slug:
             continue
+        canonical_slug = resolve_canonical_set_slug(slug)
+        slug_candidates = []
+        if canonical_slug:
+            slug_candidates.append(canonical_slug)
+        if canonical_slug != slug:
+            slug_candidates.append(slug)
+
         try:
-            icon_path = directory / f"{slug}.png"
-            if icon_path.is_file():
-                normalized_base = url_base.rstrip("/") or "/"
-                return slug, f"{normalized_base}/{slug}.png"
+            for slug_candidate in slug_candidates:
+                icon_path = directory / f"{slug_candidate}.png"
+                if icon_path.is_file():
+                    normalized_base = url_base.rstrip("/") or "/"
+                    return slug_candidate, f"{normalized_base}/{slug_candidate}.png"
         except OSError:
-            return slug, None
+            return slug_candidates[0] if slug_candidates else slug, None
     return None, None

--- a/tests/test_set_utils.py
+++ b/tests/test_set_utils.py
@@ -1,0 +1,24 @@
+"""Regression coverage for canonical set icon resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kartoteka_web.utils.sets import resolve_cached_set_icon
+
+
+def test_resolve_cached_set_icon_with_canonical_mapping(tmp_path: Path) -> None:
+    """Candidates with alternative codes should resolve to canonical slugs."""
+
+    icon_directory = tmp_path / "set-icons"
+    icon_directory.mkdir()
+    (icon_directory / "sv01.png").write_bytes(b"fake icon contents")
+
+    slug, url = resolve_cached_set_icon(
+        set_code="SV",
+        set_name="Scarlet & Violet",
+        icons_directory=icon_directory,
+    )
+
+    assert slug == "sv01"
+    assert url == "/icon/set/sv01.png"


### PR DESCRIPTION
## Summary
- load and cache canonical set slug mappings from tcg_sets.json for reuse
- normalize incoming set identifiers to canonical slugs before resolving icon files
- add regression coverage for resolving Scarlet & Violet icons from alternate codes

## Testing
- pytest tests/test_set_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dec882653c832f89dfa83ac1a0d5f7