### PR TITLE
Separate styling for rarity badge

### DIFF
--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1536,8 +1536,7 @@ body[data-theme="dark"] .card-search-set-badges {
   box-shadow: 0 8px 28px rgba(15, 23, 42, 0.12);
 }
 
-.card-detail-set-badge,
-.card-detail-rarity-badge {
+.card-detail-set-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1546,6 +1545,18 @@ body[data-theme="dark"] .card-search-set-badges {
   border-radius: var(--radius-md);
   background: var(--color-surface-alt);
   box-shadow: 0 6px 20px rgba(15, 23, 42, 0.12);
+}
+
+.card-detail-rarity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
 }
 
 .card-detail-set-icon,


### PR DESCRIPTION
## Summary
- separate the card detail set and rarity badge rules
- keep the background and shadow only for the set badge
- remove background, shadow, and rounded corners from the rarity badge while tightening its dimensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02afc9d98832fbddc63312198aacb