### PR TITLE
Add thumbnails to related card suggestions

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -2200,10 +2200,36 @@
         set_name: item.set_name,
       });
       if (item.set_code) params.set("set_code", item.set_code);
+      const cardName = (item.name || "").trim() || "Bez nazwy";
+      const setName = (item.set_name || "").trim() || "Nieznany dodatek";
+      const numberLabel = (item.number_display || item.number || "").trim();
+      const metaParts = [setName];
+      if (numberLabel) {
+        metaParts.push(numberLabel);
+      }
+      const metaText = metaParts.filter(Boolean).join(" • ");
+      const previewImage = (item.image_small || item.image_large || "").trim();
+      const hasPreviewImage = Boolean(previewImage);
+      const thumbnailAlt = `Miniatura karty ${cardName}`;
       anchor.href = `/cards/${encodeURIComponent(item.set_code || item.set_name || "")}/${encodeURIComponent(item.number)}?${params.toString()}`;
       anchor.innerHTML = `
-        <span class="related-card-name">${escapeHtml(item.name)}</span>
-        <span class="related-card-meta">${escapeHtml(item.set_name || "")}</span>
+        <figure class="related-card-media">
+          <div class="related-card-thumbnail">
+            ${
+              hasPreviewImage
+                ? `<img src="${escapeHtml(previewImage)}" alt="${escapeHtml(thumbnailAlt)}" loading="lazy" decoding="async" />`
+                : ""
+            }
+            <div class="related-card-thumbnail-fallback"${hasPreviewImage ? " hidden" : ""}>
+              <span class="related-card-thumbnail-emoji" aria-hidden="true">🖼️</span>
+              <span class="related-card-thumbnail-text">Brak miniatury</span>
+            </div>
+          </div>
+        </figure>
+        <div class="related-card-info">
+          <span class="related-card-name">${escapeHtml(cardName)}</span>
+          <span class="related-card-meta">${escapeHtml(metaText)}</span>
+        </div>
       `;
       container.appendChild(anchor);
     }

--- a/kartoteka_web/static/style.css
+++ b/kartoteka_web/static/style.css
@@ -1751,14 +1751,16 @@ body[data-theme="dark"] .card-search-set-badges {
 }
 
 .related-card {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: minmax(72px, 88px) 1fr;
+  gap: 12px;
   padding: 14px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   color: inherit;
+  text-decoration: none;
+  align-items: center;
 }
 
 .related-card:hover,
@@ -1766,13 +1768,68 @@ body[data-theme="dark"] .card-search-set-badges {
   border-color: var(--color-accent);
 }
 
+.related-card-media {
+  margin: 0;
+}
+
+.related-card-thumbnail {
+  position: relative;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, var(--color-background-alt), var(--color-surface));
+  aspect-ratio: 3 / 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.related-card-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.related-card-thumbnail-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.related-card-thumbnail-emoji {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.related-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
 .related-card-name {
   font-weight: 600;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .related-card-meta {
   font-size: 0.85rem;
   color: var(--color-muted);
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .related-empty {


### PR DESCRIPTION
## Summary
- render related cards with a thumbnail figure that lazy-loads available images and falls back to an emoji/text placeholder
- restyle related card entries to align text with the new preview and ensure names/metas truncate gracefully

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e17df24598832fb6260aabeea91f63