### PR TITLE
Adjust card detail set badge markup and fallback logic

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1959,19 +1959,27 @@
 
     const setCodeElement = document.getElementById("card-detail-set-code");
     const setCodeValue = sanitizeText(card.set_code);
+    const hasSetCodeValue = Boolean(setCodeValue);
     if (setCodeElement) {
       setCodeElement.textContent = (setCodeValue || "SET").toUpperCase();
-      setCodeElement.hidden = !setCodeValue;
+      setCodeElement.hidden = true;
     }
 
     const { primary: setIconUrl, fallback: setIconFallbackUrl } = resolveSetIconUrl(card);
     const setIconImage = document.getElementById("card-detail-set-icon");
     if (setIconImage) {
-      const showSetCode = () => {
-        if (setCodeElement && setCodeValue) {
-          setCodeElement.hidden = false;
+      const showSetCodeFallback = () => {
+        if (setCodeElement) {
+          setCodeElement.hidden = !hasSetCodeValue;
         }
       };
+
+      const hideSetCodeFallback = () => {
+        if (setCodeElement) {
+          setCodeElement.hidden = true;
+        }
+      };
+
       if (setIconUrl) {
         setIconImage.hidden = false;
         const setNameValue = sanitizeText(card.set_name);
@@ -1986,6 +1994,7 @@
           delete setIconImage.dataset.cardSetIconFallbackUrl;
           delete setIconImage.dataset.cardSetIconFallbackTried;
         }
+        hideSetCodeFallback();
         if (!setIconImage.dataset.cardSetIconHandlerAttached) {
           setIconImage.addEventListener("error", () => {
             const fallbackUrl = setIconImage.dataset.cardSetIconFallbackUrl;
@@ -1996,14 +2005,18 @@
             }
             setIconImage.hidden = true;
             setIconImage.removeAttribute("src");
-            showSetCode();
+            delete setIconImage.dataset.cardSetIconFallbackUrl;
+            delete setIconImage.dataset.cardSetIconFallbackTried;
+            showSetCodeFallback();
           });
           setIconImage.dataset.cardSetIconHandlerAttached = "true";
         }
       } else {
         setIconImage.hidden = true;
         setIconImage.removeAttribute("src");
-        showSetCode();
+        delete setIconImage.dataset.cardSetIconFallbackUrl;
+        delete setIconImage.dataset.cardSetIconFallbackTried;
+        showSetCodeFallback();
       }
     }
 

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1520,7 +1520,7 @@ body[data-theme="dark"] .card-search-set-badges {
 .card-detail-set {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 20px;
   font-size: 1rem;
   color: var(--color-muted);
   margin-bottom: 16px;
@@ -1529,8 +1529,8 @@ body[data-theme="dark"] .card-search-set-badges {
 .card-detail-set-visual {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
+  gap: 16px;
+  padding: 8px 16px;
   border-radius: var(--radius-lg);
   background: var(--color-surface);
   box-shadow: 0 8px 28px rgba(15, 23, 42, 0.12);
@@ -1540,11 +1540,9 @@ body[data-theme="dark"] .card-search-set-badges {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
+  width: 56px;
+  height: 56px;
   border-radius: var(--radius-md);
-  background: var(--color-surface-alt);
-  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.12);
 }
 
 .card-detail-rarity-badge {
@@ -1559,25 +1557,16 @@ body[data-theme="dark"] .card-search-set-badges {
   box-shadow: none;
 }
 
-.card-detail-set-icon,
+.card-detail-set-icon {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+}
+
 .card-detail-rarity-icon {
   width: 36px;
   height: 36px;
   object-fit: contain;
-}
-
-.card-detail-set-code {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 44px;
-  height: 100%;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  font-size: 0.82rem;
-  color: var(--color-text);
-  text-transform: uppercase;
-  white-space: nowrap;
 }
 
 .card-detail-rarity-fallback {
@@ -1596,8 +1585,19 @@ body[data-theme="dark"] .card-search-set-badges {
 .card-detail-set-text {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   color: var(--color-text);
+}
+
+.card-detail-set-code {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  font-size: 0.82rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .card-detail-price-badges {

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -37,12 +37,6 @@
               hidden
               data-card-set-icon
             />
-            <span
-              class="card-detail-set-code"
-              id="card-detail-set-code"
-              hidden
-              data-card-set-icon-fallback
-            ></span>
           </div>
           <div class="card-detail-rarity-badge">
             <img
@@ -63,6 +57,7 @@
           </div>
         </div>
         <div class="card-detail-set-text">
+          <span class="card-detail-set-code" id="card-detail-set-code" hidden></span>
           <span id="card-detail-set-name">{{ card_set_name or '' }}</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- simplify the card detail set badge markup so only the icon renders inside the badge and the set code fallback sits with the set text
- refresh the card detail badge styling to enlarge the set icon and align the badge with the rarity marker
- update the card detail renderer to toggle the moved text fallback when the set icon is missing or fails to load

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e175b30350832fa60358f28f416bf9