### PR TITLE
Wrap grid badges in shared capsule

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -994,6 +994,12 @@
           </div>
         </div>
       `;
+      const setBadgesGridMarkup = `
+        <div class="card-search-set-badges">
+          ${setIconMarkup}
+          ${rarityIconMarkup}
+        </div>
+      `;
       const numberDisplay = numberLabel || "—";
       const priceDisplay = priceText || "—";
       if (isListView) {
@@ -1073,8 +1079,7 @@
               </a>
             </div>
           <div class="card-search-set">
-            ${setIconMarkup}
-            ${rarityIconMarkup}
+            ${setBadgesGridMarkup}
           </div>
         </div>
         <div class="card-search-info">

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1071,6 +1071,30 @@ img {
   background: none;
 }
 
+.card-search-set-badges {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-surface-alt);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28);
+}
+
+body[data-theme="dark"] .card-search-set-badges {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.card-search-set-badges .card-search-badge {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  min-height: 0;
+}
+
 .card-search-set-code {
   font-weight: 700;
   letter-spacing: 0.12em;


### PR DESCRIPTION
## Summary
- wrap the set and rarity badges in grid results inside a shared `.card-search-set-badges` container
- style the new badge capsule for light and dark themes and remove redundant borders on inner badges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df5f2859fc832f903111b3fda939a7