### PR TITLE
Adjust set icon fallbacks

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -662,7 +662,7 @@ def card_info(
         detail.shop_url = DEFAULT_SHOP_URL
 
     local_icon = _local_set_icon_path(detail.set_code, detail.set_name)
-    if local_icon:
+    if local_icon and not detail.set_icon_path:
         detail.set_icon_path = local_icon
 
     local_rarity_icon = tcg_api.resolve_rarity_icon_path(detail.rarity)

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -906,21 +906,30 @@
     if (!item) {
       return { primary: null, fallback: null };
     }
-    const customIcon = (item.set_icon || "").trim() || null;
-    const localOverride = (item.set_icon_path || "").trim() || null;
-    if (localOverride) {
-      return { primary: localOverride, fallback: customIcon };
-    }
+    const primaryIcon = (item.set_icon || "").trim() || null;
+    const explicitFallback = (item.set_icon_path || "").trim() || null;
+
     const setCodeRaw = (item.set_code || "").trim();
-    if (!setCodeRaw) {
-      return { primary: customIcon, fallback: null };
+    let derivedFallback = null;
+    if (setCodeRaw) {
+      const normalizedCode = setCodeRaw.toLowerCase().replace(/[^a-z0-9-]/g, "");
+      if (normalizedCode) {
+        derivedFallback = `${SET_ICON_LOCAL_BASE}/${encodeURIComponent(normalizedCode)}.png`;
+      }
     }
-    const normalizedCode = setCodeRaw.toLowerCase().replace(/[^a-z0-9-]/g, "");
-    if (!normalizedCode) {
-      return { primary: customIcon, fallback: null };
+
+    const fallbackIcon = explicitFallback || derivedFallback;
+
+    if (primaryIcon) {
+      const normalizedFallback = fallbackIcon && fallbackIcon !== primaryIcon ? fallbackIcon : null;
+      return { primary: primaryIcon, fallback: normalizedFallback };
     }
-    const localUrl = `${SET_ICON_LOCAL_BASE}/${encodeURIComponent(normalizedCode)}.png`;
-    return { primary: localUrl, fallback: customIcon };
+
+    if (fallbackIcon) {
+      return { primary: fallbackIcon, fallback: null };
+    }
+
+    return { primary: null, fallback: null };
   };
 
   const renderSearchResults = (


### PR DESCRIPTION
## Summary
- avoid overwriting remote set icon paths in the card detail endpoint and keep the local path only as a fallback
- update the front-end icon resolver to prefer API-provided icons while retaining local URLs as fallbacks derived from the set code

## Testing
- pytest tests/api/test_cards.py::test_card_info_remote_fallback -q
- Manual testing of the card detail view (remote icon success, broken icon fallback)


------
https://chatgpt.com/codex/tasks/task_e_68e006411220832f9cb4236d514ddc2b