### PR TITLE
Adjust set badge layout for search cards

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1090,21 +1090,23 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
 .card-search-set {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
   gap: 12px;
   padding: 0;
   border: 0;
   background: none;
+  width: 100%;
 }
 
 .card-search-set-badges {
-  display: inline-flex;
+  display: flex;
+  width: 100%;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: 999px;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: 0;
   background: var(--color-surface-alt);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28);
 }


### PR DESCRIPTION
## Summary
- make the card search set badge bar expand across the card and use flex layout
- allow the card search set container to stretch its children across the full width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df65d39ef4832faba79225ee38766d