### PR TITLE
Add rarity icon metadata to card detail

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -139,6 +139,7 @@ def _card_to_search_schema(card: models.Card) -> schemas.CardSearchResult:
 
 
 def _card_to_detail(card: models.Card) -> schemas.CardDetail:
+    rarity_symbol = tcg_api.resolve_rarity_icon_path(card.rarity)
     return schemas.CardDetail(
         name=card.name,
         number=card.number,
@@ -151,6 +152,8 @@ def _card_to_detail(card: models.Card) -> schemas.CardDetail:
         image_small=card.image_small,
         image_large=card.image_large,
         rarity=card.rarity,
+        rarity_symbol=rarity_symbol,
+        rarity_symbol_remote=None,
         artist=None,
         series=None,
         release_date=None,
@@ -575,6 +578,22 @@ def card_info(
             if value:
                 setattr(detail, attr, value)
 
+        rarity_symbol_value = remote_card.get("rarity_symbol")
+        if isinstance(rarity_symbol_value, str):
+            rarity_symbol_clean = rarity_symbol_value.strip()
+        else:
+            rarity_symbol_clean = None
+        if rarity_symbol_clean:
+            detail.rarity_symbol = rarity_symbol_clean
+
+        rarity_symbol_remote_value = remote_card.get("rarity_symbol_remote")
+        if isinstance(rarity_symbol_remote_value, str):
+            rarity_symbol_remote_clean = rarity_symbol_remote_value.strip()
+        else:
+            rarity_symbol_remote_clean = None
+        if rarity_symbol_remote_clean:
+            detail.rarity_symbol_remote = rarity_symbol_remote_clean
+
         price_value = remote_card.get("price")
         if price_value is not None:
             detail.price = price_value
@@ -601,6 +620,12 @@ def card_info(
     local_icon = _local_set_icon_path(detail.set_code, detail.set_name)
     if local_icon:
         detail.set_icon_path = local_icon
+
+    local_rarity_icon = tcg_api.resolve_rarity_icon_path(detail.rarity)
+    if local_rarity_icon and local_rarity_icon != detail.rarity_symbol:
+        detail.rarity_symbol = local_rarity_icon
+    if not detail.rarity_symbol and detail.rarity_symbol_remote:
+        detail.rarity_symbol = detail.rarity_symbol_remote
 
     detail.price_history = schemas.CardPriceHistory()
     if remote_card_id:

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -106,6 +106,8 @@ class CardDetail(SQLModel):
     image_small: Optional[str] = None
     image_large: Optional[str] = None
     rarity: Optional[str] = None
+    rarity_symbol: Optional[str] = None
+    rarity_symbol_remote: Optional[str] = None
     artist: Optional[str] = None
     series: Optional[str] = None
     release_date: Optional[str] = None

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -22,6 +22,33 @@ _EUR_PLN_RATE_TTL = 60 * 60  # 1 hour
 
 _RARITY_ICON_BASE_PATH = "/static/icons/rarity"
 _RARITY_ICON_IMAGE_BASE_PATH = "/icon/rarity"
+_RARITY_ICON_VECTOR_MAP = {
+    "common": f"{_RARITY_ICON_BASE_PATH}/common.svg",
+    "uncommon": f"{_RARITY_ICON_BASE_PATH}/uncommon.svg",
+    "rare": f"{_RARITY_ICON_BASE_PATH}/rare.svg",
+    "rare-holo": f"{_RARITY_ICON_BASE_PATH}/rare-holo.svg",
+    "holo-rare": f"{_RARITY_ICON_BASE_PATH}/rare-holo.svg",
+    "double-rare": f"{_RARITY_ICON_BASE_PATH}/rare-ultra.svg",
+    "rare-double": f"{_RARITY_ICON_BASE_PATH}/rare-ultra.svg",
+    "ultra-rare": f"{_RARITY_ICON_BASE_PATH}/rare-ultra.svg",
+    "rare-ultra": f"{_RARITY_ICON_BASE_PATH}/rare-ultra.svg",
+    "hyper-rare": f"{_RARITY_ICON_BASE_PATH}/rare-secret.svg",
+    "rare-secret": f"{_RARITY_ICON_BASE_PATH}/rare-secret.svg",
+    "secret-rare": f"{_RARITY_ICON_BASE_PATH}/rare-secret.svg",
+    "rare-rainbow": f"{_RARITY_ICON_BASE_PATH}/rare-rainbow.svg",
+    "rainbow-rare": f"{_RARITY_ICON_BASE_PATH}/rare-rainbow.svg",
+    "illustration-rare": f"{_RARITY_ICON_BASE_PATH}/rare-illustration.svg",
+    "rare-illustration": f"{_RARITY_ICON_BASE_PATH}/rare-illustration.svg",
+    "special-illustration-rare": f"{_RARITY_ICON_BASE_PATH}/rare-illustration.svg",
+    "rare-special-illustration": f"{_RARITY_ICON_BASE_PATH}/rare-illustration.svg",
+    "shiny-rare": f"{_RARITY_ICON_BASE_PATH}/rare-shiny.svg",
+    "rare-shiny": f"{_RARITY_ICON_BASE_PATH}/rare-shiny.svg",
+    "shinyrare": f"{_RARITY_ICON_BASE_PATH}/rare-shiny.svg",
+    "ace-spec": f"{_RARITY_ICON_BASE_PATH}/rare-ace.svg",
+    "rare-ace": f"{_RARITY_ICON_BASE_PATH}/rare-ace.svg",
+    "ace-spec-rare": f"{_RARITY_ICON_BASE_PATH}/rare-ace.svg",
+    "promo": f"{_RARITY_ICON_BASE_PATH}/promo.svg",
+}
 _RARITY_ICON_MAP = {
     "common": f"{_RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Common.png",
     "uncommon": f"{_RARITY_ICON_IMAGE_BASE_PATH}/Rarity_Uncommon.png",
@@ -114,12 +141,18 @@ def resolve_rarity_icon_path(rarity: Optional[str]) -> Optional[str]:
         return None
     normalized = _normalize_rarity_key(str(rarity))
     if normalized:
+        vector_icon = _RARITY_ICON_VECTOR_MAP.get(normalized)
+        if vector_icon:
+            return vector_icon
         mapped = _RARITY_ICON_MAP.get(normalized)
         if mapped:
             return mapped
     lower_value = str(rarity).lower()
     for pattern, key in _RARITY_ICON_RULES:
         if pattern.search(lower_value):
+            vector_icon = _RARITY_ICON_VECTOR_MAP.get(key)
+            if vector_icon:
+                return vector_icon
             return _RARITY_ICON_MAP.get(key)
     return None
 

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1742,24 +1742,27 @@
     }
 
     const setCodeElement = document.getElementById("card-detail-set-code");
+    const setCodeValue = sanitizeText(card.set_code);
     if (setCodeElement) {
-      const codeValue = sanitizeText(card.set_code);
-      setCodeElement.textContent = (codeValue || "SET").toUpperCase();
+      setCodeElement.textContent = (setCodeValue || "SET").toUpperCase();
+      setCodeElement.hidden = !setCodeValue;
     }
 
     const { primary: setIconUrl, fallback: setIconFallbackUrl } = resolveSetIconUrl(card);
     const setIconImage = document.getElementById("card-detail-set-icon");
     if (setIconImage) {
-      const fallbackElement = setCodeElement;
+      const showSetCode = () => {
+        if (setCodeElement && setCodeValue) {
+          setCodeElement.hidden = false;
+        }
+      };
       if (setIconUrl) {
         setIconImage.hidden = false;
-        setIconImage.alt = sanitizeText(card.set_name)
-          ? `Symbol dodatku ${sanitizeText(card.set_name)}`
+        const setNameValue = sanitizeText(card.set_name);
+        setIconImage.alt = setNameValue
+          ? `Symbol dodatku ${setNameValue}`
           : "Symbol dodatku";
         setIconImage.src = setIconUrl;
-        if (fallbackElement) {
-          fallbackElement.hidden = true;
-        }
         if (setIconFallbackUrl && setIconFallbackUrl !== setIconUrl) {
           setIconImage.dataset.cardSetIconFallbackUrl = setIconFallbackUrl;
           setIconImage.dataset.cardSetIconFallbackTried = "false";
@@ -1777,27 +1780,97 @@
             }
             setIconImage.hidden = true;
             setIconImage.removeAttribute("src");
-            if (fallbackElement) {
-              fallbackElement.hidden = false;
-            }
+            showSetCode();
           });
           setIconImage.dataset.cardSetIconHandlerAttached = "true";
         }
       } else {
         setIconImage.hidden = true;
         setIconImage.removeAttribute("src");
-        if (fallbackElement) {
-          fallbackElement.hidden = false;
-        }
+        showSetCode();
       }
-    } else if (setCodeElement) {
-      setCodeElement.hidden = !sanitizeText(card.set_code);
     }
 
