### PR TITLE
Adjust rarity badge styling for dark theme

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -925,6 +925,19 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
   gap: 8px;
 }
 
+body[data-theme="dark"] .card-search-badge--rarity {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  body[data-theme="auto"] .card-search-badge--rarity,
+  body:not([data-theme]) .card-search-badge--rarity {
+    background: rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+}
+
 .card-search-set-icon {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- align the rarity badge styling in dark mode with the set badge palette for consistent visuals
- extend the same background and inset shadow adjustments to auto and prefers-dark themes

## Testing
- uvicorn server:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68df6c6f537c832f995fcd72528cd100