### PR TITLE
Adjust card list preview stacking context

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -784,6 +784,8 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
   border: none;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   flex-wrap: nowrap;
+  position: relative;
+  z-index: 0;
 }
 
 .card-search-results--list .card-search-item:hover,
@@ -859,7 +861,7 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
   visibility: hidden;
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
-  z-index: 10;
+  z-index: 20;
 }
 
 .card-search-list-preview img {


### PR DESCRIPTION
## Summary
- ensure card list items create a stacking context so hover previews can sit above neighbours
- raise the hover preview z-index to avoid being obscured by surrounding elements

## Testing
- browser_container.run_playwright_script (visual verification of hover previews)


------
https://chatgpt.com/codex/tasks/task_e_68df69040cac832f92732db3d5dad874