+    const rarityValue = sanitizeText(card.rarity);
     const numberElement = document.getElementById("card-detail-number");
     setTextOrFallback(numberElement, card.number_display || card.number);
     const rarityElement = document.getElementById("card-detail-rarity");
-    setTextOrFallback(rarityElement, card.rarity);
+    setTextOrFallback(rarityElement, rarityValue);
+    const rarityIconElement = document.getElementById("card-detail-rarity-icon");
+    const rarityFallbackElement = document.getElementById("card-detail-rarity-fallback");
+    const raritySymbolValue = sanitizeText(card.rarity_symbol);
+    const raritySymbolRemoteValue = sanitizeText(card.rarity_symbol_remote);
+    const rarityFallbackLabel = (rarityValue || "?").charAt(0).toUpperCase() || "?";
+    if (rarityFallbackElement) {
+      rarityFallbackElement.textContent = rarityFallbackLabel;
+    }
+    if (rarityIconElement) {
+      const iconCandidates = [];
+      if (raritySymbolValue) {
+        iconCandidates.push(raritySymbolValue);
+      }
+      const resolvedRarityIcon = resolveRarityIconUrl(rarityValue);
+      if (resolvedRarityIcon && !iconCandidates.includes(resolvedRarityIcon)) {
+        iconCandidates.push(resolvedRarityIcon);
+      }
+      if (
+        raritySymbolRemoteValue
+        && !iconCandidates.includes(raritySymbolRemoteValue)
+      ) {
+        iconCandidates.push(raritySymbolRemoteValue);
+      }
+      const [primaryRarityIcon = "", fallbackRarityIcon = ""] = iconCandidates;
+      const showRarityFallback = () => {
+        if (rarityFallbackElement) {
+          rarityFallbackElement.hidden = false;
+        }
+      };
+      const hideRarityFallback = () => {
+        if (rarityFallbackElement) {
+          rarityFallbackElement.hidden = true;
+        }
+      };
+      const resetRarityIcon = () => {
+        rarityIconElement.hidden = true;
+        rarityIconElement.removeAttribute("src");
+        delete rarityIconElement.dataset.cardRarityIconFallbackUrl;
+        delete rarityIconElement.dataset.cardRarityIconFallbackTried;
+      };
+      if (primaryRarityIcon) {
+        rarityIconElement.hidden = false;
+        rarityIconElement.alt = rarityValue
+          ? `Symbol rzadkości ${rarityValue}`
+          : "Symbol rzadkości";
+        rarityIconElement.src = primaryRarityIcon;
+        hideRarityFallback();
+        if (fallbackRarityIcon && fallbackRarityIcon !== primaryRarityIcon) {
+          rarityIconElement.dataset.cardRarityIconFallbackUrl = fallbackRarityIcon;
+          rarityIconElement.dataset.cardRarityIconFallbackTried = "false";
+        } else {
+          delete rarityIconElement.dataset.cardRarityIconFallbackUrl;
+          delete rarityIconElement.dataset.cardRarityIconFallbackTried;
+        }
+        if (!rarityIconElement.dataset.cardRarityIconHandlerAttached) {
+          rarityIconElement.addEventListener("error", () => {
+            const fallbackUrl = rarityIconElement.dataset.cardRarityIconFallbackUrl;
+            if (fallbackUrl && rarityIconElement.dataset.cardRarityIconFallbackTried !== "true") {
+              rarityIconElement.dataset.cardRarityIconFallbackTried = "true";
+              rarityIconElement.src = fallbackUrl;
+              return;
+            }
+            resetRarityIcon();
+            showRarityFallback();
+          });
+          rarityIconElement.dataset.cardRarityIconHandlerAttached = "true";
+        }
+      } else {
+        resetRarityIcon();
+        showRarityFallback();
+      }
+    } else if (rarityFallbackElement) {
+      rarityFallbackElement.hidden = false;
+    }
+
     const totalElement = document.getElementById("card-detail-total");
     setTextOrFallback(totalElement, card.total);
     const releaseElement = document.getElementById("card-detail-release");

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1310,41 +1310,73 @@ img {
 .card-detail-set {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   font-size: 1rem;
   color: var(--color-muted);
   margin-bottom: 16px;
 }
 
-.card-detail-set-badge {
+.card-detail-set-visual {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.12);
+}
+
+.card-detail-set-badge,
+.card-detail-rarity-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
-  border: 1px solid var(--color-border);
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
   background: var(--color-surface-alt);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.12);
 }
 
