### PR TITLE
Adjust floating alert placement on add card page

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -415,6 +415,17 @@ img {
   margin-bottom: 16px;
 }
 
+.alert--floating {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(640px, calc(100% - 32px));
+  margin: 0;
+  z-index: 2000;
+  box-shadow: var(--shadow-soft);
+}
+
 .alert[data-variant="success"] {
   border-color: rgba(22, 163, 74, 0.35);
   background: rgba(22, 163, 74, 0.08);
@@ -436,6 +447,10 @@ img {
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+}
+
+main:has(#add-card-page) {
+  padding-top: 96px;
 }
 
 .collection-table th,

--- a/kartoteka_web/templates/add_card.html
+++ b/kartoteka_web/templates/add_card.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% block title %}Dodaj kartę - Kartoteka{% endblock %}
 {% block content %}
+<div
+  class="alert alert--floating"
+  id="add-card-alert"
+  hidden
+  role="status"
+  aria-live="polite"
+></div>
 <section class="page-hero add-card-hero">
   <div>
     <p class="eyebrow">Rozszerz swoją kolekcję</p>
@@ -36,7 +43,6 @@
       </div>
     </div>
   </form>
-  <div class="alert" id="add-card-alert" hidden></div>
   <div class="card-search-toolbar" data-card-search-toolbar>
     <div class="card-search-toolbar-group card-search-toolbar-group--sort">
       <label for="card-sort-select">Sortowanie</label>


### PR DESCRIPTION
## Summary
- move the add-card alert container outside of the add-card panel so it can float over the page content
- style the floating alert so it stays pinned to the top center of the viewport and remains visible
- add extra main padding on the add card page to avoid the fixed alert overlapping the content

## Testing
- manual: opened http://127.0.0.1:8000/cards/add and verified the alert renders in the new floating position

------
https://chatgpt.com/codex/tasks/task_e_68df74e6e270832f9c35068621c74a33