### PR TITLE
Display artist in card detail header

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1777,11 +1777,11 @@
       title.textContent = sanitizeText(card.name) || "Szczegóły karty";
     }
 
+    const artistValue = sanitizeText(card.artist);
     const era = document.getElementById("card-detail-era");
     if (era) {
-      const eraValue = sanitizeText(card.series);
-      if (eraValue) {
-        era.textContent = eraValue;
+      if (artistValue) {
+        era.textContent = `Ilustrator: ${artistValue}`;
         era.hidden = false;
       } else {
         era.textContent = "";
@@ -1924,18 +1924,6 @@
     setTextOrFallback(totalElement, card.total);
     const releaseElement = document.getElementById("card-detail-release");
     setTextOrFallback(releaseElement, card.release_date);
-
-    const artistElement = document.getElementById("card-detail-artist");
-    const artistValue = sanitizeText(card.artist);
-    if (artistElement) {
-      if (artistValue) {
-        artistElement.textContent = `Ilustrator: ${artistValue}`;
-        artistElement.hidden = false;
-      } else {
-        artistElement.textContent = "";
-        artistElement.hidden = true;
-      }
-    }
 
     const descriptionSection = document.getElementById("card-detail-description-section");
     const descriptionContent = document.getElementById("card-detail-description");

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1621,7 +1621,7 @@ body[data-theme="dark"] .card-search-set-badges {
   color: var(--color-text);
 }
 
-.card-detail-artist {
+.card-detail-era {
   margin: 0 0 12px;
   color: var(--color-muted);
 }

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="card-detail-info">
-      <p class="card-detail-era" id="card-detail-era" hidden></p>
+      <p class="card-detail-era" id="card-detail-era" hidden aria-live="polite"></p>
       <h1 id="card-detail-title">{{ card_name or 'Szczegóły karty' }}</h1>
       <div class="card-detail-set">
         <div class="card-detail-set-visual">
@@ -76,7 +76,6 @@
           <span class="card-price-badge-value" id="card-detail-price-average"></span>
         </div>
       </div>
-      <p class="card-detail-artist" id="card-detail-artist" hidden></p>
       <dl class="card-detail-meta">
         <div>
           <dt>Numer</dt>


### PR DESCRIPTION
## Summary
- route the illustrator display through the existing `card-detail-era` element on the card detail page and hide it when no artist is provided
- update client logic and styles to remove the redundant artist field and keep the header announcement accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00b737fb0832faf9aa5cb1d8ee004