### PR TITLE
Ensure price history falls back to populated ranges

### DIFF
--- a/kartoteka_web/static/js/app.js
+++ b/kartoteka_web/static/js/app.js
@@ -1799,19 +1799,25 @@
         return;
       }
 
+      const fallbackRangeOrder = ["last_30", "last_7", "all"];
+      const requestedHasData =
+        requestedRange &&
+        Array.isArray(ranges[requestedRange]) &&
+        ranges[requestedRange].length > 0;
+      const activeHasData =
+        preserveActive &&
+        activeRange &&
+        Array.isArray(ranges[activeRange]) &&
+        ranges[activeRange].length > 0;
+
       let nextRange = null;
 
-      if (
-        requestedRange &&
-        (updatedKeys.includes(requestedRange) || (ranges[requestedRange] && ranges[requestedRange].length))
-      ) {
+      if (requestedHasData) {
         nextRange = requestedRange;
-      } else if (preserveActive && ranges[activeRange]) {
+      } else if (activeHasData) {
         nextRange = activeRange;
-      }
-
-      if (!nextRange) {
-        for (const key of ["last_30", "last_7", "all"]) {
+      } else {
+        for (const key of fallbackRangeOrder) {
           if (ranges[key] && ranges[key].length) {
             nextRange = key;
             break;
@@ -1820,7 +1826,7 @@
       }
 
       if (!nextRange) {
-        for (const key of ["last_30", "last_7", "all"]) {
+        for (const key of fallbackRangeOrder) {
           if (updatedKeys.includes(key)) {
             nextRange = key;
             break;


### PR DESCRIPTION
## Summary
- update price history range selection to keep the requested range active only when it contains data
- add fallback logic to automatically switch to the first populated range while preserving the empty-state behaviour for fully empty responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e25b9a7ba4832f94082480ea164dd9