### PR TITLE
Improve card search grid responsiveness

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -737,8 +737,25 @@ main:has(#add-card-page) {
 .card-search-results--grid {
   display: grid;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 260px));
-  justify-content: center;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (max-width: 1200px) {
+  .card-search-results--grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .card-search-results--grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .card-search-results--grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
 }
 
 .card-search-item {
@@ -757,8 +774,7 @@ main:has(#add-card-page) {
   background: var(--color-surface-alt);
   box-shadow: var(--shadow-card);
   min-height: 100%;
-  max-width: 260px;
-  margin: 0 auto;
+  width: 100%;
 }
 
 .card-search-results--grid .card-search-item:hover,


### PR DESCRIPTION
## Summary
- update the card search grid to use a fixed four-column layout on large screens and adjust to three, two, or one column at responsive breakpoints
- let grid cards stretch to fill their cells for consistent spacing across viewports

## Testing
- Manual visual inspection of the card search grid

------
https://chatgpt.com/codex/tasks/task_e_68df85a3a28c832fa4cf2b7417408dc2