### PR TITLE
Improve card price history range handling

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 import os
 import re
@@ -516,6 +517,8 @@ def card_info(
     total: str | None = None,
     set_code: str | None = None,
     set_name: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
     related_limit: int = 6,
     current_user: models.User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
@@ -600,6 +603,28 @@ def card_info(
     remote_card = _select_remote_card(remote_results, detail) if remote_results else None
     remote_card_id: str | None = None
 
+    def _parse_date_param(value: str | None) -> dt.date | None:
+        if not value:
+            return None
+        text_value = value.strip()
+        if not text_value:
+            return None
+        try:
+            return dt.date.fromisoformat(text_value)
+        except ValueError:
+            return None
+
+    today = dt.date.today()
+    requested_date_from = _parse_date_param(date_from)
+    requested_date_to = _parse_date_param(date_to)
+    date_to_value = requested_date_to or today
+    if date_to_value > today:
+        date_to_value = today
+    if requested_date_from and requested_date_from <= date_to_value:
+        date_from_value = requested_date_from
+    else:
+        date_from_value = date_to_value - dt.timedelta(days=30)
+
     if remote_card:
         remote_card_id_value = str(remote_card.get("id") or "").strip()
         remote_card_id = remote_card_id_value or None
@@ -678,6 +703,8 @@ def card_info(
                 remote_card_id,
                 rapidapi_key=RAPIDAPI_KEY,
                 rapidapi_host=RAPIDAPI_HOST,
+                date_from=date_from_value,
+                date_to=date_to_value,
             )
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning("Failed to fetch price history for card %s: %s", remote_card_id, exc)

--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -1128,6 +1128,27 @@ def list_set_cards(
     return results, request_count
 
 
+def _normalize_history_date_param(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        value = value.date()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        parsed = _parse_history_date(text)
+        if parsed:
+            return parsed.isoformat()
+        return text
+    parsed = _parse_history_date(value)
+    if parsed:
+        return parsed.isoformat()
+    return None
+
+
 def fetch_card_price_history(
     card_id: str,
     *,
@@ -1137,6 +1158,8 @@ def fetch_card_price_history(
     timeout: float = 10.0,
     market: Optional[str] = None,
     currency: Optional[str] = None,
+    date_from: Any | None = None,
+    date_to: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch market price history for a Pokémon card via RapidAPI."""
 
@@ -1157,6 +1180,14 @@ def fetch_card_price_history(
         params["market"] = market
     if currency:
         params["currency"] = currency
+    if date_from is not None:
+        normalized_from = _normalize_history_date_param(date_from)
+        if normalized_from:
+            params["date_from"] = normalized_from
+    if date_to is not None:
+        normalized_to = _normalize_history_date_param(date_to)
+        if normalized_to:
+            params["date_to"] = normalized_to
 
     try:
         response = http.get(url, params=params or None, headers=headers, timeout=timeout)

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1577,7 +1577,7 @@
     const controls = Array.from(document.querySelectorAll("[data-price-range]"));
 
     if (!section || !chart || !chartLayer || !emptyState || !controls.length) {
-      return { setData: () => {} };
+      return { setData: () => {}, setRangeFetcher: () => {} };
     }
 
     const SVG_NS = "http://www.w3.org/2000/svg";
@@ -1586,7 +1586,15 @@
       last_30: [],
       all: [],
     };
+    const RELATED_RANGES = Object.freeze({
+      last_7: [],
+      last_30: ["last_7"],
+      all: ["last_7", "last_30"],
+    });
+    const fetchedRanges = new Set();
     let activeRange = "last_30";
+    let isLoading = false;
+    let rangeFetcher = null;
 
     const parseHistoryPoints = (items) => {
       if (!Array.isArray(items)) return [];
@@ -1618,11 +1626,30 @@
       controls.forEach((button) => {
         const key = button.dataset.priceRange;
         const hasData = Boolean(key && ranges[key] && ranges[key].length);
-        button.disabled = !hasData;
-        const isActive = hasData && key === rangeKey;
+        const attempted = key ? fetchedRanges.has(key) : false;
+        const canFetch = typeof rangeFetcher === "function";
+        const disableBecauseNoData = !hasData && attempted && !canFetch;
+        const disableBecauseLoading = isLoading && key !== rangeKey;
+        button.disabled = disableBecauseNoData || disableBecauseLoading;
+        const isActive = key === rangeKey;
         button.classList.toggle("is-active", isActive);
         button.setAttribute("aria-pressed", isActive ? "true" : "false");
+        if (button.dataset.loading === "true" && !isLoading) {
+          delete button.dataset.loading;
+        }
       });
+    };
+
+    const setSectionLoading = (loading) => {
+      isLoading = Boolean(loading);
+      if (isLoading) {
+        section.dataset.loading = "true";
+        section.setAttribute("aria-busy", "true");
+      } else {
+        delete section.dataset.loading;
+        section.removeAttribute("aria-busy");
+      }
+      updateControls(activeRange);
     };
 
     const setChartAriaLabel = (rangeKey, points) => {
@@ -1714,12 +1741,164 @@
       setChartAriaLabel(rangeKey, points);
     };
 
+    const setData = (history, options = {}) => {
+      const payload = history && typeof history === "object" ? history : {};
+      const { activeRange: requestedRange, sourceRange, preserveActive = false } = options;
+
+      if (sourceRange) {
+        fetchedRanges.add(sourceRange);
+        const related = RELATED_RANGES[sourceRange] || [];
+        related.forEach((key) => fetchedRanges.add(key));
+      }
+
+      const updatedKeys = [];
+      for (const key of ["last_7", "last_30", "all"]) {
+        if (Object.prototype.hasOwnProperty.call(payload, key)) {
+          const parsed = parseHistoryPoints(payload[key]);
+          ranges[key] = parsed;
+          updatedKeys.push(key);
+        }
+      }
+
+      if (!updatedKeys.length && !requestedRange && !preserveActive) {
+        return;
+      }
+
+      let nextRange = null;
+
+      if (
+        requestedRange &&
+        (updatedKeys.includes(requestedRange) || (ranges[requestedRange] && ranges[requestedRange].length))
+      ) {
+        nextRange = requestedRange;
+      } else if (preserveActive && ranges[activeRange]) {
+        nextRange = activeRange;
+      }
+
+      if (!nextRange) {
+        for (const key of ["last_30", "last_7", "all"]) {
+          if (ranges[key] && ranges[key].length) {
+            nextRange = key;
+            break;
+          }
+        }
+      }
+
+      if (!nextRange) {
+        for (const key of ["last_30", "last_7", "all"]) {
+          if (updatedKeys.includes(key)) {
+            nextRange = key;
+            break;
+          }
+        }
+      }
+
+      if (!nextRange) {
+        chartLayer.innerHTML = "";
+        chart.setAttribute("aria-hidden", "true");
+        emptyState.hidden = false;
+        controls.forEach((button) => {
+          button.disabled = true;
+          button.classList.remove("is-active");
+          button.setAttribute("aria-pressed", "false");
+        });
+        section.hidden = true;
+        return;
+      }
+
+      section.hidden = false;
+      activeRange = nextRange;
+      updateControls(activeRange);
+      renderChart(activeRange);
+    };
+
+    const fetchRangeData = async (rangeKey, triggerButton) => {
+      if (typeof rangeFetcher !== "function") {
+        return;
+      }
+      if (isLoading) {
+        return;
+      }
+
+      const button =
+        triggerButton ||
+        controls.find((control) => control.dataset.priceRange === rangeKey) ||
+        null;
+      const wasDisabled = button ? button.disabled : false;
+
+      if (button) {
+        button.dataset.loading = "true";
+        button.disabled = true;
+      }
+
+      setSectionLoading(true);
+
+      try {
+        const result = await rangeFetcher(rangeKey);
+
+        let historyPayload = null;
+        let sourceRange = rangeKey;
+
+        if (result && typeof result === "object") {
+          if (Object.prototype.hasOwnProperty.call(result, "history")) {
+            historyPayload = result.history;
+            if (result.sourceRange) {
+              sourceRange = result.sourceRange;
+            }
+          } else if (Object.prototype.hasOwnProperty.call(result, "price_history")) {
+            historyPayload = result.price_history;
+          } else if (result.card && result.card.price_history) {
+            historyPayload = result.card.price_history;
+          } else {
+            historyPayload = result;
+          }
+        } else {
+          historyPayload = result;
+        }
+
+        if (historyPayload && typeof historyPayload === "object") {
+          setData(historyPayload, {
+            activeRange: rangeKey,
+            sourceRange,
+            preserveActive: true,
+          });
+        } else if (!ranges[rangeKey] || !ranges[rangeKey].length) {
+          setData(
+            { [rangeKey]: [] },
+            { activeRange: rangeKey, sourceRange: rangeKey, preserveActive: true },
+          );
+        }
+      } catch (error) {
+        console.error("Failed to load price history range", error);
+      } finally {
+        if (button) {
+          button.dataset.loading = "false";
+          if (!wasDisabled) {
+            button.disabled = false;
+          }
+        }
+        setSectionLoading(false);
+      }
+    };
+
     controls.forEach((button) => {
-      button.addEventListener("click", () => {
+      button.addEventListener("click", async () => {
         const rangeKey = button.dataset.priceRange;
-        if (!rangeKey || !ranges[rangeKey] || !ranges[rangeKey].length) {
+        if (!rangeKey) {
           return;
         }
+
+        if (!fetchedRanges.has(rangeKey) && typeof rangeFetcher === "function") {
+          await fetchRangeData(rangeKey, button);
+          if (activeRange === rangeKey) {
+            return;
+          }
+        }
+
+        if (activeRange === rangeKey) {
+          return;
+        }
+
         activeRange = rangeKey;
         updateControls(activeRange);
         renderChart(activeRange);
@@ -1727,39 +1906,17 @@
     });
 
     return {
-      setData(history) {
-        ranges.last_7 = parseHistoryPoints(history?.last_7);
-        ranges.last_30 = parseHistoryPoints(history?.last_30);
-        ranges.all = parseHistoryPoints(history?.all);
-
-        const availableRange = ["last_7", "last_30", "all"].find(
-          (key) => ranges[key] && ranges[key].length,
-        );
-
-        if (!availableRange) {
-          chartLayer.innerHTML = "";
-          chart.setAttribute("aria-hidden", "true");
-          emptyState.hidden = false;
-          controls.forEach((button) => {
-            button.disabled = true;
-            button.classList.remove("is-active");
-            button.setAttribute("aria-pressed", "false");
-          });
-          section.hidden = true;
-          return;
-        }
-
-        section.hidden = false;
-        activeRange = availableRange;
+      setData,
+      setRangeFetcher(handler) {
+        rangeFetcher = typeof handler === "function" ? handler : null;
         updateControls(activeRange);
-        renderChart(activeRange);
       },
     };
   };
 
   const renderCardDetail = (card, options = {}) => {
     if (!card) return;
-    const { priceHistoryModule } = options;
+    const { priceHistoryModule, priceHistoryRange } = options;
 
     const sanitizeText = (value) => (typeof value === "string" ? value.trim() : value);
     const setTextOrFallback = (element, value, fallback = "—") => {
@@ -1994,7 +2151,10 @@
     }
 
     if (priceHistoryModule && typeof priceHistoryModule.setData === "function") {
-      priceHistoryModule.setData(card.price_history || {});
+      priceHistoryModule.setData(card.price_history || {}, {
+        sourceRange: priceHistoryRange,
+        activeRange: priceHistoryRange,
+      });
     }
   };
 
@@ -2047,9 +2207,76 @@
     if (setCode) params.set("set_code", setCode);
     if (setName) params.set("set_name", setName);
 
-    apiFetch(`/cards/info?${params.toString()}`)
-      .then((data) => {
-        renderCardDetail(data?.card, { priceHistoryModule });
+    const baseParams = new URLSearchParams(params);
+    const DEFAULT_PRICE_RANGE = "last_30";
+
+    const formatDateParam = (date) => {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return "";
+      }
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      return `${year}-${month}-${day}`;
+    };
+
+    const resolveRangeParams = (rangeKey) => {
+      if (rangeKey === "all") {
+        return {};
+      }
+
+      const now = new Date();
+      const toDate = formatDateParam(now);
+      const days = rangeKey === "last_7" ? 7 : 30;
+      const fromDate = new Date(now.getTime());
+      fromDate.setDate(fromDate.getDate() - days);
+      return {
+        date_from: formatDateParam(fromDate),
+        date_to: toDate,
+      };
+    };
+
+    const buildInfoQuery = (rangeKey) => {
+      const range = rangeKey || DEFAULT_PRICE_RANGE;
+      const query = new URLSearchParams(baseParams);
+      const { date_from: dateFrom, date_to: dateTo } = resolveRangeParams(range);
+      if (dateFrom) query.set("date_from", dateFrom);
+      if (dateTo) query.set("date_to", dateTo);
+      return { query, range };
+    };
+
+    const requestCardInfo = async (rangeKey) => {
+      const { query, range } = buildInfoQuery(rangeKey);
+      const data = await apiFetch(`/cards/info?${query.toString()}`);
+      return { data, range };
+    };
+
+    if (priceHistoryModule && typeof priceHistoryModule.setRangeFetcher === "function") {
+      priceHistoryModule.setRangeFetcher(async (rangeKey) => {
+        try {
+          const { data, range } = await requestCardInfo(rangeKey);
+          const cardData = data?.card;
+          if (cardData) {
+            renderCardDetail(cardData, {
+              priceHistoryModule,
+              priceHistoryRange: range,
+            });
+          }
+          showAlert(alertBox, "");
+        } catch (error) {
+          console.error("Card price history fetch failed", error);
+          showAlert(alertBox, error.message || "Nie udało się pobrać danych karty.", "error");
+        }
+        return null;
+      });
+    }
+
+    requestCardInfo(DEFAULT_PRICE_RANGE)
+      .then(({ data, range }) => {
+        renderCardDetail(data?.card, {
+          priceHistoryModule,
+          priceHistoryRange: range,
+        });
         renderRelatedCards(data?.related || []);
         showAlert(alertBox, "");
       })

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -101,6 +101,45 @@
       <div class="alert" id="card-detail-alert" hidden></div>
     </div>
   </div>
+  <section class="panel card-detail-history" id="card-price-history-section" hidden>
+    <div class="panel-header card-detail-history-header">
+      <div>
+        <h2>Historia cen</h2>
+        <p>Zobacz, jak zmieniała się wartość tej karty.</p>
+      </div>
+      <div class="card-price-history-controls" role="group" aria-label="Zakres historii cen">
+        <button type="button" class="card-price-history-button" data-price-range="last_7">7d</button>
+        <button
+          type="button"
+          class="card-price-history-button is-active"
+          data-price-range="last_30"
+        >
+          30d
+        </button>
+        <button type="button" class="card-price-history-button" data-price-range="all">All</button>
+      </div>
+    </div>
+    <div class="card-price-chart-container">
+      <svg
+        class="card-price-chart-figure"
+        id="card-price-chart"
+        viewBox="0 0 100 48"
+        role="img"
+        aria-labelledby="card-price-chart-title"
+        preserveAspectRatio="none"
+      >
+        <title id="card-price-chart-title">Historia ceny karty</title>
+        <defs>
+          <linearGradient id="card-price-chart-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.3" />
+            <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0" />
+          </linearGradient>
+        </defs>
+        <g id="card-price-chart-data" class="card-price-chart-data"></g>
+      </svg>
+      <p class="card-price-chart-empty" id="card-price-chart-empty" hidden>Brak danych do wyświetlenia.</p>
+    </div>
+  </section>
 </section>
 
 <section class="panel card-detail-description" id="card-detail-description-section" hidden>
@@ -111,40 +150,6 @@
     </div>
   </div>
   <div class="card-detail-description-content" id="card-detail-description"></div>
-</section>
-
-<section class="panel card-detail-history" id="card-price-history-section" hidden>
-  <div class="panel-header card-detail-history-header">
-    <div>
-      <h2>Historia cen</h2>
-      <p>Zobacz, jak zmieniała się wartość tej karty.</p>
-    </div>
-    <div class="card-price-history-controls" role="group" aria-label="Zakres historii cen">
-      <button type="button" class="card-price-history-button is-active" data-price-range="last_7">7d</button>
-      <button type="button" class="card-price-history-button" data-price-range="last_30">30d</button>
-      <button type="button" class="card-price-history-button" data-price-range="all">All</button>
-    </div>
-  </div>
-  <div class="card-price-chart-container">
-    <svg
-      class="card-price-chart-figure"
-      id="card-price-chart"
-      viewBox="0 0 100 48"
-      role="img"
-      aria-labelledby="card-price-chart-title"
-      preserveAspectRatio="none"
-    >
-      <title id="card-price-chart-title">Historia ceny karty</title>
-      <defs>
-        <linearGradient id="card-price-chart-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.3" />
-          <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0" />
-        </linearGradient>
-      </defs>
-      <g id="card-price-chart-data" class="card-price-chart-data"></g>
-    </svg>
-    <p class="card-price-chart-empty" id="card-price-chart-empty" hidden>Brak danych do wyświetlenia.</p>
-  </div>
 </section>
 
 <section class="panel card-detail-related">

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import importlib
 
 import pytest
@@ -568,6 +569,52 @@ def test_card_info_accepts_normalized_set_code(api_client):
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["card"]["set_code"] == "UPPER-SET"
+
+
+def test_card_info_uses_month_range_by_default(api_client, monkeypatch):
+    class _FixedDate(dt.date):
+        @classmethod
+        def today(cls):  # pragma: no cover - patched for deterministic range
+            return cls(2024, 2, 15)
+
+    monkeypatch.setattr(cards_routes.dt, "date", _FixedDate)
+
+    remote_results = [
+        {
+            "id": "sv1-1",
+            "name": "Pikachu",
+            "number": "001",
+            "set_name": "Scarlet & Violet",
+            "set_code": "sv1",
+            "price": 9.99,
+        }
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "search_cards",
+        lambda **_: (remote_results, len(remote_results), len(remote_results)),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_history(card_id, **kwargs):
+        captured["card_id"] = card_id
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr(cards_routes.tcg_api, "fetch_card_price_history", fake_history)
+
+    response = api_client.get(
+        "/cards/info",
+        params={"name": "Pikachu", "number": "001"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured.get("card_id") == "sv1-1"
+    params = captured.get("kwargs") or {}
+    assert params.get("date_from") == dt.date(2024, 1, 16)
+    assert params.get("date_to") == dt.date(2024, 2, 15)
 
 
 def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import Any
 
 import pytest
@@ -533,6 +534,8 @@ def test_fetch_card_price_history_uses_endpoint_and_parses_data():
         rapidapi_host="https://pokemon-tcg-api.p.rapidapi.com",
         session=session,
         market="tcgplayer",
+        date_from=dt.date(2023, 1, 1),
+        date_to=dt.date(2023, 1, 31),
     )
 
     assert session.calls, "Expected a price history request"
@@ -543,6 +546,8 @@ def test_fetch_card_price_history_uses_endpoint_and_parses_data():
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
     assert params.get("market") == "tcgplayer"
+    assert params.get("date_from") == "2023-01-01"
+    assert params.get("date_to") == "2023-01-31"
     assert history == history_payload["data"]
 
 


### PR DESCRIPTION
## Summary
- move the price history panel directly under the main card details and make the 30-day range active by default
- let the client request specific history ranges and reuse freshly fetched data while preferring the 30-day window
- allow the price history endpoint to accept date_from/date_to, default to one month in card_info, and cover the behaviour with tests

## Testing
- pytest tests/test_tcg_api.py tests/api/test_cards.py::test_card_info_remote_fallback tests/api/test_cards.py::test_card_info_accepts_normalized_set_code tests/api/test_cards.py::test_card_info_uses_month_range_by_default


------
https://chatgpt.com/codex/tasks/task_e_68e00efdd6dc832fbdbce8e646c69970