### PR TITLE
Handle canonical set codes in RapidAPI card searches

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -813,9 +813,22 @@ def search_cards(
         set_code_clean = set_utils.clean_code(set_code)
         if set_code_clean:
             rapid_search_parts.append(set_code_clean)
+            canonical_set_code = set_utils.resolve_canonical_set_slug(set_code)
+            if (
+                canonical_set_code
+                and canonical_set_code != set_code_clean
+            ):
+                rapid_search_parts.append(canonical_set_code)
     if total_clean:
         rapid_search_parts.append(total_clean)
-    query_value = " ".join(part for part in rapid_search_parts if part)
+    deduped_parts: list[str] = []
+    seen_parts: set[str] = set()
+    for part in rapid_search_parts:
+        if not part or part in seen_parts:
+            continue
+        deduped_parts.append(part)
+        seen_parts.add(part)
+    query_value = " ".join(deduped_parts)
     if not query_value:
         return [], 0, 0
 

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -185,6 +185,22 @@ def test_search_cards_builds_compound_query():
     assert params["search"] == "pikachu base 102"
 
 
+def test_search_cards_uses_canonical_set_code_when_available():
+    session = _DummySession()
+    tcg_api.search_cards(
+        name="Pikachu",
+        set_code="SSP",
+        session=session,
+    )
+
+    call = session.calls[0]
+    params = call["params"] or {}
+    search_value = params["search"]
+    search_parts = search_value.split()
+    assert "ssp" in search_parts
+    assert "sv8" in search_parts
+
+
 def test_search_cards_forwards_pagination_params():
     session = _DummySession()
     tcg_api.search_cards(


### PR DESCRIPTION
## Summary
- call the canonical set slug resolver when building RapidAPI search queries
- include both abbreviation and canonical set code while deduplicating query parts
- cover the new behaviour with a dedicated unit test for search_cards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa94def84832fbc453b5e01b43da2