### PR TITLE
Improve floating alert styling and behavior

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -396,17 +396,54 @@
     return result;
   };
 
+  const ALERT_AUTOHIDE_DELAY = 3600;
+  const ALERT_TRANSITION_DURATION = 220;
+  const alertTimers = new WeakMap();
+  const scheduleFrame =
+    typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+      ? window.requestAnimationFrame.bind(window)
+      : (callback) => setTimeout(callback, 16);
+
+  const clearAlertTimer = (element) => {
+    const pending = alertTimers.get(element);
+    if (pending) {
+      clearTimeout(pending);
+      alertTimers.delete(element);
+    }
+  };
+
   const showAlert = (element, message, variant = "info") => {
     if (!element) return;
+    clearAlertTimer(element);
+    const isFloating = element.classList.contains("alert--floating");
     if (!message) {
-      element.textContent = "";
-      element.hidden = true;
+      element.classList.remove("alert--visible");
       delete element.dataset.variant;
+      if (!isFloating) {
+        element.hidden = true;
+        element.textContent = "";
+        return;
+      }
+      const timer = setTimeout(() => {
+        element.hidden = true;
+        element.textContent = "";
+        alertTimers.delete(element);
+      }, ALERT_TRANSITION_DURATION);
+      alertTimers.set(element, timer);
       return;
     }
     element.textContent = message;
     element.dataset.variant = variant;
     element.hidden = false;
+    scheduleFrame(() => {
+      element.classList.add("alert--visible");
+    });
+    if (variant === "success" && isFloating) {
+      const timer = setTimeout(() => {
+        showAlert(element, "");
+      }, ALERT_AUTOHIDE_DELAY);
+      alertTimers.set(element, timer);
+    }
   };
 
   const updateUserBadge = (user) => {

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -12,7 +12,14 @@
   --color-accent-dark: #1d4ed8;
   --color-accent-soft: #e6edff;
   --color-success: #16a34a;
+  --color-success-soft: rgba(22, 163, 74, 0.12);
+  --color-success-contrast: #14532d;
   --color-danger: #dc2626;
+  --color-danger-soft: rgba(220, 38, 38, 0.12);
+  --color-danger-contrast: #7f1d1d;
+  --color-info: #2563eb;
+  --color-info-soft: rgba(37, 99, 235, 0.12);
+  --color-info-contrast: #1d4ed8;
   --radius-lg: 18px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -58,7 +65,14 @@ body[data-theme="dark"] {
   --color-accent-dark: #3b82f6;
   --color-accent-soft: rgba(59, 130, 246, 0.22);
   --color-success: #22c55e;
+  --color-success-soft: rgba(34, 197, 94, 0.18);
+  --color-success-contrast: #bbf7d0;
   --color-danger: #f87171;
+  --color-danger-soft: rgba(248, 113, 113, 0.2);
+  --color-danger-contrast: #fee2e2;
+  --color-info: #60a5fa;
+  --color-info-soft: rgba(96, 165, 250, 0.2);
+  --color-info-contrast: #e0f2fe;
   --shadow-soft: 0 18px 48px rgba(8, 14, 26, 0.65);
   --shadow-card: 0 10px 32px rgba(8, 14, 26, 0.45);
 }
@@ -83,7 +97,14 @@ body[data-theme="auto"] {
     --color-accent-dark: #3b82f6;
     --color-accent-soft: rgba(59, 130, 246, 0.22);
     --color-success: #22c55e;
+    --color-success-soft: rgba(34, 197, 94, 0.18);
+    --color-success-contrast: #bbf7d0;
     --color-danger: #f87171;
+    --color-danger-soft: rgba(248, 113, 113, 0.2);
+    --color-danger-contrast: #fee2e2;
+    --color-info: #60a5fa;
+    --color-info-soft: rgba(96, 165, 250, 0.2);
+    --color-info-contrast: #e0f2fe;
     --shadow-soft: 0 18px 48px rgba(8, 14, 26, 0.65);
     --shadow-card: 0 10px 32px rgba(8, 14, 26, 0.45);
   }
@@ -410,7 +431,7 @@ img {
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
-  color: var(--color-muted);
+  color: var(--color-text);
   font-size: 0.9rem;
   margin-bottom: 16px;
 }
@@ -418,24 +439,47 @@ img {
 .alert--floating {
   position: fixed;
   top: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: min(640px, calc(100% - 32px));
+  right: 24px;
+  width: min(420px, calc(100% - 48px));
   margin: 0;
   z-index: 2000;
   box-shadow: var(--shadow-soft);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-12px);
+  transition: opacity 180ms ease, transform 180ms ease, visibility 0ms linear 180ms;
+}
+
+.alert--visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.alert--floating.alert--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition-delay: 0s;
 }
 
 .alert[data-variant="success"] {
-  border-color: rgba(22, 163, 74, 0.35);
-  background: rgba(22, 163, 74, 0.08);
-  color: var(--color-success);
+  border-color: transparent;
+  background: var(--color-success-soft);
+  color: var(--color-success-contrast);
 }
 
 .alert[data-variant="error"] {
-  border-color: rgba(220, 38, 38, 0.35);
-  background: rgba(220, 38, 38, 0.08);
-  color: var(--color-danger);
+  border-color: transparent;
+  background: var(--color-danger-soft);
+  color: var(--color-danger-contrast);
+}
+
+.alert[data-variant="info"] {
+  border-color: transparent;
+  background: var(--color-info-soft);
+  color: var(--color-info-contrast);
 }
 
 .table-responsive {


### PR DESCRIPTION
## Summary
- anchor floating alerts to the top-right corner and add a helper class for smooth visibility transitions
- add theme-aware soft success, error, and info color tokens for filled alert variants
- update showAlert to manage visibility timers and auto-dismiss floating success banners after a short delay

## Testing
- uvicorn server:app --host 0.0.0.0 --port 8000 (fails to reach external Pokémon API due to proxy restrictions)

------
https://chatgpt.com/codex/tasks/task_e_68df8700a5e8832fbdd42289b38e91a6