### PR TITLE
Adjust card grid layout sizing

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -737,7 +737,8 @@ main:has(#add-card-page) {
 .card-search-results--grid {
   display: grid;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 260px));
+  justify-content: center;
 }
 
 .card-search-item {
@@ -756,6 +757,8 @@ main:has(#add-card-page) {
   background: var(--color-surface-alt);
   box-shadow: var(--shadow-card);
   min-height: 100%;
+  max-width: 260px;
+  margin: 0 auto;
 }
 
 .card-search-results--grid .card-search-item:hover,


### PR DESCRIPTION
## Summary
- keep grid view cards at a fixed width and center the layout when there is extra space
- cap individual grid card widths so thumbnails maintain their intended size

## Testing
- Manual UI verification in grid and list view modes

------
https://chatgpt.com/codex/tasks/task_e_68df7d8c6494832f9d96778a6f0b731c