### PR TITLE
Add card ID to price history requests

### DIFF
--- a/kartoteka_web/services/tcg_api.py
+++ b/kartoteka_web/services/tcg_api.py
@@ -1175,7 +1175,7 @@ def fetch_card_price_history(
         headers["X-RapidAPI-Key"] = rapidapi_key
     headers["X-RapidAPI-Host"] = api_host_header
 
-    params: dict[str, str] = {}
+    params: dict[str, str] = {"id": card_id}
     if market:
         params["market"] = market
     if currency:
@@ -1190,7 +1190,7 @@ def fetch_card_price_history(
             params["date_to"] = normalized_to
 
     try:
-        response = http.get(url, params=params or None, headers=headers, timeout=timeout)
+        response = http.get(url, params=params, headers=headers, timeout=timeout)
     except requests.Timeout:
         logger.warning("Price history request timed out for card %s", card_id)
         return []

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -617,6 +617,50 @@ def test_card_info_uses_month_range_by_default(api_client, monkeypatch):
     assert params.get("date_to") == dt.date(2024, 2, 15)
 
 
+def test_card_info_price_history_section_visible_when_data_present(
+    api_client, monkeypatch
+):
+    remote_results = [
+        {
+            "id": "sv1-001",
+            "name": "Pikachu",
+            "number": "001",
+            "set_name": "Scarlet & Violet",
+            "set_code": "sv1",
+        }
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "search_cards",
+        lambda **_: (remote_results, len(remote_results), len(remote_results)),
+    )
+
+    price_history_payload = [
+        {"date": "2024-01-01", "marketPrice": 7.5, "currency": "EUR"},
+        {"date": "2024-01-15", "marketPrice": 8.25, "currency": "EUR"},
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "fetch_card_price_history",
+        lambda *_, **__: price_history_payload,
+    )
+    monkeypatch.setattr(cards_routes.tcg_api, "get_eur_pln_rate", lambda: 4.0)
+
+    response = api_client.get(
+        "/cards/info",
+        params={"name": "Pikachu", "number": "001", "set_name": "Scarlet & Violet"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    history = payload["card"]["price_history"]
+    assert history["all"], "Expected chart data to be available"
+    assert history["last_30"], "Expected month range data for chart"
+    assert all(point["currency"] == "PLN" for point in history["all"])
+
+
 def test_card_search_passes_rapidapi_credentials(api_client, monkeypatch):
     headers = _auth_headers(api_client, username="misty", password="starmie")
 

--- a/tests/test_tcg_api.py
+++ b/tests/test_tcg_api.py
@@ -545,6 +545,7 @@ def test_fetch_card_price_history_uses_endpoint_and_parses_data():
     assert headers.get("X-RapidAPI-Key") == "rapid-key"
     assert headers.get("X-RapidAPI-Host") == DEFAULT_HOST
     params = call["params"] or {}
+    assert params.get("id") == "sv1-1"
     assert params.get("market") == "tcgplayer"
     assert params.get("date_from") == "2023-01-01"
     assert params.get("date_to") == "2023-01-31"


### PR DESCRIPTION
## Summary
- ensure `fetch_card_price_history` always forwards the RapidAPI card identifier alongside optional filters
- tighten the existing unit test to assert the presence of the `id` query parameter
- add an integration test that confirms price history data keeps the chart section visible when data is available

## Testing
- pytest tests/test_tcg_api.py::test_fetch_card_price_history_uses_endpoint_and_parses_data tests/api/test_cards.py::test_card_info_price_history_section_visible_when_data_present


------
https://chatgpt.com/codex/tasks/task_e_68e18e6190a8832f800bdc389fa0a6ff