### PR TITLE
Fix card search pagination totals and expose remote counts

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -470,7 +470,7 @@ def search_cards_endpoint(
         requested_page = 1
     requested_page = max(1, requested_page)
 
-    records, total_count = tcg_api.search_cards(
+    records, filtered_total, upstream_total = tcg_api.search_cards(
         name=name_value or search_query,
         number=number_value,
         set_name=set_name,
@@ -484,9 +484,11 @@ def search_cards_endpoint(
         rapidapi_host=RAPIDAPI_HOST,
     )
 
-    effective_total = min(overall_cap, max(len(records), total_count))
     if result_cap < overall_cap:
         records = records[:result_cap]
+
+    filtered_total = len(records)
+    effective_total = min(overall_cap, filtered_total)
     max_pages = max(1, (effective_total + per_page_value - 1) // per_page_value)
     page_value = min(requested_page, max_pages)
 
@@ -503,6 +505,7 @@ def search_cards_endpoint(
         page=page_value,
         per_page=per_page_value,
         suggested_query=suggestion,
+        total_remote=upstream_total,
     )
 
 
@@ -539,7 +542,7 @@ def card_info(
 
     remote_results: list[dict[str, Any]] = []
     try:
-        remote_results, _ = tcg_api.search_cards(
+        remote_results, _, _ = tcg_api.search_cards(
             name=detail.name or name,
             number=detail.number,
             set_name=detail.set_name,

--- a/kartoteka_web/schemas.py
+++ b/kartoteka_web/schemas.py
@@ -80,6 +80,7 @@ class CardSearchResponse(SQLModel):
     page: int = 1
     per_page: int = 20
     suggested_query: Optional[str] = None
+    total_remote: Optional[int] = None
 
 
 class CardPriceHistoryPoint(SQLModel):

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -759,9 +759,9 @@ def search_cards(
     rapidapi_host: Optional[str] = None,
     session: Optional[requests.sessions.Session] = None,
     timeout: float = 10.0,
-) -> tuple[list[dict], int]:
+) -> tuple[list[dict], int, int]:
     if not name:
-        return [], 0
+        return [], 0, 0
 
     http = session or requests
 
@@ -812,7 +812,7 @@ def search_cards(
         rapid_search_parts.append(total_clean)
     query_value = " ".join(part for part in rapid_search_parts if part)
     if not query_value:
-        return [], 0
+        return [], 0, 0
 
     max_results = 100
     aggregated_cards: list[dict[str, Any]] = []
@@ -981,9 +981,10 @@ def search_cards(
     if not total_count:
         total_count = len(results)
 
-    total_count = min(max_results, total_count)
+    total_count = max(total_count, len(results))
+    filtered_total = len(results)
 
-    return results, total_count
+    return results, filtered_total, total_count
 
 
 def list_set_cards(

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -173,7 +173,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return search_results, 84
+        return search_results, len(search_results), 84
 
     monkeypatch.setattr(
         "kartoteka_web.routes.cards.tcg_api.search_cards",
@@ -210,7 +210,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert captured["page"] == 1
     assert captured["per_page"] == 20
     assert payload["total"] == len(search_results)
-    assert payload["total_count"] == 84
+    assert payload["total_count"] == len(search_results)
+    assert payload["total_remote"] == 84
     assert payload["page"] == 1
     assert payload["per_page"] == 20
     assert payload["suggested_query"] == "Eevee"
@@ -346,7 +347,7 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return [], 0
+        return [], 0, 0
 
     monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
     monkeypatch.setattr(cards_routes, "RAPIDAPI_KEY", "rapid-key")
@@ -413,7 +414,7 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return [], 0
+        return [], 0, 0
 
     monkeypatch.setattr(reloaded_cards.tcg_api, "search_cards", fake_search_cards)
 
@@ -468,7 +469,7 @@ def test_card_search_pagination_clamping(api_client, monkeypatch):
                 "rapidapi_host": rapidapi_host,
             }
         )
-        return [], 150
+        return [], 0, 150
 
     monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
 
@@ -483,9 +484,83 @@ def test_card_search_pagination_clamping(api_client, monkeypatch):
     assert captured["page"] == 1
     assert captured["per_page"] == 20
     assert captured["limit"] == 100
-    assert payload["page"] == 5
+    assert payload["page"] == 1
     assert payload["per_page"] == 20
-    assert payload["total_count"] == 100
+    assert payload["total_count"] == 0
+    assert payload["total_remote"] == 150
+
+
+def test_card_search_uses_filtered_total_for_pagination(api_client, monkeypatch):
+    headers = _auth_headers(api_client, username="janine", password="ariados")
+
+    filtered_records = [
+        {
+            "name": "Mew",
+            "number": "001",
+            "number_display": "1/20",
+            "total": "20",
+            "set_name": "Mythical Collection",
+            "set_code": "mythic",
+            "rarity": "Rare",
+            "image_small": None,
+            "image_large": None,
+        },
+        {
+            "name": "Mew",
+            "number": "002",
+            "number_display": "2/20",
+            "total": "20",
+            "set_name": "Mythical Collection",
+            "set_code": "mythic",
+            "rarity": "Rare",
+            "image_small": None,
+            "image_large": None,
+        },
+        {
+            "name": "Mew",
+            "number": "003",
+            "number_display": "3/20",
+            "total": "20",
+            "set_name": "Mythical Collection",
+            "set_code": "mythic",
+            "rarity": "Rare",
+            "image_small": None,
+            "image_large": None,
+        },
+    ]
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        total=None,
+        limit=None,
+        sort=None,
+        order=None,
+        page=None,
+        per_page=None,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        return filtered_records, len(filtered_records), 80
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+
+    response = api_client.get(
+        "/cards/search",
+        params={"query": "Mew", "page": 5, "per_page": 2},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["page"] == 2
+    assert payload["per_page"] == 2
+    assert payload["total"] == 1
+    assert payload["total_count"] == len(filtered_records)
+    assert payload["total_remote"] == 80
+    assert [item["number"] for item in payload["items"]] == ["003"]
 
 
 def test_card_search_uses_local_pagination(api_client, monkeypatch):
@@ -535,7 +610,7 @@ def test_card_search_uses_local_pagination(api_client, monkeypatch):
                 "per_page": per_page,
             }
         )
-        return records, 100
+        return records, len(records), 100
 
     monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
 
@@ -552,7 +627,8 @@ def test_card_search_uses_local_pagination(api_client, monkeypatch):
     assert payload["page"] == 3
     assert payload["per_page"] == 20
     assert payload["total"] == 20
-    assert payload["total_count"] == 100
+    assert payload["total_count"] == len(records)
+    assert payload["total_remote"] == 100
     returned_numbers = [item["number"] for item in payload["items"]]
     assert returned_numbers[0] == "041"
     assert returned_numbers[-1] == "060"

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -75,7 +75,7 @@ class _PagingSession:
 
 def test_search_cards_uses_rapidapi_headers():
     session = _DummySession()
-    results, total_count = tcg_api.search_cards(
+    results, filtered_total, total_count = tcg_api.search_cards(
         name="Pikachu",
         rapidapi_key="rapid-key",
         rapidapi_host=DEFAULT_HOST,
@@ -85,6 +85,7 @@ def test_search_cards_uses_rapidapi_headers():
     )
 
     assert results == []
+    assert filtered_total == 0
     assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
@@ -103,7 +104,7 @@ def test_search_cards_uses_rapidapi_headers():
 
 def test_search_cards_uses_default_host_when_missing():
     session = _DummySession()
-    results, total_count = tcg_api.search_cards(
+    results, filtered_total, total_count = tcg_api.search_cards(
         name="Eevee",
         rapidapi_key="rapid-key",
         rapidapi_host=None,
@@ -111,6 +112,7 @@ def test_search_cards_uses_default_host_when_missing():
     )
 
     assert results == []
+    assert filtered_total == 0
     assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
@@ -125,11 +127,12 @@ def test_search_cards_uses_default_host_when_missing():
 
 def test_search_cards_without_key_omits_auth_header():
     session = _DummySession()
-    results, total_count = tcg_api.search_cards(
+    results, filtered_total, total_count = tcg_api.search_cards(
         name="Ditto", rapidapi_host=DEFAULT_HOST, session=session
     )
 
     assert results == []
+    assert filtered_total == 0
     assert total_count == 0
     assert session.calls, "Expected a single HTTP request"
     call = session.calls[0]
@@ -205,7 +208,7 @@ def test_search_cards_matches_uppercase_collector_number():
     }
     session = _DummySession(response_data={"data": [card_payload]})
 
-    results, total_count = tcg_api.search_cards(
+    results, filtered_total, total_count = tcg_api.search_cards(
         name="Pikachu",
         number="RC5A",
         session=session,
@@ -213,6 +216,7 @@ def test_search_cards_matches_uppercase_collector_number():
 
     assert results, "Expected to receive at least one suggestion"
     assert results[0]["number"] == "rc5a"
+    assert filtered_total == 1
     assert total_count == 1
 
 
@@ -236,7 +240,7 @@ def test_search_cards_aggregates_multiple_pages():
         pages.append({"data": cards, "totalCount": 150})
 
     session = _PagingSession(pages)
-    results, total_count = tcg_api.search_cards(
+    results, filtered_total, total_count = tcg_api.search_cards(
         name="Pikachu",
         limit=100,
         per_page=50,
@@ -244,7 +248,8 @@ def test_search_cards_aggregates_multiple_pages():
     )
 
     assert len(results) == 100
-    assert total_count == 100
+    assert filtered_total == 100
+    assert total_count == 150
     assert len(session.calls) == 2
     assert session.calls[0]["params"]["page"] == "1"
     assert session.calls[1]["params"]["page"] == "2"


### PR DESCRIPTION
## Summary
- update the RapidAPI search helper to return both filtered and upstream totals
- base card search pagination on the filtered results and expose the remote total in the API response
- expand API and service tests to cover filtered-vs-remote totals and clamped pagination

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68df7fb9b7e4832fa18ee19490f6d618