### PR TITLE
Add remote fallback for card info endpoint

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -524,6 +524,12 @@ def card_info(
 
     limit_value = max(0, min(related_limit, 24))
 
+    name_value = name.strip()
+    number_value = number.strip()
+    set_name_value = (set_name or "").strip()
+    set_code_value = set_utils.clean_code(set_code) or None
+    total_value = text.sanitize_number(total) if total else None
+
     card = _find_card(
         session,
         name=name,
@@ -531,24 +537,35 @@ def card_info(
         set_name=set_name,
         set_code=set_code,
     )
-    if card is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Nie znaleziono karty.")
 
-    detail = _card_to_detail(card)
-    if total and not detail.total:
-        detail.total = text.sanitize_number(total)
+    if card is not None:
+        detail = _card_to_detail(card)
+        if total and not detail.total:
+            detail.total = text.sanitize_number(total)
+    else:
+        detail = schemas.CardDetail(
+            name=name_value or name,
+            number=number_value or number,
+            number_display=number_value or number,
+            total=total_value,
+            set_name=set_name_value,
+            set_code=set_code_value,
+            shop_url=DEFAULT_SHOP_URL,
+        )
 
     detail.shop_url = (detail.shop_url or DEFAULT_SHOP_URL).strip() or DEFAULT_SHOP_URL
 
     remote_results: list[dict[str, Any]] = []
+    remote_fetch_limit = max(6, limit_value + 1)
     try:
         remote_results, _, _ = tcg_api.search_cards(
-            name=detail.name or name,
-            number=detail.number,
-            set_name=detail.set_name,
-            total=detail.total,
-            limit=6,
-            per_page=6,
+            name=name,
+            number=number,
+            set_name=set_name,
+            set_code=set_code,
+            total=total,
+            limit=remote_fetch_limit,
+            per_page=remote_fetch_limit,
             rapidapi_key=RAPIDAPI_KEY,
             rapidapi_host=RAPIDAPI_HOST,
         )
@@ -655,8 +672,29 @@ def card_info(
                 ),
             )
 
-    related_cards = _load_related_cards(session, card, limit_value)
-    related_items = [_card_to_search_schema(item) for item in related_cards[:limit_value]]
+    if card is None and not remote_card:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Nie znaleziono karty."
+        )
+
+    related_items: list[schemas.CardSearchResult] = []
+    if card is not None:
+        related_cards = _load_related_cards(session, card, limit_value)
+        related_items = [
+            _card_to_search_schema(item) for item in related_cards[:limit_value]
+        ]
+    elif remote_results:
+        remote_related: list[dict[str, Any]] = []
+        selected_id = remote_card.get("id") if remote_card else None
+        for record in remote_results:
+            if remote_card is not None and record is remote_card:
+                continue
+            if selected_id and record.get("id") == selected_id:
+                continue
+            remote_related.append(record)
+        related_items = [
+            _payload_to_search_schema(item) for item in remote_related[:limit_value]
+        ]
 
     return schemas.CardDetailResponse(card=detail, related=related_items)
 

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -749,6 +749,7 @@ def search_cards(
     name: str,
     number: str | None = None,
     set_name: Optional[str] = None,
+    set_code: Optional[str] = None,
     total: Optional[str] = None,
     limit: int = 10,
     sort: Optional[str] = None,
@@ -808,6 +809,10 @@ def search_cards(
         set_query = text.normalize(set_name, keep_spaces=True)
         if set_query:
             rapid_search_parts.append(set_query)
+    if set_code:
+        set_code_clean = set_utils.clean_code(set_code)
+        if set_code_clean:
+            rapid_search_parts.append(set_code_clean)
     if total_clean:
         rapid_search_parts.append(total_clean)
     query_value = " ".join(part for part in rapid_search_parts if part)

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -149,6 +149,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit,
         sort=None,
@@ -163,6 +164,7 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "name": name,
                 "number": number,
                 "set_name": set_name,
+                "set_code": set_code,
                 "total": total,
                 "limit": limit,
                 "sort": sort,
@@ -173,6 +175,8 @@ def test_card_search_and_detail(api_client, monkeypatch):
                 "rapidapi_host": rapidapi_host,
             }
         )
