### PR TITLE
Align card detail price display with search results

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -2137,30 +2137,21 @@
       }
     }
 
-    const priceBadge = document.getElementById("card-detail-price-badge");
+    const priceContainer = document.getElementById("card-detail-price-container");
     const priceElement = document.getElementById("card-detail-price");
-    const priceValue = normalizePriceInput(card.price);
-    if (priceBadge && priceElement) {
-      if (priceValue !== null) {
-        priceElement.textContent = formatCardPrice(priceValue);
-        priceBadge.hidden = false;
+    const priceValue = getCardPriceValue(card);
+    const priceText = priceValue === null ? "" : formatCardPrice(priceValue);
+    if (priceElement) {
+      if (priceText) {
+        priceElement.textContent = `Cena: ${priceText}`;
+        priceElement.hidden = false;
       } else {
         priceElement.textContent = "";
-        priceBadge.hidden = true;
+        priceElement.hidden = true;
       }
     }
-
-    const averageBadge = document.getElementById("card-detail-price-average-badge");
-    const averageElement = document.getElementById("card-detail-price-average");
-    const averageValue = normalizePriceInput(card.price_7d_average);
-    if (averageBadge && averageElement) {
-      if (averageValue !== null) {
-        averageElement.textContent = formatCardPrice(averageValue);
-        averageBadge.hidden = false;
-      } else {
-        averageElement.textContent = "";
-        averageBadge.hidden = true;
-      }
+    if (priceContainer) {
+      priceContainer.hidden = !priceText;
     }
 
     const buyButton = document.getElementById("detail-buy-button");

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1600,36 +1600,8 @@ body[data-theme="dark"] .card-search-set-badges {
   white-space: nowrap;
 }
 
-.card-detail-price-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.card-detail-price {
   margin-bottom: 16px;
-}
-
-.card-price-badge {
-  min-width: 150px;
-  padding: 12px 16px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-alt);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-}
-
-.card-price-badge-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.card-price-badge-value {
-  font-size: 1.4rem;
-  font-weight: 600;
-  color: var(--color-text);
 }
 
 .card-detail-era,
@@ -2162,10 +2134,6 @@ body[data-theme="dark"] .card-search-set-badges {
 
   .card-detail-main {
     grid-template-columns: 1fr;
-  }
-
-  .card-detail-price-badges {
-    flex-direction: column;
   }
 
   .card-detail-history-header {

--- a/kartoteka_web/templates/card_detail.html
+++ b/kartoteka_web/templates/card_detail.html
@@ -62,15 +62,8 @@
         </div>
       </div>
       <p class="card-detail-artist" id="card-detail-artist" hidden aria-live="polite"></p>
-      <div class="card-detail-price-badges">
-        <div class="card-price-badge" id="card-detail-price-badge" hidden>
-          <span class="card-price-badge-label">Aktualna cena</span>
-          <span class="card-price-badge-value" id="card-detail-price"></span>
-        </div>
-        <div class="card-price-badge" id="card-detail-price-average-badge" hidden>
-          <span class="card-price-badge-label">Średnia 7 dni</span>
-          <span class="card-price-badge-value" id="card-detail-price-average"></span>
-        </div>
+      <div class="card-detail-price" id="card-detail-price-container" hidden>
+        <p class="card-search-price" data-card-price id="card-detail-price"></p>
       </div>
       <dl class="card-detail-meta">
         <div>


### PR DESCRIPTION
## Summary
- show the card detail price in a single search-style container instead of two badges
- reuse the shared price selection helper so detail pages match search results
- remove unused CSS that supported the old price badges

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17973f518832f970b1722342d8180