### PR TITLE
Add fallback card search without set filters

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -581,6 +581,18 @@ def card_info(
                 rapidapi_key=RAPIDAPI_KEY,
                 rapidapi_host=RAPIDAPI_HOST,
             )
+        if not remote_results and (set_code_value or set_name_value):
+            remote_results, _, _ = tcg_api.search_cards(
+                name=name,
+                number=None,
+                set_name=None,
+                set_code=None,
+                total=None,
+                limit=remote_fetch_limit,
+                per_page=remote_fetch_limit,
+                rapidapi_key=RAPIDAPI_KEY,
+                rapidapi_host=RAPIDAPI_HOST,
+            )
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.warning("Failed to fetch remote card details for %s #%s: %s", name, number, exc)
         remote_results = []

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -399,6 +399,74 @@ def test_card_info_remote_fallback(api_client, monkeypatch):
         assert session.exec(select(models.Card)).all() == []
 
 
+def test_card_info_remote_fallback_without_set_filters(api_client, monkeypatch):
+    remote_payload = {
+        "id": "sv1-12",
+        "name": "Pikachu",
+        "number": "12",
+        "number_display": "012/190",
+        "total": "190",
+        "set_name": "Scarlet & Violet",
+        "set_code": "sv1",
+        "rarity": "Common",
+        "image_small": "https://example.com/pikachu-small.jpg",
+        "image_large": "https://example.com/pikachu-large.jpg",
+    }
+
+    attempts: list[tuple[str | None, str | None, str | None]] = []
+
+    def fake_search_cards(
+        *,
+        name,
+        number=None,
+        set_name=None,
+        set_code=None,
+        total=None,
+        limit=None,
+        sort=None,
+        order=None,
+        page=None,
+        per_page=None,
+        rapidapi_key=None,
+        rapidapi_host=None,
+    ):
+        attempts.append((number, set_name, set_code))
+        if set_code or set_name:
+            return [], 0, 0
+        return [remote_payload], 1, 1
+
+    monkeypatch.setattr(cards_routes.tcg_api, "search_cards", fake_search_cards)
+    monkeypatch.setattr(
+        cards_routes.tcg_api, "fetch_card_price_history", lambda *args, **kwargs: []
+    )
+
+    response = api_client.get(
+        "/cards/info",
+        params={
+            "name": "Pikachu",
+            "number": "12",
+            "set_name": "Scarlet & Violet",
+            "set_code": "sv1",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["card"]["name"] == "Pikachu"
+    assert payload["card"]["set_code"] == "sv1"
+    assert payload["related"] == []
+    assert payload["card"]["image_small"] == remote_payload["image_small"]
+    assert payload["card"]["image_large"] == remote_payload["image_large"]
+
+    assert len(attempts) >= 3
+    # Initial query retains the provided number and set filters.
+    assert attempts[0] == ("12", "Scarlet & Violet", "sv1")
+    # First retry drops the number but still carries the set filters.
+    assert attempts[1] == (None, "Scarlet & Violet", "sv1")
+    # Final retry removes the set filters entirely, allowing the remote result.
+    assert attempts[-1] == (None, None, None)
+
+
 def test_card_info_retries_without_number(api_client, monkeypatch):
     calls: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Summary
- extend the card info endpoint to perform a final remote lookup that drops set filters when earlier attempts fail
- cover the new fallback behaviour with a regression test that simulates RapidAPI succeeding only after set filters are removed

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68dfad112bcc832f96f1aead6e07c8bc