+        if name and "missing" in name.lower():
+            return [], 0, 0
         return search_results, len(search_results), 84
 
     monkeypatch.setattr(
@@ -287,6 +291,114 @@ def test_card_search_and_detail(api_client, monkeypatch):
     assert unauthenticated_search.status_code == 401
 
 
+def test_card_info_remote_fallback(api_client, monkeypatch):
+    remote_cards = [
+        {
+            "id": "base1-4",
+            "name": "Charizard",
+            "number": "4",
+            "number_display": "4/102",
+            "total": "102",
+            "set_name": "Base Set",
+            "set_code": "base1",
+            "rarity": "Rare Holo",
+            "image_small": "https://example.com/charizard-small.jpg",
+            "image_large": "https://example.com/charizard-large.jpg",
+            "set_icon": "https://example.com/base-set.png",
+            "artist": "Mitsuhiro Arita",
+            "series": "Base",
+            "release_date": "1999/01/09",
+            "price": 123.45,
+            "price_7d_average": 120.0,
+            "description": "Opis zdalnej karty",
+            "shop_url": "https://example.com/shop/charizard",
+        },
+        {
+            "id": "base1-5",
+            "name": "Charizard",
+            "number": "5",
+            "number_display": "5/102",
+            "total": "102",
+            "set_name": "Base Set",
+            "set_code": "base1",
+            "rarity": "Rare",
+            "image_small": "https://example.com/charizard-5-small.jpg",
+            "image_large": "https://example.com/charizard-5-large.jpg",
+        },
+    ]
+
+    captured: dict[str, object] = {}
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        set_code=None,
+        total=None,
+        limit=None,
+        sort=None,
+        order=None,
+        page=None,
+        per_page=None,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        captured.update(
+            {
+                "name": name,
+                "number": number,
+                "set_name": set_name,
+                "set_code": set_code,
+                "total": total,
+                "limit": limit,
+                "per_page": per_page,
+                "rapidapi_key": rapidapi_key,
+                "rapidapi_host": rapidapi_host,
+            }
+        )
+        return remote_cards, len(remote_cards), len(remote_cards)
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+
+    price_history_payload = [
+        {"date": "2024-01-01", "marketPrice": 10.0, "currency": "EUR"},
+        {"date": "2024-01-02", "marketPrice": 12.0, "currency": "EUR"},
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "fetch_card_price_history",
+        lambda *args, **kwargs: price_history_payload,
+    )
+    monkeypatch.setattr(cards_routes.tcg_api, "get_eur_pln_rate", lambda: 4.0)
+
+    response = api_client.get(
+        "/cards/info",
+        params={
+            "name": "Charizard",
+            "number": "4",
+            "set_name": "Base Set",
+            "set_code": "base1",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    card = payload["card"]
+    assert card["name"] == "Charizard"
+    assert card["set_code"] == "base1"
+    assert card["price"] == pytest.approx(123.45)
+    history = card["price_history"]
+    assert history["all"], "Expected remote price history to be populated"
+    assert captured["set_code"] == "base1"
+    assert payload["related"], "Expected related cards from remote search"
+    assert payload["related"][0]["number"] == "5"
+
+    with database.session_scope() as session:
+        assert session.exec(select(models.Card)).all() == []
+
+
 def test_card_info_accepts_normalized_set_code(api_client):
     with database.session_scope() as session:
         session.add(
@@ -323,6 +435,7 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit,
         sort=None,
@@ -337,6 +450,7 @@ def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
                 "name": name,
                 "number": number,
                 "set_name": set_name,
+                "set_code": set_code,
                 "total": total,
                 "limit": limit,
                 "sort": sort,
@@ -390,6 +504,7 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit,
         sort=None,
@@ -404,6 +519,7 @@ def test_cards_module_uses_generic_rapidapi_env(monkeypatch):
                 "name": name,
                 "number": number,
                 "set_name": set_name,
+                "set_code": set_code,
                 "total": total,
                 "limit": limit,
                 "sort": sort,
@@ -445,6 +561,7 @@ def test_card_search_pagination_clamping(api_client, monkeypatch):
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit=None,
         sort=None,
@@ -459,6 +576,7 @@ def test_card_search_pagination_clamping(api_client, monkeypatch):
                 "name": name,
                 "number": number,
                 "set_name": set_name,
+                "set_code": set_code,
                 "total": total,
                 "limit": limit,
                 "sort": sort,
@@ -534,6 +652,7 @@ def test_card_search_uses_filtered_total_for_pagination(api_client, monkeypatch)
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit=None,
         sort=None,
@@ -593,6 +712,7 @@ def test_card_search_uses_local_pagination(api_client, monkeypatch):
         name,
         number=None,
         set_name=None,
+        set_code=None,
         total=None,
         limit=None,
         sort=None,
@@ -605,6 +725,7 @@ def test_card_search_uses_local_pagination(api_client, monkeypatch):
         captured.update(
             {
                 "name": name,
+                "set_code": set_code,
                 "limit": limit,
                 "page": page,
                 "per_page": per_page,


### PR DESCRIPTION
## Summary
- allow the card info route to build responses from remote search results when a local card is missing
- include set codes in remote search queries to improve matching
- cover the remote fallback path with an API test scenario

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68df9a170ce8832fa747c77d6cbcf269