### PR TITLE
Improve remote card selection for details

### DIFF
--- a/kartoteka_web/routes/cards.py
+++ b/kartoteka_web/routes/cards.py
@@ -201,7 +201,10 @@ def _history_points_to_schema(
 
 
 def _select_remote_card(
-    records: list[dict[str, Any]], detail: schemas.CardDetail
+    records: list[dict[str, Any]],
+    detail: schemas.CardDetail,
+    *,
+    require_number_match: bool = False,
 ) -> dict[str, Any] | None:
     if not records:
         return None
@@ -209,8 +212,22 @@ def _select_remote_card(
     def _norm(value: Any) -> str:
         return (str(value or "").strip().lower())
 
-    target_number = _norm(detail.number)
+    def _clean_number(value: Any) -> str:
+        text_value = str(value or "").strip()
+        if not text_value:
+            return ""
+        simplified = re.sub(r"[^0-9a-zA-Z]+", "", text_value)
+        if not simplified:
+            return ""
+        normalized = text.sanitize_number(simplified)
+        return normalized.lower()
+
+    target_number_raw = detail.number or detail.number_display or ""
+    target_number = _norm(target_number_raw)
+    target_number_clean = _clean_number(target_number_raw)
+    target_total_clean = _clean_number(detail.total)
     target_set_code = _norm(detail.set_code)
+    target_set_code_clean = set_utils.clean_code(detail.set_code) or ""
     target_set_name = _norm(detail.set_name)
 
     best_score = -1
@@ -218,14 +235,43 @@ def _select_remote_card(
 
     for record in records:
         score = 0
-        record_number = _norm(record.get("number"))
+        record_number_value = record.get("number")
+        record_number_display = record.get("number_display")
+        record_number_raw = record_number_value or record_number_display
+        record_number = _norm(record_number_raw)
+        record_number_clean = _clean_number(record_number_value)
+        record_number_display_clean = _clean_number(record_number_display)
+        combined_number_clean = record_number_clean or record_number_display_clean
+        record_total_clean = _clean_number(record.get("total"))
         record_set_code = _norm(record.get("set_code"))
+        record_set_code_clean = set_utils.clean_code(record.get("set_code")) or ""
         record_set_name = _norm(record.get("set_name"))
 
         if target_number and record_number == target_number:
-            score += 3
+            score += 5
+        if (
+            target_number_clean
+            and combined_number_clean
+            and target_number_clean == combined_number_clean
+        ):
+            score += 4
+        if (
+            target_number_clean
+            and combined_number_clean
+            and combined_number_clean.startswith(target_number_clean)
+        ):
+            score += 1
+        if target_total_clean and record_total_clean:
+            if target_total_clean == record_total_clean:
+                score += 1
         if target_set_code and record_set_code == target_set_code:
             score += 3
+        if (
+            target_set_code_clean
+            and record_set_code_clean
+            and target_set_code_clean == record_set_code_clean
+        ):
+            score += 2
         if target_set_name and record_set_name == target_set_name:
             score += 1
         if score > best_score:
@@ -233,8 +279,14 @@ def _select_remote_card(
             best_record = record
 
     if best_record and best_score > 0:
+        if require_number_match and target_number_clean:
+            best_number_clean = _clean_number(best_record.get("number"))
+            best_number_display_clean = _clean_number(best_record.get("number_display"))
+            combined_best_number = best_number_clean or best_number_display_clean
+            if not combined_best_number or combined_best_number != target_number_clean:
+                return None
         return best_record
-    return records[0]
+    return None
 
 
 def _matches_filters(
@@ -602,7 +654,15 @@ def card_info(
         logger.warning("Failed to fetch remote card details for %s #%s: %s", name, number, exc)
         remote_results = []
 
-    remote_card = _select_remote_card(remote_results, detail) if remote_results else None
+    remote_card = (
+        _select_remote_card(
+            remote_results,
+            detail,
+            require_number_match=card is not None and bool(detail.number),
+        )
+        if remote_results
+        else None
+    )
     remote_card_id: str | None = None
 
     def _parse_date_param(value: str | None) -> dt.date | None:

--- a/tests/api/test_cards.py
+++ b/tests/api/test_cards.py
@@ -378,7 +378,7 @@ def test_card_info_remote_fallback(api_client, monkeypatch):
         "/cards/info",
         params={
             "name": "Charizard",
-            "number": "4",
+            "number": "004",
             "set_name": "Base Set",
             "set_code": "base1",
         },
@@ -390,6 +390,7 @@ def test_card_info_remote_fallback(api_client, monkeypatch):
     assert card["name"] == "Charizard"
     assert card["set_code"] == "base1"
     assert card["price"] == pytest.approx(123.45)
+    assert card["number_display"] == "4/102"
     history = card["price_history"]
     assert history["all"], "Expected remote price history to be populated"
     assert captured["set_code"] == "base1"
@@ -399,6 +400,57 @@ def test_card_info_remote_fallback(api_client, monkeypatch):
     with database.session_scope() as session:
         assert session.exec(select(models.Card)).all() == []
 
+
+def test_card_info_remote_skip_when_numbers_conflict(api_client, monkeypatch):
+    with database.session_scope() as session:
+        session.add(
+            models.Card(
+                name="Eevee",
+                number="133",
+                set_name="Base Set",
+                set_code="base1",
+                rarity="Common",
+            )
+        )
+
+    remote_cards = [
+        {
+            "id": "base2-200",
+            "name": "Eevee",
+            "number": "200",
+            "number_display": "200/151",
+            "total": "151",
+            "set_name": "Base Set 2",
+            "set_code": "base2",
+            "rarity": "Rare",
+            "price": 99.99,
+        }
+    ]
+
+    monkeypatch.setattr(
+        cards_routes.tcg_api,
+        "search_cards",
+        lambda *args, **kwargs: (remote_cards, len(remote_cards), len(remote_cards)),
+    )
+
+    response = api_client.get(
+        "/cards/info",
+        params={
+            "name": "Eevee",
+            "number": "133",
+            "set_name": "Base Set",
+            "set_code": "base1",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    card = payload["card"]
+    assert card["number"] == "133"
+    assert card["number_display"] == "133"
+    assert card["set_code"] == "base1"
+    assert card.get("price") is None
+    assert payload["related"] == []
 
 def test_card_info_price_history_bounded_then_fallback(api_client, monkeypatch):
     today = dt.date.today()


### PR DESCRIPTION
## Summary
- normalise remote card numbers and tighten matching so we only merge details when the number really matches a stored card
- keep remote fallbacks available when we rely solely on API data to populate details
- cover the new behaviour with API tests for leading zeros and conflicting remote numbers

## Testing
- pytest tests/api/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68e35f725c5c832fa8956bee2ac71291