### PR TITLE
Keep price history controls active when data is missing

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1632,9 +1632,8 @@
       controls.forEach((button) => {
         const key = button.dataset.priceRange;
         const hasData = Boolean(key && ranges[key] && ranges[key].length);
-        const attempted = key ? fetchedRanges.has(key) : false;
         const canFetch = typeof rangeFetcher === "function";
-        const disableBecauseNoData = !hasData && attempted && !canFetch;
+        const disableBecauseNoData = !hasData && !canFetch;
         const disableBecauseLoading = isLoading && key !== rangeKey;
         button.disabled = disableBecauseNoData || disableBecauseLoading;
         const isActive = key === rangeKey;
@@ -1803,12 +1802,17 @@
         chartLayer.innerHTML = "";
         chart.setAttribute("aria-hidden", "true");
         emptyState.hidden = false;
-        controls.forEach((button) => {
-          button.disabled = true;
-          button.classList.remove("is-active");
-          button.setAttribute("aria-pressed", "false");
-        });
-        section.hidden = true;
+        if (typeof rangeFetcher === "function") {
+          section.hidden = false;
+          updateControls(activeRange);
+        } else {
+          section.hidden = true;
+          controls.forEach((button) => {
+            button.disabled = true;
+            button.classList.remove("is-active");
+            button.setAttribute("aria-pressed", "false");
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- ensure the price history chart remains visible with empty-state messaging when data is missing but a fetcher is available
- prevent range buttons from disabling when ranges lack data yet can still be fetched

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68e250a5f484832facfed683ae700172