### PR TITLE
Add Docker Compose configuration with ngrok tunnel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ uvicorn server:app --reload
 
 The development server defaults to `http://127.0.0.1:8000/` and serves the dashboard, collection and portfolio pages alongside the JSON API.
 
+### Running with Docker Compose
+Container builds are provided for local development and automated testing. Build the image and start the stack (FastAPI app + ngrok tunnel) with:
+
+```bash
+docker compose up --build
+```
+
+By default the application is exposed on `http://localhost:8000`. Copy `.env.example` to `.env` if you need to customise configuration values before starting the stack.
+
+The ngrok sidecar shares a public tunnel that you can use for remote testing. Set `NGROK_AUTHTOKEN` either in your shell environment or in the `.env` file before starting Compose:
+
+```bash
+export NGROK_AUTHTOKEN=your-token-here
+docker compose up
+```
+
+After the tunnel boots, inspect requests and retrieve the assigned public URL at `http://localhost:4040`.
+
 ### Synchronising the Card Catalogue
 
 The `/cards/search` endpoint now reads directly from the local `CardRecord` table. Populate it with the cards you care about before switching the UI to offline mode:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    command: ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]
+
+  ngrok:
+    image: ngrok/ngrok:alpine
+    restart: unless-stopped
+    depends_on:
+      - app
+    env_file:
+      - .env
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    command: ["http", "app:8000", "--log=stdout"]
+    ports:
+      - "4040:4040"


### PR DESCRIPTION
## Summary
- add a Dockerfile and docker-compose stack to run the FastAPI app alongside an ngrok tunnel for remote testing
- document the container workflow and tunnel requirements in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690a04f42b10832faa91acc1f61811d6