### PR TITLE
Prioritize local rarity icons in card detail

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1859,19 +1859,15 @@
     }
     if (rarityIconElement) {
       const iconCandidates = [];
-      if (raritySymbolValue) {
-        iconCandidates.push(raritySymbolValue);
-      }
+      const addIconCandidate = (iconUrl) => {
+        if (iconUrl && !iconCandidates.includes(iconUrl)) {
+          iconCandidates.push(iconUrl);
+        }
+      };
       const resolvedRarityIcon = resolveRarityIconUrl(rarityValue);
-      if (resolvedRarityIcon && !iconCandidates.includes(resolvedRarityIcon)) {
-        iconCandidates.push(resolvedRarityIcon);
-      }
-      if (
-        raritySymbolRemoteValue
-        && !iconCandidates.includes(raritySymbolRemoteValue)
-      ) {
-        iconCandidates.push(raritySymbolRemoteValue);
-      }
+      addIconCandidate(resolvedRarityIcon);
+      addIconCandidate(raritySymbolValue);
+      addIconCandidate(raritySymbolRemoteValue);
       const [primaryRarityIcon = "", fallbackRarityIcon = ""] = iconCandidates;
       const showRarityFallback = () => {
         if (rarityFallbackElement) {


### PR DESCRIPTION
## Summary
- ensure card detail pages prioritise locally resolved rarity icons before API-provided fallbacks
- retain remote rarity symbol URLs as subsequent fallbacks with the existing load-error handling

## Testing
- Manual verification of rarity icons in the add-card search and detail views

------
https://chatgpt.com/codex/tasks/task_e_68e0094f77ec832f80ce96c66fc3d337