### PR TITLE
Add fallback shop search URL for cards

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -2156,8 +2156,56 @@
 
     const buyButton = document.getElementById("detail-buy-button");
     if (buyButton) {
-      const shopUrl = sanitizeText(card.shop_url) || DEFAULT_SHOP_URL;
-      buyButton.href = shopUrl;
+      const sanitizeSearchComponent = (value) => {
+        const text = sanitizeText(value);
+        if (text === null || text === undefined) return "";
+        const stringValue = String(text).trim();
+        if (!stringValue) return "";
+        return stringValue
+          .normalize("NFKD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .replace(/[^\p{L}\p{N}\s/-]+/gu, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+      };
+
+      const buildFallbackShopUrl = () => {
+        const parts = [];
+        const uniqueParts = new Set();
+        const addPart = (value) => {
+          const sanitized = sanitizeSearchComponent(value);
+          if (sanitized) {
+            const key = sanitized.toLowerCase();
+            if (!uniqueParts.has(key)) {
+              uniqueParts.add(key);
+              parts.push(sanitized);
+            }
+          }
+        };
+
+        addPart(card.name);
+        addPart(card.set_code ? String(card.set_code).toUpperCase() : null);
+        addPart(card.number_display || card.number);
+
+        const query = parts.join(" ").trim();
+        if (!query) return DEFAULT_SHOP_URL;
+        const encodedQuery = encodeURIComponent(query);
+        return `https://kartoteka.shop/pl/searchquery/${encodedQuery}/1/full/5?url=${encodedQuery}`;
+      };
+
+      const isGenericShopUrl = (url) => {
+        if (!url) return true;
+        const normalizedDefault = DEFAULT_SHOP_URL.replace(/\/+$/, "").toLowerCase();
+        const normalizedUrl = String(url).trim().replace(/\/+$/, "").toLowerCase();
+        if (!normalizedUrl) return true;
+        return normalizedUrl === normalizedDefault;
+      };
+
+      const shopUrl = sanitizeText(card.shop_url);
+      const resolvedShopUrl =
+        shopUrl && !isGenericShopUrl(shopUrl) ? shopUrl : buildFallbackShopUrl();
+
+      buyButton.href = resolvedShopUrl || DEFAULT_SHOP_URL;
     }
 
     const image = document.getElementById("card-detail-image");


### PR DESCRIPTION
## Summary
- compute a fallback Kartoteka search URL for the card detail buy button when the API returns a missing or generic shop link
- sanitize and encode card attributes before building the fallback query to keep valid API-provided URLs intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e184247c20832f8f34fd8ccdcb6949