### PR TITLE
Support full-range price history fetch

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -519,6 +519,7 @@ def card_info(
     set_name: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    range: str | None = None,
     related_limit: int = 6,
     current_user: models.User | None = Depends(get_optional_user),
     session: Session = Depends(get_session),
@@ -532,6 +533,7 @@ def card_info(
     set_name_value = (set_name or "").strip()
     set_code_value = set_utils.clean_code(set_code) or None
     total_value = text.sanitize_number(total) if total else None
+    range_value = (range or "").strip().lower() or None
 
     card = _find_card(
         session,
@@ -622,6 +624,8 @@ def card_info(
         date_to_value = today
     if requested_date_from and requested_date_from <= date_to_value:
         date_from_value = requested_date_from
+    elif range_value == "all":
+        date_from_value = None
     else:
         date_from_value = date_to_value - dt.timedelta(days=30)
 

--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -2262,6 +2262,7 @@
     const buildInfoQuery = (rangeKey) => {
       const range = rangeKey || DEFAULT_PRICE_RANGE;
       const query = new URLSearchParams(baseParams);
+      query.set("range", range);
       const { date_from: dateFrom, date_to: dateTo } = resolveRangeParams(range);
       if (dateFrom) query.set("date_from", dateFrom);
       if (dateTo) query.set("date_to", dateTo);


### PR DESCRIPTION
## Summary
- include the selected range in card info requests from the frontend
- allow the cards info endpoint to bypass the 30-day default when requesting the full history
- keep pre-sliced price history ranges available in the response

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e17c2e93d0832fb9c607ceeb4d1dfa