### PR TITLE
Make card search list layout use full width

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -730,6 +730,8 @@ main:has(#add-card-page) {
 .card-search-results--list {
   display: grid;
   gap: 0;
+  grid-template-columns: minmax(0, 1fr);
+  width: 100%;
 }
 
 .card-search-results--grid {
@@ -791,17 +793,17 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
 }
 
 .card-search-results--list .card-search-item {
-  --card-search-list-columns: auto minmax(72px, auto) minmax(0, 1fr) minmax(72px, auto)
-    minmax(160px, auto) minmax(80px, auto) auto;
+  --card-search-list-columns: auto minmax(56px, auto) minmax(0, 2fr) minmax(56px, auto)
+    minmax(140px, auto) minmax(72px, auto) auto;
   display: grid;
   align-items: center;
   grid-template-columns: var(
     --card-search-list-columns,
     auto auto minmax(0, 1fr) auto auto auto auto
   );
-  column-gap: 16px;
-  row-gap: 12px;
-  padding: 12px 18px;
+  column-gap: 12px;
+  row-gap: 6px;
+  padding: 8px 12px;
   background: none;
   border: none;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
@@ -824,8 +826,8 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
   );
   grid-template-areas: "thumb set name number rarity price form";
   align-items: center;
-  column-gap: 16px;
-  row-gap: 12px;
+  column-gap: 12px;
+  row-gap: 6px;
   width: 100%;
 }
 
@@ -913,7 +915,7 @@ body[data-theme="dark"] .card-search-results--grid .card-search-item:focus-withi
 
 .card-search-list-title {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--color-text);
 }
@@ -1005,7 +1007,7 @@ body[data-theme="dark"] .card-search-badge--rarity {
   grid-area: number;
   justify-self: center;
   text-align: center;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--color-muted);
   white-space: nowrap;
 }
@@ -1018,7 +1020,7 @@ body[data-theme="dark"] .card-search-badge--rarity {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--color-muted);
   white-space: nowrap;
 }
@@ -1035,6 +1037,7 @@ body[data-theme="dark"] .card-search-badge--rarity {
   grid-area: price;
   justify-self: end;
   text-align: right;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--color-accent-dark);
   white-space: nowrap;
@@ -1375,7 +1378,7 @@ body[data-theme="dark"] .card-search-set-badges {
   .card-search-results--list .card-search-item {
     --card-search-list-columns: minmax(0, 1fr);
     grid-template-columns: var(--card-search-list-columns);
-    row-gap: 16px;
+    row-gap: 12px;
   }
 
   .card-search-list-row {
@@ -1386,7 +1389,7 @@ body[data-theme="dark"] .card-search-set-badges {
       "number rarity"
       "price price"
       "form form";
-    row-gap: 16px;
+    row-gap: 12px;
   }
 
   .card-search-list-set {


### PR DESCRIPTION
## Summary
- make the list view container stretch across its panel by using a single grid column
- rebalance the list row template so the name column grows and the number column keeps a fixed minimum width
- tighten spacing and font sizing (desktop and mobile) to deliver a more compact list presentation

## Testing
- Manually verified desktop and mobile card search list layout in the browser

------
https://chatgpt.com/codex/tasks/task_e_68df75ba8c44832fa0c7f3b662079308