### PR TITLE
Stop card search pagination after reaching requested limit

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -833,6 +833,8 @@ def search_cards(
         return [], 0, 0
 
     max_results = 100
+    limit_value = limit if limit and limit > 0 else per_page_value
+    limit_value = min(limit_value, max_results)
     aggregated_cards: list[dict[str, Any]] = []
     total_count_remote = 0
     inferred_total = 0
@@ -887,6 +889,8 @@ def search_cards(
             break
 
         aggregated_cards.extend(cards_page)
+        if len(aggregated_cards) >= limit_value:
+            break
 
         fetched_total = (current_page - page_value) * per_page_value + len(cards_page)
         inferred_total = max(inferred_total, fetched_total)
@@ -973,8 +977,6 @@ def search_cards(
 
     seen: set[tuple[str | None, str]] = set()
     results: list[dict] = []
-    limit_value = limit if limit and limit > 0 else per_page_value
-    limit_value = min(limit_value, max_results)
     for item in suggestions:
         score_value = float(item.get("_score", 0) or 0)
         if score_value <= 0:

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -271,6 +271,44 @@ def test_search_cards_aggregates_multiple_pages():
     assert session.calls[1]["params"]["page"] == "2"
 
 
+def test_search_cards_stops_fetching_when_limit_reached():
+    pages = [
+        {
+            "data": [
+                {
+                    "name": "Test",
+                    "number": str(index),
+                    "set": {"name": "Test Set", "code": "TST"},
+                    "id": f"test-{index}",
+                }
+                for index in range(1, 21)
+            ],
+        },
+        {
+            "data": [
+                {
+                    "name": "Test",
+                    "number": "21",
+                    "set": {"name": "Test Set", "code": "TST"},
+                    "id": "test-21",
+                }
+            ],
+        },
+    ]
+    session = _PagingSession(pages)
+
+    results, filtered_total, total_count = tcg_api.search_cards(
+        name="Test",
+        limit=7,
+        session=session,
+    )
+
+    assert len(session.calls) == 1
+    assert len(results) == 7
+    assert filtered_total == 7
+    assert total_count >= 7
+
+
 def test_list_set_cards_without_key_uses_default_headers():
     session = _DummySession()
     tcg_api.list_set_cards("base", limit=1, session=session)


### PR DESCRIPTION
## Summary
- stop the RapidAPI pagination loop in `search_cards` once enough cards are aggregated to satisfy the requested limit
- add a regression test that exercises a paged session and asserts a single RapidAPI request is issued for `limit=7`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb75b9028832fa726314f53b36347