### PR TITLE
Add dedicated artist element to card detail view

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1941,14 +1941,26 @@
     }
 
     const artistValue = sanitizeText(card.artist);
+    const eraValue = sanitizeText(card.era);
     const era = document.getElementById("card-detail-era");
     if (era) {
-      if (artistValue) {
-        era.textContent = `Ilustrator: ${artistValue}`;
+      if (eraValue) {
+        era.textContent = eraValue;
         era.hidden = false;
       } else {
         era.textContent = "";
         era.hidden = true;
+      }
+    }
+
+    const artistElement = document.getElementById("card-detail-artist");
+    if (artistElement) {
+      if (artistValue) {
+        artistElement.textContent = `Ilustrator: ${artistValue}`;
+        artistElement.hidden = false;
+      } else {
+        artistElement.textContent = "";
+        artistElement.hidden = true;
       }
     }
 
@@ -2104,6 +2116,7 @@
     const descriptionSection = document.getElementById("card-detail-description-section");
     const descriptionContent = document.getElementById("card-detail-description");
     const descriptionMeta = document.getElementById("card-detail-description-meta");
+    const descriptionMetaValue = sanitizeText(card.description_meta);
     const descriptionValue = sanitizeText(card.description);
     if (descriptionSection && descriptionContent) {
       if (descriptionValue) {
@@ -2115,8 +2128,8 @@
       }
     }
     if (descriptionMeta) {
-      if (artistValue) {
-        descriptionMeta.textContent = `Ilustrator: ${artistValue}`;
+      if (descriptionMetaValue) {
+        descriptionMeta.textContent = descriptionMetaValue;
         descriptionMeta.hidden = false;
       } else {
         descriptionMeta.textContent = "";

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1632,7 +1632,8 @@ body[data-theme="dark"] .card-search-set-badges {
   color: var(--color-text);
 }
 
-.card-detail-era {
+.card-detail-era,
+.card-detail-artist {
   margin: 0 0 12px;
   color: var(--color-muted);
 }

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -61,6 +61,7 @@
           <span id="card-detail-set-name">{{ card_set_name or '' }}</span>
         </div>
       </div>
+      <p class="card-detail-artist" id="card-detail-artist" hidden aria-live="polite"></p>
       <div class="card-detail-price-badges">
         <div class="card-price-badge" id="card-detail-price-badge" hidden>
           <span class="card-price-badge-label">Aktualna cena</span>


### PR DESCRIPTION
## Summary
- add a dedicated artist container to the card detail template and align its styling with the surrounding layout
- update the card detail renderer to populate the artist container and reserve the era and description metadata fields for their own data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e177d2f5b8832f8866c233fa0d3557