-.card-detail-set-icon {
-  width: 40px;
-  height: 40px;
+.card-detail-set-icon,
+.card-detail-rarity-icon {
+  width: 36px;
+  height: 36px;
   object-fit: contain;
 }
 
 .card-detail-set-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 100%;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  font-size: 0.8rem;
-  color: var(--color-muted);
+  letter-spacing: 0.12em;
+  font-size: 0.82rem;
+  color: var(--color-text);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.card-detail-rarity-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  color: var(--color-text);
+  text-transform: uppercase;
 }
 
 .card-detail-set-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  color: var(--color-text);
 }
 
 .card-detail-price-badges {

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -26,22 +26,41 @@
       <p class="card-detail-era" id="card-detail-era" hidden></p>
       <h1 id="card-detail-title">{{ card_name or 'Szczegóły karty' }}</h1>
       <div class="card-detail-set">
-        <div class="card-detail-set-badge">
-          <img
-            id="card-detail-set-icon"
-            class="card-detail-set-icon"
-            alt="Symbol dodatku"
-            loading="lazy"
-            decoding="async"
-            hidden
-            data-card-set-icon
-          />
-          <span
-            class="card-detail-set-code"
-            id="card-detail-set-code"
-            hidden
-            data-card-set-icon-fallback
-          ></span>
+        <div class="card-detail-set-visual">
+          <div class="card-detail-set-badge">
+            <img
+              id="card-detail-set-icon"
+              class="card-detail-set-icon"
+              alt="Symbol dodatku"
+              loading="lazy"
+              decoding="async"
+              hidden
+              data-card-set-icon
+            />
+            <span
+              class="card-detail-set-code"
+              id="card-detail-set-code"
+              hidden
+              data-card-set-icon-fallback
+            ></span>
+          </div>
+          <div class="card-detail-rarity-badge">
+            <img
+              id="card-detail-rarity-icon"
+              class="card-detail-rarity-icon"
+              alt="Symbol rzadkości"
+              loading="lazy"
+              decoding="async"
+              hidden
+              data-card-rarity-icon
+            />
+            <span
+              class="card-detail-rarity-fallback"
+              id="card-detail-rarity-fallback"
+              hidden
+              aria-hidden="true"
+            ></span>
+          </div>
         </div>
         <div class="card-detail-set-text">
           <span id="card-detail-set-name">{{ card_set_name or '' }}</span>


### PR DESCRIPTION
## Summary
- expose `rarity_symbol` metadata from the API, preferring local vector icons and keeping remote fallbacks
- update the card detail template, scripts, and styles to show set and rarity visuals together with graceful degradation
- align rarity icon resolution logic so the frontend and backend share the same fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ded7d08a7c832fbd22e87c33f6e72d